### PR TITLE
Adds armor to basic MODsuits 

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -4363,6 +4363,7 @@
 #include "jollystation_modules\code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "jollystation_modules\code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "jollystation_modules\code\modules\mob\living\simple_animal\friendly\dog.dm"
+#include "jollystation_modules\code\modules\mod\mod_theme.dm"
 #include "jollystation_modules\code\modules\modular_computers\computers\item\tablet_presets.dm"
 #include "jollystation_modules\code\modules\movespeed\modifiers\reagent.dm"
 #include "jollystation_modules\code\modules\reagents\chemistry\reagents\drink_reagents.dm"

--- a/jollystation_modules/code/modules/mod/mod_theme.dm
+++ b/jollystation_modules/code/modules/mod/mod_theme.dm
@@ -1,10 +1,10 @@
-// Modualr mod theme changes. Modception.
+// -- Modular mod theme changes. -- (Modception.)
 
 /datum/mod_theme/engineering // Engineer
-	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10)
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10)
 
 /datum/mod_theme/atmospheric // Atmospheric Technician
-	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 75, WOUND = 10)
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 100, FIRE = 100, ACID = 75, WOUND = 10)
 
 /datum/mod_theme/advanced // Chief Engineer
 	armor = list(MELEE = 30, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90, WOUND = 10)
@@ -16,7 +16,7 @@
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 10)
 
 /datum/mod_theme/rescue // Chief Medical Officer
-	armor = list(MELEE = 20, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 100, WOUND = 10)
+	armor = list(MELEE = 20, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 20, BIO = 100, FIRE = 100, ACID = 100, WOUND = 10)
 
 /datum/mod_theme/research // Research Director
 	armor = list(MELEE = 10, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15)
@@ -31,17 +31,17 @@
 	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 20)
 
 /datum/mod_theme/cosmohonk // Clown
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 30, WOUND = 5)
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 50, ACID = 25, WOUND = 5)
 
 /datum/mod_theme/syndicate // Bloodred Syndicate
-	armor = list(MELEE = 20, BULLET = 25, LASER = 15, ENERGY = 20, BOMB = 35, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25)
+	armor = list(MELEE = 20, BULLET = 25, LASER = 15, ENERGY = 20, BOMB = 40, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25)
 
 /obj/item/mod/module/armor_booster
 	// Half of the old armor is on the MODsuit, the other half is from the booster
 	armor_values = list(MELEE = 20, BULLET = 25, LASER = 15, ENERGY = 20)
 
 /datum/mod_theme/elite // Elite Syndiate
-	armor = list(MELEE = 30, BULLET = 30, LASER = 25, ENERGY = 30, BOMB = 55, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 25, ENERGY = 30, BOMB = 60, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25)
 
 /obj/item/mod/module/armor_booster/elite
 	// Ditto - half on suit, half on booster

--- a/jollystation_modules/code/modules/mod/mod_theme.dm
+++ b/jollystation_modules/code/modules/mod/mod_theme.dm
@@ -1,7 +1,7 @@
 // -- Modular mod theme changes. -- (Modception.)
 
 /datum/mod_theme/engineering // Engineer
-	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10)
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10)
 
 /datum/mod_theme/atmospheric // Atmospheric Technician
 	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 100, FIRE = 100, ACID = 75, WOUND = 10)

--- a/jollystation_modules/code/modules/mod/mod_theme.dm
+++ b/jollystation_modules/code/modules/mod/mod_theme.dm
@@ -1,0 +1,57 @@
+// Modualr mod theme changes. Modception.
+
+/datum/mod_theme/engineering // Engineer
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10)
+
+/datum/mod_theme/atmospheric // Atmospheric Technician
+	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 75, WOUND = 10)
+
+/datum/mod_theme/advanced // Chief Engineer
+	armor = list(MELEE = 30, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90, WOUND = 10)
+
+/datum/mod_theme/mining // Shaft Miner
+	armor = list(MELEE = 40, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15)
+
+/datum/mod_theme/medical // Paramedic / Medical Doctor
+	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 10)
+
+/datum/mod_theme/rescue // Chief Medical Officer
+	armor = list(MELEE = 20, BULLET = 5, LASER = 5, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 100, WOUND = 10)
+
+/datum/mod_theme/research // Research Director
+	armor = list(MELEE = 10, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15)
+
+/datum/mod_theme/security // Security Officer
+	armor = list(MELEE = 30, BULLET = 20, LASER = 20, ENERGY = 30, BOMB = 20, BIO = 100, FIRE = 75, ACID = 75, WOUND = 20)
+
+/datum/mod_theme/safeguard // Head of Security
+	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 30, BIO = 100, FIRE = 100, ACID = 95, WOUND = 25)
+
+/datum/mod_theme/magnate // Captain
+	armor = list(MELEE = 40, BULLET = 40, LASER = 40, ENERGY = 40, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 20)
+
+/datum/mod_theme/cosmohonk // Clown
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 60, ACID = 30, WOUND = 5)
+
+/datum/mod_theme/syndicate // Bloodred Syndicate
+	armor = list(MELEE = 20, BULLET = 25, LASER = 15, ENERGY = 20, BOMB = 35, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25)
+
+/obj/item/mod/module/armor_booster
+	// Half of the old armor is on the MODsuit, the other half is from the booster
+	armor_values = list(MELEE = 20, BULLET = 25, LASER = 15, ENERGY = 20)
+
+/datum/mod_theme/elite // Elite Syndiate
+	armor = list(MELEE = 30, BULLET = 30, LASER = 25, ENERGY = 30, BOMB = 55, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25)
+
+/obj/item/mod/module/armor_booster/elite
+	// Ditto - half on suit, half on booster
+	armor_values = list(MELEE = 30, BULLET = 30, LASER = 25, ENERGY = 30)
+
+/datum/mod_theme/prototype // Charlie Station
+	armor = list(MELEE = 25, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 5)
+
+/datum/mod_theme/responsory // ERT
+	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90, WOUND = 15)
+
+/datum/mod_theme/corporate // Centcom Commander
+	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15)


### PR DESCRIPTION
Adds armor to all the basic MODsuits. 

They're all ROUGHLY the same as the old versions of the hardsuits, adjusted down slightly to accommodate for all the added utility (and speed) that MODsuits bring. 

Additionally, syndicate MODsuits now have half their armor innate, and half their armor gained from activating their booster. 
