### PR TITLE
Fixes the roundend text for Cultists with conversion disblaed

### DIFF
--- a/jollystation_modules/code/modules/antagonists/_common/advanced_objective.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_objective.dm
@@ -57,7 +57,7 @@
 /// Number is the number in the list that this objective is. (1 to 5)
 /datum/advanced_antag_goal/proc/get_roundend_text(number)
 	var/datum/advanced_antag_datum/our_antag_datum = our_antag
-	var/formatted_text = "<br><B>Objective #[number]</B>: [goal]"
+	var/formatted_text = "<b>Objective #[number]</b>: [goal]"
 	if(LAZYLEN(similar_objectives) || always_succeed)
 		if(check_relative_success())
 			formatted_text += span_greentext("<br>The [our_antag_datum.name] succeeded this goal!")
@@ -66,7 +66,7 @@
 	if(notes)
 		formatted_text += span_info("<br>Extra info they had about this goal: [notes]")
 
-	return formatted_text
+	return formatted_text + "<br>"
 
 /// Loop through all our similar objectives and see if we completed them.
 /// If [check_all_objectives] is true, we need all objectives in the list to be successful to return TRUE.

--- a/jollystation_modules/code/modules/antagonists/advanced_cult/blood_cult/blood_cult_theme.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_cult/blood_cult/blood_cult_theme.dm
@@ -76,7 +76,7 @@
 /datum/cult_theme/narsie/get_allowed_runes(datum/antagonist/advanced_cult/cultist_datum)
 	. = ..()
 	var/datum/advanced_antag_datum/cultist/cultist = cultist_datum.linked_advanced_datum
-	if(cultist.no_conversion)
+	if(!cultist.conversion_allowed)
 		. -= "Revive"
 		. -= "Summon Cultist"
 		. -= "Boil Blood"

--- a/tgui/packages/tgui/interfaces/_AdvancedCultPanel.js
+++ b/tgui/packages/tgui/interfaces/_AdvancedCultPanel.js
@@ -8,7 +8,7 @@ export const _AdvancedCultPanel = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     goals_finalized,
-    cannot_convert,
+    can_convert,
   } = data;
 
   return (
@@ -22,7 +22,7 @@ export const _AdvancedCultPanel = (props, context) => {
           content="Enable Conversion"
           textAlign="center"
           disabled={goals_finalized}
-          checked={!cannot_convert}
+          checked={can_convert}
           tooltip="If checked, the ability to convert will be enabled. \
             Disabling conversion rewards +1 max spell slots."
           onClick={() => act('toggle_conversion')} />


### PR DESCRIPTION
- Fixes cultists with conversion disabled not getting roundend text.
- Renamed `no_coversion` to `conversion_allowed` because it was getting confusing. Not sure why I named it that in the first place?