### PR TITLE
Allows numbers in name / backup name preferences

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -4249,6 +4249,7 @@
 #include "jollystation_modules\code\modules\client\preferences\languages.dm"
 #include "jollystation_modules\code\modules\client\preferences\loadout_preference.dm"
 #include "jollystation_modules\code\modules\client\preferences\multiline_preferences.dm"
+#include "jollystation_modules\code\modules\client\preferences\name_preferences.dm"
 #include "jollystation_modules\code\modules\client\preferences\runechat_color.dm"
 #include "jollystation_modules\code\modules\client\preferences\toggle_radio.dm"
 #include "jollystation_modules\code\modules\client\preferences\toggle_speech.dm"

--- a/jollystation_modules/code/modules/client/preferences/name_preferences.dm
+++ b/jollystation_modules/code/modules/client/preferences/name_preferences.dm
@@ -1,0 +1,7 @@
+// -- Name preference stuff --
+// Allow numbers in names for synthetics and stuff.
+/datum/preference/name/real_name
+	allow_numbers = TRUE
+
+/datum/preference/name/backup_human
+	allow_numbers = TRUE


### PR DESCRIPTION
- Allows users to input numbers for their character names / backup human name preferences. Primarily for those who play (gross) robots. 