### PR TITLE
Adds in departmental order consoles to pubby, fixes minor visual bugs.

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3,11 +3,11 @@
 /turf/open/space/basic,
 /area/space)
 "aac" = (
-/obj/machinery/computer/cargo/request{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
+	},
+/obj/machinery/computer/department_orders/security{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security)
@@ -2356,11 +2356,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/cargo/request{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
+	},
+/obj/machinery/computer/department_orders/service{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
@@ -5884,12 +5884,6 @@
 	pixel_x = -24;
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/west{
 	id = "bridgespace";
 	name = "Bridge Space Lockdown";
@@ -5911,10 +5905,6 @@
 "asT" = (
 /obj/structure/chair/office{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /obj/machinery/button/door/directional/east{
 	id = "bridgespace";
@@ -8045,9 +8035,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "azo" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -8430,7 +8417,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/asset_protection,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/command/bridge)
 "aAE" = (
 /obj/structure/cable,
@@ -9040,12 +9032,15 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/vending/drugs,
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -9937,11 +9932,11 @@
 	c_tag = "Medbay Surgical Wing";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/computer/cargo/request{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
+	},
+/obj/machinery/computer/department_orders/medical{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -15546,10 +15541,10 @@
 /turf/open/floor/iron/smooth,
 /area/service/janitor)
 "bba" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/green/half{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -19759,6 +19754,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/medical/cryo)
 "brc" = (
@@ -19845,10 +19843,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/computer/cargo/request,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/machinery/computer/department_orders/science,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "brq" = (
@@ -20051,6 +20049,7 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "brT" = (
+/obj/effect/turf_decal/tile/purple/anticorner,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -20059,7 +20058,6 @@
 	name = "emergency shower"
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/purple/anticorner,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
@@ -20174,21 +20172,6 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"bsp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_edge{
-	dir = 8
-	},
-/area/science/genetics)
 "bsq" = (
 /obj/structure/closet{
 	name = "janitorial supplies"
@@ -20357,7 +20340,9 @@
 /obj/item/kirbyplants,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/dark_tile/anticorner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
 /area/science/robotics)
 "bsX" = (
 /obj/structure/disposalpipe/segment,
@@ -21066,9 +21051,6 @@
 /turf/open/floor/iron/edge,
 /area/hallway/primary/aft)
 "bvF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -21078,6 +21060,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -21490,9 +21475,6 @@
 /turf/open/floor/iron/large,
 /area/hallway/primary/aft)
 "bxo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 25
 	},
@@ -21507,6 +21489,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -22054,9 +22039,6 @@
 /turf/open/floor/iron/large,
 /area/hallway/primary/aft)
 "byN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -22065,6 +22047,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -22566,9 +22551,6 @@
 /turf/open/floor/iron/large,
 /area/hallway/primary/aft)
 "bAx" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -22576,6 +22558,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -22682,13 +22667,13 @@
 /area/medical/storage)
 "bAR" = (
 /obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
 /obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_edge{
@@ -23776,7 +23761,6 @@
 "bET" = (
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
-	dir = 1;
 	network = list("ss13","rd")
 	},
 /obj/machinery/suit_storage_unit/rd,
@@ -24609,11 +24593,11 @@
 /area/maintenance/department/engine)
 "bHS" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -26950,14 +26934,14 @@
 /area/engineering/lobby)
 "bRq" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/computer/cargo/request{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/computer/department_orders/engineering{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -28780,10 +28764,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/dark_tile/edge{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/half,
 /area/command/heads_quarters/ce)
 "bXi" = (
@@ -31960,10 +31944,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/dark_tile/edge{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/half,
 /area/command/heads_quarters/ce)
 "coc" = (
@@ -34889,9 +34873,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/science/mixing)
 "dgz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34906,6 +34887,9 @@
 /obj/effect/turf_decal/tile/neutral/half,
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/science/xenobiology)
@@ -36850,9 +36834,6 @@
 /turf/closed/wall,
 /area/space/nearstation)
 "eOe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
@@ -36860,6 +36841,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_half,
 /area/medical/medbay/central)
@@ -38002,10 +37986,13 @@
 /turf/open/floor/iron/textured_large,
 /area/cargo/storage)
 "fEZ" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/green/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green/half{
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_half{
@@ -38751,9 +38738,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gjt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Virology Lab";
 	dir = 4;
@@ -38766,6 +38750,12 @@
 	},
 /obj/item/radio/intercom/directional/east{
 	pixel_x = 36
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/virology)
@@ -38810,12 +38800,12 @@
 /obj/machinery/shower{
 	pixel_y = 15
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/green/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_half,
@@ -39384,9 +39374,6 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "gGs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half{
 	dir = 8
@@ -39395,6 +39382,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_half{
@@ -39781,13 +39771,13 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "gXg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 8
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
@@ -41826,13 +41816,13 @@
 /obj/structure/sink{
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -42589,9 +42579,6 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/science/xenobiology)
 "jxl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -42600,6 +42587,9 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -43299,9 +43289,6 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/science/mixing)
 "kmq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -43313,6 +43300,9 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -45277,14 +45267,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "lUC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -46099,9 +46089,6 @@
 	},
 /area/science/explab)
 "mAu" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -46112,6 +46099,9 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "mAQ" = (
@@ -47697,13 +47687,13 @@
 /turf/open/floor/grass,
 /area/medical/storage)
 "nOY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_edge,
@@ -52422,15 +52412,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "rus" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green/anticorner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -53877,13 +53867,13 @@
 /area/cargo/sorting)
 "syQ" = (
 /obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
 /obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_edge{
@@ -54023,14 +54013,14 @@
 	},
 /area/medical/medbay/central)
 "sDk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -54325,11 +54315,11 @@
 /area/hallway/primary/central)
 "sSl" = (
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/green/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_half{
@@ -54588,12 +54578,12 @@
 /obj/machinery/shower{
 	pixel_y = 15
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
@@ -56455,11 +56445,11 @@
 /area/maintenance/department/engine)
 "uko" = (
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/medical/virology)
@@ -56946,9 +56936,6 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "uAx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -56957,6 +56944,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -59258,11 +59248,11 @@
 /turf/open/floor/iron/smooth_half,
 /area/maintenance/disposal)
 "wkZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /obj/machinery/shower{
 	dir = 4;
@@ -60021,12 +60011,15 @@
 	pixel_y = 22;
 	req_access_txt = "39"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/light_switch/directional/north{
 	name = "Light Switch";
 	pixel_x = -6
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/virology)
@@ -91703,7 +91696,7 @@ puW
 ayg
 ayg
 wyP
-fnK
+ayb
 aBy
 pVt
 aDJ
@@ -94273,7 +94266,7 @@ atW
 ayg
 gVE
 wyP
-mSL
+ayb
 aBy
 poi
 vRN
@@ -105885,7 +105878,7 @@ eOJ
 wkZ
 bnd
 brJ
-bsp
+bAR
 bAR
 gXg
 jiD


### PR DESCRIPTION
People wanted it, its a thing from 2022 /tg/ code standards, its departmental order consoles. These replace the stupid supply consoles with shiny new freebie-ordery consolies.

Also, a bunch of visual glitches are fixed from improper overlaying, alongside duplicate and missing decals in certain areas. A revamp of some departments is to be due since some map decals were fixed or added in the development of the map.