### PR TITLE
Fixes the phantom pain from the random prosthetic quirk

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -449,7 +449,7 @@
 		if(BODY_ZONE_R_LEG)
 			prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)
 			slot_string = "right leg"
-	prosthetic.replace_limb(human_holder)
+	prosthetic.replace_limb(human_holder, TRUE) // NON-MODULE CHANGE
 	qdel(old_part)
 	human_holder.regenerate_icons()
 


### PR DESCRIPTION
Random prosthetics call `replace_limb` without setting special, which causes pain
(The targeted prosthetic quirks called special properly so that's funny)