### PR TITLE
Overrides to rebalance techshells, mostly nerfs.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -4539,6 +4539,8 @@
 #include "maplestation_modules\code\modules\mod\mod_theme.dm"
 #include "maplestation_modules\code\modules\modular_computers\computers\item\tablet_presets.dm"
 #include "maplestation_modules\code\modules\movespeed\modifiers\reagent.dm"
+#include "maplestation_modules\code\modules\projectiles\ammunition\ballistic\shotgun.dm"
+#include "maplestation_modules\code\modules\projectiles\projectile\bullets\shotgun.dm"
 #include "maplestation_modules\code\modules\reagents\chemistry\reagents\drink_reagents.dm"
 #include "maplestation_modules\code\modules\reagents\chemistry\reagents\mutation_reagents.dm"
 #include "maplestation_modules\code\modules\reagents\chemistry\reagents\pain_reagents.dm"

--- a/maplestation_modules/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -1,0 +1,4 @@
+///Overrides for shotgun ammo and any new shotgun ammo
+//Overrides laser scatter ammo to fire a unique projectile with a different damage value
+/obj/item/ammo_casing/shotgun/laserslug
+	projectile_type = /obj/projectile/beam/weak/laser_scatter

--- a/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -11,7 +11,7 @@
 //Overrides meteorslug to have no stun, lower knockdown but also causes a lot of PAIN
 /obj/projectile/bullet/shotgun_meteorslug
 	paralyze = 0
-	knockdown = 50
+	knockdown = 5 SECONDS
 
 /obj/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -16,6 +16,6 @@
 /obj/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		if(M.pain_controller)
-			M.cause_pain(BODY_ZONES_ALL, 50) //OW MY BONES
+		var/mob/living/carbon/unfortunate_soul = target
+		if(unfortunate_soul.pain_controller)
+			unfortunate_soul.sharp_pain(BODY_ZONES_ALL, 50) //OW MY BONES

--- a/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -12,7 +12,6 @@
 /obj/projectile/bullet/shotgun_meteorslug
 	paralyze = 0
 	knockdown = 50
-	stamina = 35
 
 /obj/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,0 +1,22 @@
+///Overrides to shotgun projectiles and any new projectiles go here
+//Overrides frag12 to not have innate damage and stunning
+/obj/projectile/bullet/shotgun_frag12
+	damage = 0
+	paralyze = 0
+
+//New laser scatter projectile type, 11 damage for 6 pellets doing 66 damage in total
+/obj/projectile/beam/weak/laser_scatter
+	damage = 11
+
+//Overrides meteorslug to have no stun, lower knockdown but also causes a lot of PAIN
+/obj/projectile/bullet/shotgun_meteorslug
+	paralyze = 0
+	knockdown = 50
+	stamina = 35
+
+/obj/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		if(M.pain_controller)
+			M.cause_pain(BODY_ZONES_ALL, 50) //OW MY BONES


### PR DESCRIPTION
So, tech shells have been nerfed. Here's the changelog.

Frag-12 no longer has the innate damage and stunning, the explosion already causes a LOT of damage.
Laser Scatter now does 66 damage over it's 6 pellets (11 per pellet) instead of 90 over it's 6 pellets (15 per pellet). This ends up being under 50 when wearing an armor vest!
Meteor slugs are now a true war crime of a projectile, no longer stunning their opponents and knocking them down for shorter times, but causing an incredible amount of pain.