### PR TITLE
[CRITICAL] Stamina damage effect is now run through an armor calculation.

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -119,7 +119,8 @@
 	return TRUE
 
 /// applies multiple effects at once via [/mob/living/proc/apply_effect]
-/mob/living/proc/apply_effects(stun = 0, knockdown = 0, unconscious = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = 0, stamina = 0, jitter = 0, paralyze = 0, immobilize = 0)
+/mob/living/proc/apply_effects(stun = 0, knockdown = 0, unconscious = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = 0, stamina = 0, jitter = 0, paralyze = 0, immobilize = 0, obj/projectile/P, def_zone)
+//NON-MODULE CHANGE: Carry over any projectile hitting and the zone it hits. Used to run armor calculations on stamina damage.
 	if(blocked >= 100)
 		return FALSE
 	if(stun)
@@ -141,7 +142,8 @@
 	if(drowsy)
 		apply_effect(drowsy, EFFECT_DROWSY, blocked)
 	if(stamina)
-		apply_damage(stamina, STAMINA, null, blocked)
+		var/armor_check = check_projectile_armor(def_zone, P, is_silent = TRUE) //NON-MODULE CHANGE: Actually apply the armor to the stamina damage!
+		apply_damage(stamina, STAMINA, null, armor_check) //NON-MODULE CHANGE
 	if(jitter)
 		apply_effect(jitter, EFFECT_JITTER, blocked)
 	return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -62,7 +62,7 @@
 		// on [/atom/proc/bullet_act] where it's just to pass it to the projectile's on_hit().
 		var/armor_check = check_projectile_armor(def_zone, P, is_silent = TRUE)
 		apply_damage(P.damage, P.damage_type, def_zone, armor_check, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
-		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize)
+		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize, P, def_zone)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
 	return . ? BULLET_ACT_HIT : BULLET_ACT_BLOCK

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -62,6 +62,7 @@
 		// on [/atom/proc/bullet_act] where it's just to pass it to the projectile's on_hit().
 		var/armor_check = check_projectile_armor(def_zone, P, is_silent = TRUE)
 		apply_damage(P.damage, P.damage_type, def_zone, armor_check, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
+		//NON-MODULE CHANGE: Carries over the projectile and hit zone to apply_effects in order to have the stamina effect apply it's armor.
 		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize, P, def_zone)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)

--- a/maplestation_modules/README.md
+++ b/maplestation_modules/README.md
@@ -166,6 +166,8 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\modules\jobs\job_types\quartermaster.dm
 - code\modules\language\language_holder.dm
 - code\modules\mob\dead\new_player\new_player.dm
+- code\modules\mob\living\damage_procs.dm
+- code\modules\mob\living\living_defense.dm
 - code\modules\mob\living\carbon\human\human.dm
 - code\modules\mob\living\carbon\human\human_update_icons.dm
 - code\modules\mob\living\carbon\human\species.dm


### PR DESCRIPTION
Non-modular fix, but it's probably going to get ported in some way to /tg/station anyway.

This fixes the stamina damage _effect_ from projectiles ignoring armor, an example being beanbags doing 55 damage through armor.

Tested:
![https://i.imgur.com/2abLXpn.png](https://i.imgur.com/2abLXpn.png)