### PR TITLE
Fixes clockwork armor doing literally nothing, gives it more reasonable armor.

### DIFF
--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
@@ -4,15 +4,19 @@
 	desc = "A heavily-armored helmet worn by warriors of the Rat'varian cult. It can withstand hard vacuum."
 	icon_state = "clockwork_helmet"
 	inhand_icon_state = "clockwork_helmet_inhand"
-	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 60, BOMB = 50, BIO = 30, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 35, LASER = 30, ENERGY = 40, BOMB = 50, BIO = 30, FIRE = 100, ACID = 100, WOUND = 10)
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK | HIDEEARS | HIDEEYES | HIDEFACE | HIDEHAIR | HIDEFACIALHAIR | HIDESNOUT
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	cold_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	heat_protection = HEAD
 	flash_protect = FLASH_PROTECTION_WELDER
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	actions_types = list()
+	strip_delay = 50
+	equip_delay_other = 50
 
 /obj/item/clothing/suit/hooded/clock
 	name = "\improper Rat'varian clockwork suit"
@@ -23,12 +27,17 @@
 	w_class = WEIGHT_CLASS_BULKY
 	allowed = list(/obj/item/clockwork_slab, /obj/item/melee/ratvar_spear, /obj/item/tank/internals, /obj/item/construction/rcd/clock)
 	hoodtype = /obj/item/clothing/head/hooded/clock
-	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 60, BOMB = 50, BIO = 30, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 35, LASER = 30, ENERGY = 40, BOMB = 50, BIO = 30, FIRE = 100, ACID = 100, WOUND = 10) //Slightly better than a secvest
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
+	body_parts_covered = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	heat_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	resistance_flags = NONE
+	strip_delay = 80
+	equip_delay_other = 80
 
 // Hack to get around hooded things changing their icon state
 /obj/item/clothing/suit/hooded/clock/ToggleHood()

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
@@ -15,8 +15,8 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
 	actions_types = list()
-	strip_delay = 50
-	equip_delay_other = 50
+	strip_delay = 5 SECONDS
+	equip_delay_other = 5 SECONDS
 
 /obj/item/clothing/suit/hooded/clock
 	name = "\improper Rat'varian clockwork suit"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
@@ -36,8 +36,8 @@
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	heat_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	resistance_flags = NONE
-	strip_delay = 80
-	equip_delay_other = 80
+	strip_delay = 8 SECONDS
+	equip_delay_other = 8 SECONDS
 
 // Hack to get around hooded things changing their icon state
 /obj/item/clothing/suit/hooded/clock/ToggleHood()


### PR DESCRIPTION
So clockwork armor did literally nothing beforehand. It covered no region of the body aside from the head. It also was missing a bunch of flags that should've been there.

The armor's also been changed to be more reasonable for how you obtain it, since the brass structures only cost iron in terms of resources. Therefore, it's better than a sec vest, but worse than the captain's armor. Not really any balance data on this though since the armor didn't do anything beforehand.