### PR TITLE
Completely destroys the balance of Pubbystation (adds a condimaster to the bar)

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2303,6 +2303,7 @@
 	dir = 4
 	},
 /obj/machinery/chem_master/condimaster,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ahQ" = (
@@ -13242,11 +13243,11 @@
 	},
 /area/service/bar)
 "aSQ" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/item/storage/box/beanbag,
 /obj/item/assembly/mousetrap,
 /obj/item/storage/box/mousetraps,
 /obj/machinery/light/directional/east,
+/obj/structure/closet/crate/wooden,
 /turf/open/floor/wood,
 /area/service/bar)
 "aSR" = (
@@ -14144,7 +14145,6 @@
 /area/service/bar)
 "aWm" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/storage/box/drinkingglasses,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14400,6 +14400,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
 "aWY" = (
@@ -14422,7 +14423,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -35489,6 +35489,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/service/bar)
 "dGR" = (
@@ -52128,7 +52129,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rof" = (
-/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
@@ -52623,6 +52623,18 @@
 	dir = 8
 	},
 /area/hallway/primary/central)
+"rBD" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/iron/dark,
+/area/service/bar)
 "rBL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -93513,9 +93525,9 @@ aPE
 aRU
 aPE
 aPE
-was
-aWh
 aPE
+aWh
+was
 aPE
 aYZ
 liQ
@@ -95058,7 +95070,7 @@ aPE
 cpb
 wzu
 beB
-aYg
+rBD
 aZd
 dXz
 lTf

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2302,6 +2302,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
+/obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ahQ" = (


### PR DESCRIPTION
<!-- Hi! Thanks for contributing to our code! Please make sure to check the check list below. -->
<!-- Please make sure that modulairty is in order to prevent headaches later. For more information, check the README.md in /maplestation_modules/ -->

# What have I wrought

Adds a condimaster to the bar of pubbystation so you don't need to go all the way to the coldroom to use it.
Also rearranges some other things in the bar to facilitate this change, and finally moves some boxes off the floor.
![2022 05 15-17 09 11](https://user-images.githubusercontent.com/66052067/168493995-2f2e73fe-f361-4e07-9731-3b2ee6e2be9e.png)
![guh](https://user-images.githubusercontent.com/66052067/168493996-80e85d87-cfb7-4fb4-8494-7af45690a52e.png)

