### PR TITLE
TRAIT_NOBREATH no longer prevents spawning with lungs.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -38,6 +38,7 @@
 	// changes, only the Random Golem type can be chosen
 	limbs_id = "golem"
 	fixed_mut_color = "#aaaaaa"
+	mutantlungs = null //NON-MODULE CHANGE: NOBREATH used to handle lung removal, but not anymore
 	var/info_text = "As an <span class='danger'>Iron Golem</span>, you don't have any special traits."
 	var/random_eligible = TRUE //If false, the golem subtype can't be made through golem mutation toxin
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -506,8 +506,9 @@
 		owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!"))
 		failed = TRUE
 
-/obj/item/organ/lungs/get_availability(datum/species/owner_species)
-	return !(TRAIT_NOBREATH in owner_species.inherent_traits)
+///NON-MODULE CHANGE: This is just an old bit of code from before ways of editing species' lungs directly were a thing. It's a bug fix, so it's non-modular
+// /obj/item/organ/lungs/get_availability(datum/species/owner_species)
+//	return !(TRAIT_NOBREATH in owner_species.inherent_traits)
 
 /obj/item/organ/lungs/plasmaman
 	name = "plasma filter"

--- a/maplestation_modules/README.md
+++ b/maplestation_modules/README.md
@@ -171,6 +171,7 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\modules\mob\living\carbon\human\human.dm
 - code\modules\mob\living\carbon\human\human_update_icons.dm
 - code\modules\mob\living\carbon\human\species.dm
+- code\modules\mob\living\carbon\human\species_types\golems.dm
 - code\modules\modular_computers\file_system\programs\jobmanagement.dm
 - code\modules\reagents\chemistry\reagents\other_reagents.dm
 - code\modules\surgery\bodyparts\_bodyparts.dm


### PR DESCRIPTION
Bug fix time! TRAIT_NOBREATH now no longer prevents species from spawning with lungs via the removal of some old, definitively deprecated code. Golems have been edited to have no lungs, as it makes sense for them to not have any.

Most notably, this fixes synths having no lungs.