### PR TITLE
Ports tgstation's food processor multiplier fix.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -55,7 +55,7 @@
 /obj/machinery/processor/proc/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	if(recipe.output && loc && !QDELETED(src))
 		var/list/cached_mats = recipe.preserve_materials && what.custom_materials
-		var/cached_multiplier = recipe.multiplier
+		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
 			var/atom/processed_food = new recipe.output(drop_location())
 			if(cached_mats)

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -9,8 +9,8 @@
 	var/time = 40
 	/// The machine required to do this recipe
 	var/required_machine = /obj/machinery/processor
-	/// The number of products this recipe creates.
-	var/multiplier = 1 //This multiplies the number of products produced per object processed.
+	/// Multiplied additional food made when processed
+	var/food_multiplier = 1
 	/// Whether to copy the materials from the input to the output
 	var/preserve_materials = TRUE
 
@@ -22,7 +22,7 @@
 		/obj/item/food/meat/slab/xeno,
 		/obj/item/food/meat/slab/bear,
 		/obj/item/food/meat/slab/chicken)
-	multiplier = 3
+	food_multiplier = 3
 
 /datum/food_processor_process/cutlet
 	input = /obj/item/food/meat/cutlet/plain
@@ -70,7 +70,7 @@
 /datum/food_processor_process/meat/chicken
 	input = /obj/item/food/meat/slab/chicken
 	output = /obj/item/food/raw_meatball/chicken
-	multiplier = 3
+	food_multiplier = 3
 	blacklist = null
 
 /datum/food_processor_process/cutlet/chicken
@@ -127,5 +127,5 @@
 /datum/food_processor_process/towercap
 	input = /obj/item/grown/log
 	output = /obj/item/popsicle_stick
-	multiplier = 3
+	food_multiplier = 3
 	preserve_materials = FALSE


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/65783 earlier than any upstream merge would.

Basically, this fixes food processors not giving a multiplier to how much food they output when upgraded. For example, a tier 4 food processor is intended to output 4 pieces of spaghetti per dough slice, but only outputs 1. This fixes that.
