### PR TITLE
Makes clockwork cult lore more consistent with server lore.

### DIFF
--- a/maplestation_modules/code/__DEFINES/antag_defines.dm
+++ b/maplestation_modules/code/__DEFINES/antag_defines.dm
@@ -33,7 +33,7 @@
 
 /// Styles of cult.
 #define CULT_STYLE_NARSIE "Nar'sian Cult"
-#define CULT_STYLE_RATVAR "Rat'varian Cult"
+#define CULT_STYLE_RATVAR "Rat-varian Cult"
 
 /// Trait for people who were recently funnyhanded and can't be for a few seconds. (See TRAIT_IWASBATONNED)
 #define TRAIT_I_WAS_FUNNY_HANDED "i_was_funny_handed"

--- a/maplestation_modules/code/game/objects/unique_examine_items.dm
+++ b/maplestation_modules/code/game/objects/unique_examine_items.dm
@@ -210,7 +210,7 @@
 			EXAMINE_CHECK_FACTION, "cult")
 	else
 		AddElement(/datum/element/unique_examine, \
-			"A sigil of power inscribed by the followers of the Clockwork God Rat'var \
+			"A sigil of power inscribed by the followers of the Clockwork God Rat-Var \
 			to channel powerful clock magics through the invoker.", \
 			EXAMINE_CHECK_FACTION, "cult")
 

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/buildings/clock_daemon.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/buildings/clock_daemon.dm
@@ -1,15 +1,15 @@
 #define JUDICIAL_VISOR "Judicial Visor"
-#define RATVAR_SPEAR "Rat'varian Spear"
+#define RATVAR_SPEAR "Rat-varian Spear"
 #define BRASS_ARMOR "Brass Armor"
 
 // The daemon forge
 // produces combat items
 /obj/structure/destructible/cult/item_dispenser/daemon_forge
 	name = "daemon forge"
-	desc = "A forge used by follower of Ratvar to construct more advanced creations."
+	desc = "A forge used by follower of Rat-Var to construct more advanced creations."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "tinkerers_daemon"
-	cult_examine_tip = "A Rat'varian cultist can use it to create judicial visors, ratvarian spears, and brass armor."
+	cult_examine_tip = "A Rat-varian cultist can use it to create judicial visors, ratvarian spears, and brass armor."
 	break_message = "<span class='warning'>The forge crumbles, spilling out alloys and brass.</span>"
 	light_range = 1.5
 	light_color = "#ffff99"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/buildings/clock_tinkers.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/buildings/clock_tinkers.dm
@@ -6,7 +6,7 @@
 // produces utility items
 /obj/structure/destructible/cult/item_dispenser/tinkers_cache
 	name = "tinkerer's cache"
-	desc = "A cache of gizmos and gears constructed by a follower of Ratvar."
+	desc = "A cache of gizmos and gears constructed by a follower of Rat-Var."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "tinkerers_cache"
 	cult_examine_tip = "Can be used to create replica fabricators, wraith specs, and truesight lenses."

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_cult_theme.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_cult_theme.dm
@@ -1,7 +1,7 @@
 // Clockcult ~2~ 3, Electric Boogaloo.
 /datum/cult_theme/ratvarcult
 	name = CULT_STYLE_RATVAR
-	default_deity = "Rat'var"
+	default_deity = "Rat-Var" //Formal name, Rat-Var. Informally can be referred to as Ratvar. Rat'Var is cursed and invokes Nar'Sie.
 	faction = "ratvar"
 	cultist_hud_name = "clockwork"
 	cultist_lead_hud_name = "clockwork_lead"
@@ -42,13 +42,13 @@
 /datum/cult_theme/ratvarcult/get_start_making_rune_text(mob/living/cultist)
 	var/list/text = list()
 	text["visible_message"] = span_warning("[cultist] begins outlining out a strange design!")
-	text["self_message"] = span_brass("You begin drawing a sigil of Ratvar.")
+	text["self_message"] = span_brass("You begin drawing a sigil of Rat-Var.")
 	return text
 
 /datum/cult_theme/ratvarcult/get_end_making_rune_text(mob/living/cultist)
 	var/list/text = list()
 	text["visible_message"] = span_warning("[cultist] creates a strange, bright circle.")
-	text["self_message"] = span_brass("You finish drawing the arcane markings of Ratvar.")
+	text["self_message"] = span_brass("You finish drawing the arcane markings of Rat-Var.")
 	return text
 
 /datum/cult_theme/ratvarcult/get_start_invoking_magic_text(added_magic, atom/target)
@@ -65,12 +65,12 @@
 		"Hap'rn-fvat..",
 		"Gv'px Gb'px..",
 		"FNG NAN!",
-		"Ur'yc Rat'var.."
+		"Ur'yc Rat-Var.."
 	))
 
-/datum/cult_theme/ratvarcult/pick_god_shame_line()
+/datum/cult_theme/ratvarcult/pick_god_shame_line() //Not given out by Ratvar, but by the leader of the clockwork cult. Ratvar's against the clockwork cult, and they're trying to bring him back.
 	return pick(list(
-		"Do not give in, my return counts on you.",
+		"Do not give in, the return of our lord counts on you.",
 		"Scour this poison, you must - or else!",
 		"All this power, and you still falter?",
 		"The cogs will not continue to turn without you.",

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
@@ -1,6 +1,6 @@
 // Ratvarian language.
 /datum/language/ratvarian
-	name = "Ratvarian"
+	name = "Rat-varian"
 	desc = "A timeless language full of power and incomprehensible to the unenlightened."
 	//ask_verb = "requests"
 	//exclaim_verb = "proclaims"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_ritual_item.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_ritual_item.dm
@@ -1,7 +1,7 @@
 // Clockwork slab babyyy
 /obj/item/clockwork_slab
 	name = "clockwork slab"
-	desc = "A slab of brass covered in cogs and gizmos used by agents of Rat'var to invoke their spells."
+	desc = "A slab of brass covered in cogs and gizmos used by agents of Rat-Var to invoke their spells."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "dread_ipad"
 	worn_icon_state = "dread_ipad"
@@ -16,10 +16,10 @@
 
 /obj/item/clockwork_slab/Initialize(mapload)
 	. = ..()
-	var/examine_text = {"Allows the scribing of sigils and access to the powers of the cult of Rat'var.
+	var/examine_text = {"Allows the scribing of sigils and access to the powers of the cult of Rat-Var.
 Can be used on <b>cult structures</b> to move them around.
 Can also be used on <b>sigils or runes</b> to clear them away.
-Can block melee attacks for followers of Rat'var when held in hand."}
+Can block melee attacks for followers of Rat-Var when held in hand."}
 
 	AddComponent(/datum/component/cult_ritual_item/advanced, \
 		span_brass(examine_text), \

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/judicial_visor.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/judicial_visor.dm
@@ -3,7 +3,7 @@
 // but they are told what direction you are afterwards.
 /obj/item/clothing/glasses/judicial_visor
 	name = "judicial visor"
-	desc = "A Rat'varian brass visor with a purple eye guard that occasionally flares brightly."
+	desc = "A Rat-varian brass visor with a purple eye guard that occasionally flares brightly."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	base_icon_state = "judicial_visor"
 	icon_state = "judicial_visor_1"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_hardsuit.dm
@@ -1,7 +1,7 @@
 // Clockwork hardsuit and helemet.
 /obj/item/clothing/head/hooded/clock
-	name = "\improper Rat'varian clockwork suit"
-	desc = "A heavily-armored helmet worn by warriors of the Rat'varian cult. It can withstand hard vacuum."
+	name = "\improper Rat-varian clockwork suit"
+	desc = "A heavily-armored helmet worn by warriors of the Rat-varian cult. It can withstand hard vacuum."
 	icon_state = "clockwork_helmet"
 	inhand_icon_state = "clockwork_helmet_inhand"
 	armor = list(MELEE = 40, BULLET = 35, LASER = 30, ENERGY = 40, BOMB = 50, BIO = 30, FIRE = 100, ACID = 100, WOUND = 10)
@@ -19,8 +19,8 @@
 	equip_delay_other = 5 SECONDS
 
 /obj/item/clothing/suit/hooded/clock
-	name = "\improper Rat'varian clockwork suit"
-	desc = "A heavily-armored exosuit worn by warriors of the Rat'varian cult. It can withstand hard vacuum."
+	name = "\improper Rat-varian clockwork suit"
+	desc = "A heavily-armored exosuit worn by warriors of the Rat-varian cult. It can withstand hard vacuum."
 	icon_state = "clockwork_cuirass"
 	worn_icon_state = "clockwork_cuirass"
 	inhand_icon_state = "clockwork_cuirass_inhand"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_spear.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/ratvar_spear.dm
@@ -1,7 +1,7 @@
-// A real Rat'varian Spear.
+// A real Rat-varian Spear.
 // Slightly less force than an E.L., more armor pen and throwforce.
 /obj/item/melee/ratvar_spear
-	name = "rat'varian spear"
+	name = "rat-varian spear"
 	desc = "A mechanical spear made of genuine brass. It menaces as you stare upon it."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	worn_icon = 'icons/mob/clothing/belt.dmi'

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/replica_fabricator.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/replica_fabricator.dm
@@ -20,7 +20,7 @@
 // It's a buffed RCD.
 /obj/item/construction/rcd/clock
 	name = "replica fabricator"
-	desc = "A cryptic looking device that can be used by ratvarian cultists to construct and deconstruct at rapid pace."
+	desc = "A cryptic looking device that can be used by rat-varian cultists to construct and deconstruct at rapid pace."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "replica_fabricator"
 	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi'

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/truesight_lens.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/truesight_lens.dm
@@ -2,7 +2,7 @@
 // Binoculars for cultists only.
 /obj/item/binoculars/truesight_lens
 	name = "truesight lens"
-	desc = "A yellow lens created by Rat'varian worshippers to spy great distances."
+	desc = "A yellow lens created by Rat-varian worshippers to spy great distances."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "truesight_lens"
 	inhand_icon_state = "none"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/wraith_specs.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/wraith_specs.dm
@@ -6,7 +6,7 @@
 // ...But if you examine anything you'd be unable to see normally, you'll recieve eye damage.
 /obj/item/clothing/glasses/wraith_specs
 	name = "wraith specs"
-	desc = "A set of glasses constructed by worshippers of Rat'var to grant them eyes of a wraith, greatly enhancing their sight."
+	desc = "A set of glasses constructed by worshippers of Rat-Var to grant them eyes of a wraith, greatly enhancing their sight."
 	icon = 'maplestation_modules/icons/obj/clockwork_objects.dmi'
 	icon_state = "wraith_specs"
 	worn_icon_state = "wraith_specs"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/magic/clock_magic_item_conversion.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/magic/clock_magic_item_conversion.dm
@@ -1,7 +1,7 @@
 /datum/action/item_action/cult/clock_spell/item_conversion
 	name = "Slab: Brass Touch"
 	desc = "Empowers the slab to convert structures and items into brass after a channel."
-	examine_hint = "channels on the target structure or item, morphing it into a brass Rat'varian version if possible. Turns iron into brass sheets."
+	examine_hint = "channels on the target structure or item, morphing it into a brass Rat-varian version if possible. Turns iron into brass sheets."
 	button_icon_state = "integration_cog"
 	invocation = "Gb-hpu bs oen'ff!"
 	active_overlay_name = "compromise"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/runes/conversion_sigil.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/runes/conversion_sigil.dm
@@ -2,7 +2,7 @@
 	name = "sigil"
 	desc = "An odd collection of symbols that glint when shined light upon."
 	cultist_name = "Sigil of Submission"
-	cultist_desc = "subject a non-cultist to the power of Rat'var, converting the victim to your cult. \
+	cultist_desc = "subject a non-cultist to the eternal power of the machine, converting the victim to your cult. \
 		If you opted out of conversion, or the victim is mindshielded, subjects them to torment instead."
 	invocation = "Fho'zvg Gb Engine!"
 	icon = 'maplestation_modules/icons/effects/clockwork_effects.dmi'


### PR DESCRIPTION
Also more consistent with itself, as there were some issues.

Establishes some naming rules for Rat-Var. Rat-Var formally and Ratvar informally, Rat-var used mainly in adjectives. Was chosen for sounding more mechanical, like it's in sections done by each teeth of a cog.

In addition, a deconversion line has been changed to not have Rat-Var refer to their return in first person, as the clockwork cult is mostly trying to bring Ratty back to their side, rather than summon him.