### PR TITLE
Adds in the ability to ricoshot projectiles off of coins.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -4496,6 +4496,7 @@
 #include "maplestation_modules\code\modules\loadouts\loadout_ui\loadout_outfit_helpers.dm"
 #include "maplestation_modules\code\modules\mining\machine_vending.dm"
 #include "maplestation_modules\code\modules\mining\mining_redemption.dm"
+#include "maplestation_modules\code\modules\mining\ores_coins.dm"
 #include "maplestation_modules\code\modules\mob\logout.dm"
 #include "maplestation_modules\code\modules\mob\mob.dm"
 #include "maplestation_modules\code\modules\mob\mob_defines.dm"

--- a/maplestation_modules/code/modules/mining/ores_coins.dm
+++ b/maplestation_modules/code/modules/mining/ores_coins.dm
@@ -1,0 +1,20 @@
+///Modular file for adding onto coins. Used for Ricoshots.
+
+///Ricoshots. Shoot a coin for extra speed and damage on the projectile, but you've gotta aim it.
+/obj/item/coin/bullet_act(obj/projectile/hitting_projectile, piercing_hit = FALSE)
+	playsound(src, hitting_projectile.hitsound, 50, TRUE)
+	if(hitting_projectile.damage >= 40) //If we do too much damage, the coin just shatters
+		visible_message("[src] shatters from [hitting_projectile]'s impact!")
+		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 50, TRUE)
+		qdel(src)
+		return BULLET_ACT_FORCE_PIERCE //We hit so hard we're going through.
+	if(piercing_hit == TRUE)
+		visible_message("[hitting_projectile] pierces through [src]!")
+		playsound(src, 'sound/effects/picaxe3.ogg', 50, TRUE) //I wanted to use sounds already in the game and this fits quite well.
+		return BULLET_ACT_HIT
+	visible_message("[hitting_projectile] ricoshots off of [src] and gains momentum!")
+	playsound(src, 'sound/items/coinflip.ogg', 50, TRUE)
+	flick("coin_[coinflip]_flip", src) //Flips the coin for some flair. You can actually hit the coin while it's flipping if you're fast enough.
+	hitting_projectile.speed /= 2 //lower speed = faster
+	hitting_projectile.damage *= 1.5
+	return BULLET_ACT_FORCE_PIERCE //Force a piercing shot so that the projectile doesn't get deleted


### PR DESCRIPTION
Projectiles can now ricoshot off of coins if you shoot at them, gaining a 1.5x increase to damage and a whopping 2x increase to speed. The coin flips afterwards, which adds in some flair alongside adding a small cooldown.

This allows some pretty risky and tricky maneuvers, but they could prove to be an effective source of damage. Of course, this is mainly just an easter egg for players of certain games (there's more than one game where shooting a coin increases damage).

If you shoot the coin with a projectile that's too powerful, you'll break the coin. No cheesing revolvers or laser cannons.