### PR TITLE
Adds Pride Pin to loadouts, adds reskin support to loadout, adds relaying support for loudout accessories

### DIFF
--- a/maplestation_modules/code/__DEFINES/_module_defines.dm
+++ b/maplestation_modules/code/__DEFINES/_module_defines.dm
@@ -28,6 +28,8 @@
 
 #define INFO_GREYSCALE "greyscale"
 #define INFO_NAMED "name"
+#define INFO_RESKIN "reskin"
+#define INFO_LAYER "layer"
 
 /// Max amonut of misc / backpack items that are allowed.
 #define MAX_ALLOWED_MISC_ITEMS 3
@@ -38,6 +40,7 @@
 #define TOOLTIP_RANDOM_COLOR "RANDOM COLOR -This item has a random color and will change every round."
 #define TOOLTIP_GREYSCALE "GREYSCALED - This item can be customized via the greyscale modification UI."
 #define TOOLTIP_RENAMABLE "RENAMABLE - This item can be given a custom name."
+#define TOOLTIP_RESKINNABLE "RESKINNABLE - This item can be reskinned."
 
 /// Modular traits
 #define TRAIT_DISEASE_RESISTANT "disease_resistant"

--- a/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -1,15 +1,46 @@
 // --- Loadout item datums for accessories ---
 
+#define ADJUSTABLE_TOOLTIP "LAYER ADJUSTABLE - You can opt to have accessory above or below your suit."
+
 /// Accessory Items (Moves overrided items to backpack)
 GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/accessory))
 
 /datum/loadout_item/accessory
 	category = LOADOUT_ITEM_ACCESSORY
+	// Can we adjust this accessory to be above or below suits?
+	var/can_be_layer_adjusted = FALSE
+
+/datum/loadout_item/accessory/New()
+	. = ..()
+	var/obj/item/clothing/accessory/accessory = item_path
+	if(!ispath(accessory))
+		return
+
+	can_be_layer_adjusted = TRUE
+	add_tooltip(ADJUSTABLE_TOOLTIP, inverse_order = TRUE)
 
 /datum/loadout_item/accessory/insert_path_into_outfit(datum/outfit/outfit, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	if(outfit.accessory)
 		LAZYADD(outfit.backpack_contents, outfit.accessory)
 	outfit.accessory = item_path
+
+/datum/loadout_item/accessory/on_equip_item(datum/preferences/preference_source, mob/living/carbon/human/equipper, visuals_only = FALSE)
+	. = ..()
+	var/obj/item/clothing/accessory/equipped_item = .
+	var/obj/item/clothing/under/suit = equipper.w_uniform
+	if(!istype(equipped_item))
+		return
+
+	var/list/our_loadout = preference_source.read_preference(/datum/preference/loadout)
+	if(can_be_layer_adjusted && (INFO_LAYER in our_loadout[item_path]))
+		equipped_item.above_suit = our_loadout[item_path][INFO_LAYER]
+
+	if(!istype(suit))
+		return
+
+	// Hacky, but accessory will ONLY update when attached or detached.
+	equipped_item.detach(suit)
+	suit.attach_accessory(equipped_item)
 
 /datum/loadout_item/accessory/maid_apron
 	name = "Maid Apron"
@@ -78,3 +109,10 @@ GLOBAL_LIST_INIT(loadout_accessory, generate_loadout_items(/datum/loadout_item/a
 	name = "Heirloom Skull Codpiece"
 	item_path = /obj/item/clothing/accessory/armorless_skullcodpiece
 	additional_tooltip_contents = list(TOOLTIP_NO_ARMOR)
+
+/datum/loadout_item/accessory/pride
+	name = "Pride Pin"
+	item_path = /obj/item/clothing/accessory/pride
+	can_be_reskinned = TRUE
+
+#undef ADJUSTABLE_TOOLTIP

--- a/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 
 // We didn't spawn any item yet, so nothing to call here.
 /datum/loadout_item/pocket_items/wallet/on_equip_item(datum/preferences/preference_source, mob/living/carbon/human/equipper, visuals_only)
+	SHOULD_CALL_PARENT(FALSE)
 	return FALSE
 
 // We add our wallet at the very end of character initialization (after quirks, etc) to ensure the backpack / their ID is all set by now.

--- a/tgui/packages/tgui/interfaces/_LoadoutManager.js
+++ b/tgui/packages/tgui/interfaces/_LoadoutManager.js
@@ -139,6 +139,26 @@ export const LoadoutTabs = (props, context) => {
                           })} />
                       </Stack.Item>
                     )}
+                    { !!item.is_reskinnable
+                    && (
+                      <Stack.Item>
+                        <Button
+                          icon="theater-masks"
+                          onClick={() => act('set_skin', {
+                            path: item.path,
+                          })} />
+                      </Stack.Item>
+                    )}
+                    { !!item.is_layer_adjustable
+                    && (
+                      <Stack.Item>
+                        <Button
+                          icon="arrow-down"
+                          onClick={() => act('set_layer', {
+                            path: item.path,
+                          })} />
+                      </Stack.Item>
+                    )}
                     <Stack.Item>
                       <Button.Checkbox
                         checked={selected_loadout.includes(item.path)}


### PR DESCRIPTION
- Adds the Pride Pin to loadouts. 
- Adds reskin support to loadouts. If set, an item with possible reskins can be ... reskinned, out of the box, instead of needing to do it roundstart. 
- Adds layer adjusting support for loadout accessories. (Deciding whether or not an accessory renders above or below any worn suits.)

Kinda WIP while I decide whether or not I'd like to improve the code. It's currently a bit janky and hacky and could definitely be much better. 