### PR TITLE
Adds a griddle to any prison that didn't have one, and puts a source of water in all the prison gardens

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -389,7 +389,7 @@
 /obj/item/folder/blue,
 /obj/item/clothing/under/rank/centcom/commander,
 /obj/item/clothing/head/centhat{
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0);
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0);
 	desc = "A replica hat of a Central Commander's attire. It has a small tag on it saying, 'It's good to be emperor.'";
 	name = "Replica CentCom hat"
 	},
@@ -4454,7 +4454,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
+	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing=15);
 	name = "Delta-Down";
 	pixel_x = 5;
 	pixel_y = 5
@@ -4508,6 +4508,7 @@
 /obj/structure/table,
 /obj/item/trash/popcorn,
 /obj/machinery/light/directional/west,
+/obj/item/kitchen/fork/plastic,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aNJ" = (
@@ -4683,15 +4684,17 @@
 /turf/open/floor/iron/white,
 /area/security/prison/safe)
 "aPs" = (
-/obj/structure/table,
-/obj/item/kitchen/fork/plastic,
+/obj/machinery/vending/sustenance,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aPt" = (
-/obj/machinery/vending/sustenance,
 /obj/machinery/camera/directional/south{
 	c_tag = "Permabrig - Kitchen";
 	network = list("ss13","prison")
+	},
+/obj/machinery/griddle,
+/obj/structure/window{
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -34603,7 +34606,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Supermatter Foyer";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /obj/structure/rack,
 /obj/item/analyzer,
@@ -43216,7 +43219,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Freezers";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
@@ -45035,7 +45038,7 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Supermatter Room Port";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -51004,10 +51007,6 @@
 /area/service/kitchen/abandoned)
 "iCN" = (
 /obj/structure/table,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/servingdish,
 /obj/structure/reagent_dispensers/servingdish,
 /obj/item/clothing/head/chefhat,
 /turf/open/floor/iron/cafeteria,
@@ -63734,7 +63733,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Supermatter Room Starboard";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -63983,7 +63982,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Supermatter";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /obj/structure/sign/warning/radiation{
 	pixel_x = 32
@@ -71587,7 +71586,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering - Supermatter Emitters";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/power/emitter{
@@ -78099,7 +78098,7 @@
 /obj/item/folder/red,
 /obj/item/toy/gun,
 /obj/item/clothing/head/beret/sec{
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0);
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0);
 	desc = "A replica beret resembling that of a special operations officer under Nanotrasen.";
 	name = "replica officer's beret"
 	},
@@ -83718,7 +83717,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering - Supermatter Room Aft";
 	name = "engineering camera";
-	network = list("ss13", "engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
@@ -87277,10 +87276,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"scA" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/security/prison)
 "scE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -165377,7 +165372,7 @@ hXT
 oWK
 oWK
 bbt
-scA
+aNK
 aKV
 wOH
 eGN

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -10015,7 +10015,7 @@
 "aXN" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -65221,13 +65221,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/item/radio/intercom/prison/directional/north,
+/obj/machinery/griddle,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "rhk" = (
@@ -73693,6 +73688,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/white,
 /area/security/prison)
 "ukN" = (
@@ -77121,7 +77121,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -38851,6 +38851,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/griddle,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "lFM" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36919,6 +36919,8 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/book/manual/chef_recipes,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "eTj" = (
@@ -38922,9 +38924,7 @@
 /area/engineering/supermatter/room)
 "gqx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/security/prison)
 "gsP" = (
@@ -49656,9 +49656,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/flour,
+/obj/machinery/griddle,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "pqw" = (
@@ -53321,8 +53319,22 @@
 	pixel_x = 32
 	},
 /obj/structure/table,
-/obj/item/cultivator,
-/obj/item/cultivator,
+/obj/item/cultivator{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/cultivator{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/shovel/spade{
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/shovel/spade{
+	pixel_y = -2;
+	pixel_x = -2
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "sbX" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6695,6 +6695,14 @@
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"aQY" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "aQZ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -11509,6 +11517,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/central/greater)
+"cFw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/griddle,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison/mess)
 "cFF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -26739,6 +26752,7 @@
 "ilM" = (
 /obj/item/radio/intercom/prison/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "ims" = (
@@ -26893,6 +26907,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "ioP" = (
@@ -28766,6 +28781,11 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
+"iZG" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "iZK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -41122,6 +41142,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	dir = 4;
+	name = "old sink";
+	pixel_x = -12
+	},
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "nEN" = (
@@ -45672,6 +45698,7 @@
 /area/command/heads_quarters/hop)
 "pmq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "pmr" = (
@@ -57716,6 +57743,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "tKg" = (
@@ -60966,6 +60994,7 @@
 "uPl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "uPn" = (
@@ -61933,6 +61962,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"vma" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Prison Garden"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison/garden)
 "vmd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -89375,7 +89416,7 @@ fnk
 pmL
 tkJ
 tfO
-tfO
+cFw
 oXH
 maZ
 pxG
@@ -94253,7 +94294,7 @@ fGY
 cIh
 ftR
 aFl
-pmL
+iZG
 ojx
 ojx
 ojx
@@ -94510,7 +94551,7 @@ pyA
 cIh
 oJB
 smK
-qOq
+aQY
 nTn
 dhe
 dhe
@@ -94767,7 +94808,7 @@ bkY
 bkY
 pNB
 jiS
-pNB
+vma
 bkY
 bkY
 dhe


### PR DESCRIPTION
Some of the prisons didn't have griddles while others did, and for some reason some of them were even missing water in their gardens. Pubby actually didn't have a single source of water before!
The griddle opens up possible recipes while still not giving the prison access to all the tools (i.e. the oven and processor), I think it only fair that the ones that didn't have one before should get one.

# Pics
## Delta
![image](https://user-images.githubusercontent.com/66052067/190946267-e2a12c2f-d0fd-4bf2-bb61-930e7d85116d.png)
## Kilo
![image](https://user-images.githubusercontent.com/66052067/190946296-ba228a02-cef1-485d-899d-a20791edf1ca.png)
## Meta
![image](https://user-images.githubusercontent.com/66052067/190946351-6e3228cb-7261-4f53-9da6-cba656cfe5c8.png)
## Pubby (And hydro water)
![image](https://user-images.githubusercontent.com/66052067/190946365-953f0294-dd59-4014-baef-f18a6bad8cc0.png)
![image](https://user-images.githubusercontent.com/66052067/190946384-48604010-58ef-45ef-b986-cd48d749086e.png)
## Tram (with new sink in hydro)
![image](https://user-images.githubusercontent.com/66052067/190946409-2037bc77-4b1b-4720-bad3-a3b000024238.png)
![image](https://user-images.githubusercontent.com/66052067/190946423-bd45df33-d4d5-41a6-9ea1-a7c6fef2003c.png)
