### PR TITLE
Some fax fixes (again)

### DIFF
--- a/maplestation_modules/code/game/machinery/fax_machine.dm
+++ b/maplestation_modules/code/game/machinery/fax_machine.dm
@@ -626,7 +626,7 @@ GLOBAL_LIST_EMPTY(fax_machines)
 
 	if(!silent)
 		flick("fax_receive", src)
-		balloon_alert_to_viewers("removed fax")
+		balloon_alert_to_viewers("removed paper")
 	if(user && user.CanReach(src))
 		user.put_in_hands(stored_paper)
 	else


### PR DESCRIPTION
Minor fixes for the fax machine I noticed recently. 
- Bad span
- Weird balloon alerts
- Accidentally setting title to content of message