### PR TITLE
Captain's Announcements and RC Desk Announcements will now append the identity and name of the ID that authorized it

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -729,7 +729,11 @@
 		input = user.treat_message(input) //Adds slurs and so on. Someone should make this use languages too.
 	// NON-MODULE CHANGE
 	if(authorize_job && authorize_name)
-		input += "\n\n - [authorize_job] [authorize_name]"
+		if(authorize_job == authorize_name)
+			input += "\n\n - [authorize_name]"
+		else
+			input += "\n\n - [authorize_job] [authorize_name]"
+
 	var/list/players = get_communication_players()
 	SScommunications.make_announcement(user, is_ai, input, syndicate || (obj_flags & EMAGGED), players)
 	deadchat_broadcast(" made a priority announcement from [span_name("[get_area_name(usr, TRUE)]")].", span_name("[user.real_name]"), user, message_type=DEADCHAT_ANNOUNCEMENT)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -274,6 +274,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/requests_console, 30)
 			// NON-MODULE CHANGE
 			if(istext(announceAuth))
 				message += "\n - [announceAuth]"
+
 		minor_announce(message, "[department] Announcement:", html_encode = FALSE)
 		GLOB.news_network.SubmitArticle(message, department, "Station Announcements", null)
 		usr.log_talk(message, LOG_SAY, tag="station announcement from [src]")


### PR DESCRIPTION
This is something that a few other servers do (Paradise off the top of my head) and I think it's neat (which you may have noticed) and would like to see it formalized. 

Captain's announcements and RC Desk announcements will append the job and name of the ID card used to authenticate at the end of the message. Demonstrations below.

![image](https://user-images.githubusercontent.com/51863163/203222455-67f95339-d298-4bff-872a-0fe25a2d7749.png)

![image](https://user-images.githubusercontent.com/51863163/203222470-32d77a34-5214-4aba-a021-0d2eedc3a727.png)

![image](https://user-images.githubusercontent.com/51863163/203222483-5fc04a6d-c7f1-417e-9891-3ca9ec95353b.png)

![image](https://user-images.githubusercontent.com/51863163/203222496-cc03e753-2caa-4178-88e8-52b83ee68647.png)

Emagged consoles display "Unknown". 