### PR TITLE
[MODULAR] Adds a barebones magic system. Only opening so people can peep and give me feedback.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5145,6 +5145,8 @@
 #include "maplestation_modules\story_content\captain_equipment\code\captainclothing.dm"
 #include "maplestation_modules\story_content\casual_clothing\code\casualclothing.dm"
 #include "maplestation_modules\story_content\chaplain_equipment\code\chaplainclothing.dm"
+#include "maplestation_modules\story_content\magic\code\magic.dm"
+#include "maplestation_modules\story_content\magic\code\magic_costs.dm"
 #include "maplestation_modules\story_content\noble_equipment\code\beacon.dm"
 #include "maplestation_modules\story_content\noble_equipment\code\nobleclothing.dm"
 #include "maplestation_modules\story_content\noname_equipment\code\nonameclothing.dm"

--- a/maplestation_modules/code/__DEFINES/_module_defines.dm
+++ b/maplestation_modules/code/__DEFINES/_module_defines.dm
@@ -47,3 +47,6 @@
 
 /// Modular traits
 #define TRAIT_DISEASE_RESISTANT "disease_resistant"
+
+/// Magic
+#define STORY_MAGIC_BASE_CONSUME_SCORE 50

--- a/maplestation_modules/story_content/magic/code/magic.dm
+++ b/maplestation_modules/story_content/magic/code/magic.dm
@@ -1,0 +1,83 @@
+#define BASE_MAGIC_COST 1
+#define NO_CATALYST_COST_MULT 5
+
+/mob/proc/get_base_casting_cost()
+	var/mult = BASE_MAGIC_COST
+	return mult
+
+/mob/living/carbon/get_base_casting_cost()
+	. = ..()
+	var/obj/held_item = src.get_active_held_item()
+	if (!held_item)
+		. *= NO_CATALYST_COST_MULT
+
+/datum/action/cooldown/spell/story_magic
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
+
+/datum/action/cooldown/spell/story_magic/proc/get_possible_costs(mob/living/target)
+	var/list/costs = list()
+	for (var/datum/story_magic_cost/cost as anything in GLOB.story_magic_costs)
+		if (want_to_use_cost(cost) && cost.can_be_applied_to(target)) costs += cost
+
+	return costs
+
+/// Use for blacklisting certain costs.
+/datum/action/cooldown/spell/story_magic/proc/want_to_use_cost(datum/story_magic_cost/cost)
+	return TRUE
+
+/datum/action/cooldown/spell/story_magic/convect
+	name = "Convect"
+	desc = "Manipulate the temperature of matter around you."
+	school = SCHOOL_TRANSMUTATION
+
+/datum/action/cooldown/spell/story_magic/convect/before_cast(atom/cast_on)
+	. = ..()
+	if (!iscarbon(cast_on))
+		return SPELL_CANCEL_CAST
+	return
+
+/datum/action/cooldown/spell/story_magic/convect/cast(atom/cast_on)
+	. = ..()
+	if (!iscarbon(cast_on))
+		return SPELL_CANCEL_CAST
+	var/mob/living/carbon/carbon_cast_on = cast_on
+	var/list/things_to_convect = list()
+
+	for (var/obj/item in carbon_cast_on.get_all_worn_items()) things_to_convect += item
+	for (var/obj/item in carbon_cast_on.held_items) things_to_convect += item
+	if (carbon_cast_on.pulling != null) things_to_convect += carbon_cast_on.pulling
+
+	var/turf/carbon_turf = get_turf(carbon_cast_on)
+	if (carbon_turf != null)
+		things_to_convect += carbon_turf
+
+	things_to_convect += carbon_cast_on
+	if (things_to_convect.len == 0) return SPELL_CANCEL_CAST
+
+	var/mob/living/carbon/carbon_cast_on = cast_on
+
+	var/atom/target = tgui_input_list(carbon_cast_on, "Which one would you like to convect?", "Convect", things_to_convect)
+	if (target == null) return
+
+	var/temperature = tgui_input_number(carbon_cast_on, "How much would you like to convect by?", "Convect", null)
+	if (temperature == null) return
+
+	var/datum/story_magic_cost/cost = tgui_input_list(carbon_cast_on, "What will be transmuted into the thermal energy?", "Convect", get_possible_costs(carbon_cast_on))
+	if (cost == null) return
+
+	if (target == null || temperature == null || cost == null) return
+
+	if (iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.adjust_bodytemperature(temperature, use_insulation = TRUE)
+		carbon_target.reagents.expose_temperature(temperature)
+	else if (is_reagent_container(target))
+		var/obj/item/reagent_containers/container = target
+		container.reagents.expose_temperature(temperature)
+	else if (isturf(target))
+		var/turf/turf_target = target
+		var/datum/gas_mixture/turf_air = turf_target.return_air()
+		if (turf_air != null)
+			turf_target.temperature_expose(turf_air, temperature)
+
+	cost.apply(owner, temperature)

--- a/maplestation_modules/story_content/magic/code/magic_costs.dm
+++ b/maplestation_modules/story_content/magic/code/magic_costs.dm
@@ -1,0 +1,124 @@
+GLOBAL_LIST_INIT(story_magic_costs, typecacheof(/datum/story_magic_cost))
+
+/datum/story_magic_cost
+	var/name = "Base type, do not use"
+	var/description = "Description unset"
+
+/datum/story_magic_cost/proc/can_be_applied_to(mob/living/target, var/score)
+	return TRUE
+
+/// Protects apply_effect from having to check can_be_applied_to by acting as a buffer.
+/datum/story_magic_cost/proc/apply(mob/living/target, var/score)
+	if (can_be_applied_to(target, score)) return FALSE
+	return apply_effect(target, score)
+
+/// Never call directly, call apply instead.
+/datum/story_magic_cost/proc/apply_effect(mob/living/target, var/score)
+	PROTECTED_PROC(TRUE) //should be buffered behind apply
+	return FALSE
+
+/datum/story_magic_cost/stamina
+	name = "Stamina"
+	description = "Transmute the energy in your muscles into magic"
+
+/datum/story_magic_cost/stamina/can_be_applied_to(mob/living/target, var/score)
+	if (!iscarbon(target)) return FALSE
+	return ..()
+
+/datum/story_magic_cost/stamina/apply_effect(mob/living/carbon/target, var/score)
+	target.adjustStaminaLoss(score)
+	to_chat(target, span_warning("You feel your muscles ache as the chemical energy stored within them seemingly vanishes."))
+	. = ..()
+
+/datum/story_magic_cost/nutrition
+	name = "Nutrition"
+	description = "Transmute the raw celluar ATP in your body into magic"
+
+/datum/story_magic_cost/nutrition/can_be_applied_to(mob/living/target, var/score)
+	if (!iscarbon(target)) return FALSE
+	return ..()
+
+/datum/story_magic_cost/nutrition/apply_effect(mob/living/carbon/target, var/score)
+	target.adjust_nutrition(score)
+	to_chat(target, span_warning("You feel more sluggish, your energy to move seemingly vanishing."))
+	. = ..()
+
+/datum/story_magic_cost/blood
+	name = "Blood"
+	description = "Transmute your own plasma into the lifeblood of the universe"
+
+/datum/story_magic_cost/blood/can_be_applied_to(mob/living/target, var/score)
+	if (!iscarbon(target)) return FALSE
+	return ..()
+
+/datum/story_magic_cost/blood/apply_effect(mob/living/carbon/target, var/score)
+	target.blood_volume = max(0, target.blood_volume - score)
+	. = ..()
+
+/// Doesn't have a tangible cost-EXCEPT for informing admins that you used it.
+/datum/story_magic_cost/leyline
+	name = "The intrinsic power of leylines"
+	description = "Gather raw mana from the latent magical leylines underlying spacetime"
+
+/datum/story_magic_cost/leyline/apply_effect(mob/living/target, var/score)
+	to_chat(target, span_warning("You gather magical power from the magical leylines underlying all of spacetime. They thrum like violin strings..."))
+	message_admins("[target] used leylines to fuel magic, with a cost \"Score\" of [score]. [ADMIN_JMP(target)], [ADMIN_VV(target)], [ADMIN_SMITE(target)]")
+	. = ..()
+
+/datum/story_magic_cost/flesh
+	name = "Flesh"
+	description = "Transmute your own flesh into magic"
+
+/datum/story_magic_cost/flesh/apply_effect(mob/living/target, var/score)
+	target.apply_damage(score, BRUTE, sharpness = SHARP_EDGED, forced = TRUE) // b l e e d .
+	. = ..()
+
+/// Basetype for any spell that requires a held item.
+/datum/story_magic_cost/catalyst
+
+/datum/story_magic_cost/catalyst/can_be_applied_to(mob/living/target, score)
+	. = ..()
+	if (!iscarbon(target)) return FALSE
+
+	var/mob/living/carbon/carbon_target = target
+	var/obj/item = carbon_target.get_active_held_item()
+	if (item == null) return FALSE
+
+	return TRUE
+
+/datum/story_magic_cost/catalyst/consume
+	name = "Your held item"
+	description = "Transmute your held item into magic"
+
+/datum/story_magic_cost/catalyst/consume/can_be_applied_to(mob/living/target, score)
+	. = ..()
+	if (. == FALSE) return
+	var/mob/living/carbon/carbon_target = target
+	var/obj/item = carbon_target.get_active_held_item()
+
+	if (item.resistance_flags & INDESTRUCTIBLE)
+		to_chat(target, span_warning("[item] neither shifts nor bends - you cannot seem to transmute it!"))
+		return FALSE
+
+	var/item_score = get_item_score(item)
+	if (item_score < score)
+		to_chat(target, span_warning("[item] remains still. Maybe if you used something with more mass/material value?"))
+		return FALSE
+
+/datum/story_magic_cost/catalyst/consume/proc/get_item_score(/obj/item)
+	var/score = STORY_MAGIC_BASE_CONSUME_SCORE
+	var/list/composition = item.get_material_composition(BREAKDOWN_INCLUDE_ALCHEMY)
+	for (var/datum/material/material_composition in composition)
+		score += (composition[material_composition] * material_composition.value_per_unit)
+	return score /// THIS WILL NOT WORK LMFAO I DONT GET HOW THE PROC WORKS
+
+
+/datum/story_magic_cost/catalyst/consume/apply_effect(mob/living/carbon/target, score)
+	. = ..()
+
+	var/obj/item = target.get_active_held_item()
+	if (item == null) return FALSE
+
+	item.visible_message(span_warning("[item] vanishes!"))
+
+	qdel(item)


### PR DESCRIPTION
big burger

Following the magic lore document, all "story" magic (That is, magic added in this module) will have to follow the law of conservation. No energy can be created from nothing, no energy can be destroyed. As such, whenever you cast a spell, you will have to pick a price to pay. This includes stamina damage, blood, nutrition, or just drwaing from latent magical leylines and giving admins a ticket to mess with you in proportion to the amount of magic drawn.

This doesn't mean by the end of it all spells will be subtyped under story magic-I realized that doesn't really work if you want to make, say, a /pointed/ subtype spell. I'm not quite sure how to handle that, honestly.

Current spells -
Convect: The precursor to most temperature manipulation (As of now, only works with physical proximity, but later, I might make it give you the option to have it be ranged? I dunno). You can alter the temperature of any object you are physically touching, but you must sacrifice something to do so.

In the future, either later into this PR or after this PR (I'm thinking of keeping convect locked to specific chars until we at lesat get to Mu), I will add a sort of "spellbook" characters can pick spells from for their personal characters, along with guidelines as to how they're used.

NOTE THAT THIS ISNT MEANT TO BE BALANCED THIS IS DEPENDANT ON THE PEOPLE THAT USE IT USING THEM WITH AN HONOR SYSTEM
