### PR TITLE
Optimizes the tabletide smite

### DIFF
--- a/maplestation_modules/code/modules/admin/smites/tabletide.dm
+++ b/maplestation_modules/code/modules/admin/smites/tabletide.dm
@@ -4,15 +4,19 @@
 
 /datum/smite/tabletide/effect(client/user, mob/living/target)
 	. = ..()
-	priority_announce("[target] has brought the wrath of the gods upon themselves and is now being tableslammed across the station. Please stand by.")
-	var/list/areas = list()
-	for(var/area/area in world)
-		if(area.z == SSmapping.station_start)
-			areas += area
-	SEND_SOUND(target, sound('maplestation_modules/sound/slamofthenorthstar.ogg',volume=40))
-	for(var/area/area in areas)
-		for(var/obj/structure/table/table in area)
-			if(!istype(table, /obj/structure/table/glass))
-				table.tablepush(target, target)
-				sleep(1)
-	do_teleport(target, get_safe_random_station_turf(list(/area/station/medical/treatment_center, /area/station/commons/lounge))) // Show 'em what happened.
+	priority_announce("[target] has brought the wrath of the gods upon themselves \
+		and is now being tableslammed across the station. Please stand by.")
+
+	SEND_SOUND(target, sound('maplestation_modules/sound/slamofthenorthstar.ogg', volume = 40))
+	for(var/area/station_area as anything in GLOB.areas)
+		if(station_area.z == 0 || !is_station_level(station_area.z))
+			continue
+		for(var/turf/area_turf as anything in station_area.get_contained_turfs())
+			var/obj/structure/table/slam_jam = locate() in area_turf
+			if(!QDELETED(slam_jam) && !istype(slam_jam, /obj/structure/table/glass))
+				slam_jam.tablepush(target, target)
+				stoplag(0.1 SECONDS)
+		CHECK_TICK
+
+	var/turf/deposit = get_safe_random_station_turf(list(/area/station/medical/treatment_center, /area/station/commons/lounge, /area/station/service/bar))
+	do_teleport(target, deposit, forced = TRUE) // Show 'em what happened.


### PR DESCRIPTION
`for(thing in area)` is secretly a loop that does `for(thing in world) if(thing in area) ...`
This smite abused `in area`, which in turn meant it did a lot... a LOT of world iterations. Like 150+. 
Swaps it over to using the area contents system. Now it check ticks. 

Also added the more common bar area to teleport destinations. 

Two bugs I noticed with it that can be fixed later:
- Pacifist are immune to it.
- People with CQC will demolish every table. 