### PR TITLE
[MODULAR] Fixes spellbook customization, adds tooltips to boolean values, makes boolean values look prettier, makes spells not apply to dummies

### DIFF
--- a/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_spell_entry.dm
+++ b/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_spell_entry.dm
@@ -3,10 +3,16 @@
 	var/datum/action/our_action_typepath
 
 /datum/spellbook_item/spell/apply(mob/living/carbon/human/target, list/params)
+	if(isdummy(target)) //if we're just adding spells, why would we want them to be given to the dummy?
+		return
+
 	. = ..()
 
 	var/datum/action/our_spell = new our_action_typepath(target.mind || target)
-	apply_params(arglist(list(our_spell) + params))
+	if (islist(params))
+		apply_params(arglist(list(our_spell) + params))
+	else
+		stack_trace("[src]'s apply had [params] passed down as a non-list! This is against design!")
 	our_spell.Grant(target)
 
 /// Exists primarily for convenience.

--- a/maplestation_modules/code/modules/client/preferences/spellbook/spellbook.dm
+++ b/maplestation_modules/code/modules/client/preferences/spellbook/spellbook.dm
@@ -13,7 +13,7 @@
 
 	var/list/list_value = value
 	for (var/datum/spellbook_item/entry in spellbook_list_to_datums(value))
-		entry.apply(target, list_value[entry])
+		entry.apply(target, list_value[entry.type])
 
 /datum/preference/spellbook/deserialize(input, datum/preferences/preferences)
 	return sanitize_spellbook_list(input, preferences.parent?.mob)

--- a/tgui/packages/tgui/interfaces/_spellbookCustomizationMenu.js
+++ b/tgui/packages/tgui/interfaces/_spellbookCustomizationMenu.js
@@ -34,8 +34,8 @@ export const _spellbookCustomizationMenu = (props, context) => {
                 )}
                 {element.interfacetype === 'boolean' && (
                   <Button.Checkbox
-                    content={element.name}
                     checked={!!element.current_value === true}
+                    tooltip={element.tooltip}
                     onClick={() =>
                       act('change_value', {
                         key: element.key,


### PR DESCRIPTION
<!-- Hi! Thanks for contributing to our code! Please make sure to check the check list below. -->
<!-- Please make sure that modularity is in order to prevent headaches later. For more information, check the README.md in /maplestation_modules/ -->

Self-explanatory, what it does. Turns out that while dances made a mistake in their flare PR, even if they hadnt, null would've been passed anyway.