### PR TITLE
Lesser flare customization

### DIFF
--- a/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_item_lumenomancy.dm
+++ b/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_item_lumenomancy.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_INIT(spellbook_lumenomancy_items, generate_spellbook_items(SPELLBOOK_CATEGORY_LUMENOMANCY))
 
-/datum/spellbook_item/spell/flare
+/datum/spellbook_item/spell/conjure_item/flare
 	name = "Flare"
 	description = "Conjure lumens into a glob to be held or thrown to light an area."
 	lore = "A simple application of lumenomancy, although quite complex enough for those new to magic to have the resulting globule sustain itself for so long. \n\
@@ -11,5 +11,10 @@ GLOBAL_LIST_INIT(spellbook_lumenomancy_items, generate_spellbook_items(SPELLBOOK
 	Those interested in the lumenomancy school/predisposition use this spell to further their understanding of luminosity and their ability to warp its directions."
 
 	category = SPELLBOOK_CATEGORY_LUMENOMANCY
+	has_params = TRUE
 
 	our_action_typepath = /datum/action/cooldown/spell/conjure_item/flare
+// Customization to allow lesser flare
+/datum/spellbook_item/spell/conjure_item/flare/generate_customization_params()
+	. = list()
+	.["lesser"] = new /datum/spellbook_customization_entry/boolean("lesser", "Lesser, weaker, somewhat cheaper version", "A cheap less lasting flare that fizzles out faster than expected, for those just learning magic or unable to grasp the full concept of luminosity.")

--- a/maplestation_modules/code/modules/magic/story_spells/flare.dm
+++ b/maplestation_modules/code/modules/magic/story_spells/flare.dm
@@ -1,6 +1,5 @@
 /datum/component/uses_mana/story_spell/conjure_item/flare
 	var/attunement_amount = 0.5
-	var/flare_cost = 30
 
 /datum/component/uses_mana/story_spell/conjure_item/flare/get_attunement_dispositions()
 	. = ..()
@@ -9,7 +8,7 @@
 /datum/component/uses_mana/story_spell/conjure_item/flare/get_mana_required(...)
 	. = ..()
 	var/datum/action/cooldown/spell/conjure_item/flare/flare_spell = parent
-	return (flare_cost * flare_spell.owner.get_casting_cost_mult())
+	return (flare_spell.flare_cost * flare_spell.owner.get_casting_cost_mult())
 
 /datum/component/uses_mana/story_spell/conjure_item/flare/react_to_successful_use(atom/cast_on)
 	. = ..()
@@ -30,6 +29,17 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 	/// What color the flare created appears to be
 	var/flare_color
+	/// What the mana cost is, affected by Lesser variant.
+	var/flare_cost = 30
+
+//Variant that conjures a weaker version
+/datum/spellbook_item/spell/conjure_item/flare/apply_params(datum/action/cooldown/spell/conjure_item/flare/our_spell, lesser)
+	if (lesser)
+		our_spell.item_type = /obj/item/flashlight/glowstick/magic/lesser
+		our_spell.flare_cost = 10
+		our_spell.name = "Lesser Flare"
+		our_spell.desc = "Conjure lumens into a glob to be held or thrown to light an area. Right-click the spell icon to set the light color. This weaker version burns up quicker and may fizzle out after casting."
+	return
 
 /datum/action/cooldown/spell/conjure_item/flare/make_item()
 	var/obj/item/created = ..()
@@ -53,6 +63,16 @@
 	actions_types = null
 	//If it should decay and delete itself after it uses all its fuel
 	var/auto_destroy = TRUE
+
+
+/obj/item/flashlight/glowstick/magic/lesser
+	name = "lesser self sustaining flare"
+	desc = "Lumens that stays alight similar to a candle. This one's small and appears unstable to sustain itself for long."
+	light_range = 3
+
+/obj/item/flashlight/glowstick/magic/lesser/Initialize(mapload)
+	. = ..()
+	fuel = rand(2, 100)
 
 //Will have the flare start on and slowly burn through its fuel, when it runs out it will fizzle, fade out and delete itself. Similar to magic lockers from the staff.
 /obj/item/flashlight/glowstick/magic/Initialize(mapload)


### PR DESCRIPTION
Allows flare to be customized in the spell book to a lesser cheaper version, lasts less than a minute and may fizzle out right after casting it.

![image](https://user-images.githubusercontent.com/16868239/224617526-ea220ab9-15df-435e-8af0-01551803f6ea.png)
