### PR TITLE
Adds white cane to loadout items

### DIFF
--- a/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -18,6 +18,10 @@ GLOBAL_LIST_INIT(loadout_inhand_items, generate_loadout_items(/datum/loadout_ite
 	name = "Cane"
 	item_path = /obj/item/cane
 
+/datum/loadout_item/inhand/cane_white
+	name = "White Cane"
+	item_path = /obj/item/cane/white
+
 /datum/loadout_item/inhand/briefcase
 	name = "Briefcase"
 	item_path = /obj/item/storage/briefcase


### PR DESCRIPTION
Adds the White Cane to loadout item inhands. 

The White Cane being the cane used by blind personnel to detect their surroundings better. 