### PR TITLE
Fixes the bomber jacket option in the loadout manager

### DIFF
--- a/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_suits.dm
+++ b/maplestation_modules/code/modules/loadouts/loadout_items/loadout_datum_suits.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 
 /datum/loadout_item/suit/bomber_jacket
 	name = "Bomber Jacket"
-	item_path = /obj/item/clothing/suit/jacket
+	item_path = /obj/item/clothing/suit/jacket/bomber
 
 /datum/loadout_item/suit/military_jacket
 	name = "Military Jacket"


### PR DESCRIPTION
The item path for bomber jacket in the loadout manager was set to the invisible jacket so this should fix it I think.