### PR TITLE
Fixes Robotic Wings

### DIFF
--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -177,7 +177,7 @@
 /obj/item/organ/external/wings/functional/robotic
 	name = "robotic wings"
 	desc = "Using microscopic hover-engines, or \"microwings,\" as they're known in the trade, these tiny devices are able to lift a few grams at a time. Gathering enough of them, and you can lift impressively large things."
-	sprite_accessory_override = /datum/sprite_accessory/wings/megamoth
+	sprite_accessory_override = /datum/sprite_accessory/wings/robotic
 
 ///skeletal wings, which relate to skeletal races.
 /obj/item/organ/external/wings/functional/skeleton


### PR DESCRIPTION
##AAAAAAAAA
basically I fucked up during the cherry pick(s) and did the sprite override of robotic wings as the megamoth moth wings. this mistake was found during pre-round 159 on 4/23/2023
one line fix hopefully this works

