### PR TITLE
Talk through toys

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -4941,6 +4941,7 @@
 #include "maplestation_modules\code\game\objects\items\holy_weapons.dm"
 #include "maplestation_modules\code\game\objects\items\locker_spawners.dm"
 #include "maplestation_modules\code\game\objects\items\plushes.dm"
+#include "maplestation_modules\code\game\objects\items\toys.dm"
 #include "maplestation_modules\code\game\objects\items\weaponry.dm"
 #include "maplestation_modules\code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "maplestation_modules\code\game\objects\items\devices\radio\encryptionkey.dm"

--- a/maplestation_modules/code/game/objects/items/toys.dm
+++ b/maplestation_modules/code/game/objects/items/toys.dm
@@ -1,0 +1,12 @@
+// Let users talk through all toys instead of only ventriloquist dummy and decapitated heads.
+
+/obj/item/toy/talk_into(atom/movable/A, message, channel, list/spans, datum/language/language, list/message_mods)
+	var/mob/M = A
+	if (istype(M))
+		M.log_talk(message, LOG_SAY, tag="toy")
+
+	say(message, language, sanitize = FALSE)
+	return NOPASS
+
+/obj/item/toy/GetVoice()
+	return name


### PR DESCRIPTION
Allows players to talk through all toys similar to ventriloquist dummies. Such as typing ":r I am leezord" when in the right hand to talk through them.

![image](https://github.com/MrMelbert/MapleStationCode/assets/16868239/af1d69a8-dd1c-43f1-89f2-96597af8e2f7)