### PR TITLE
Coroning Coroners

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12305,7 +12305,7 @@
 "bmx" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bmz" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -32025,10 +32025,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
-"ffr" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ffO" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -47661,12 +47657,6 @@
 "kMW" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
-"kNc" = (
-/obj/structure/transit_tube,
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "kNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -65853,6 +65843,7 @@
 /obj/effect/landmark/blobstart,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rkz" = (
@@ -77076,6 +77067,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/stool,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "vjy" = (
@@ -77234,6 +77226,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "vmU" = (
@@ -105424,7 +105417,7 @@ cwy
 cwy
 vpc
 nmC
-cwy
+cwq
 amh
 soP
 cwy
@@ -105668,20 +105661,20 @@ acm
 acm
 acm
 acm
-ffr
+acK
 kBs
 cwy
 oEo
 cwy
 cwy
 cwy
-cwy
+cwq
 kbO
 nAs
 cwy
 vmL
 bof
-cwy
+cwq
 gsT
 cwy
 cwq
@@ -106193,7 +106186,7 @@ nHd
 cmm
 cwy
 cwy
-cwy
+cwq
 quv
 cwy
 xCu
@@ -106452,7 +106445,7 @@ cwy
 cLe
 cwy
 czu
-cwy
+cwq
 krq
 usm
 aNu
@@ -107732,8 +107725,8 @@ fRa
 vVS
 gYl
 cIg
-kNc
-kNc
+gYl
+gYl
 gWM
 byx
 sLw
@@ -107987,7 +107980,7 @@ acm
 acm
 cmU
 cmU
-cnR
+cmU
 aeU
 aeU
 aeU

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9539,8 +9539,8 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/paper/guides/jobs/medical/morgue,
+/obj/item/clipboard,
+/obj/item/paper,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -28365,6 +28365,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/item/clipboard,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "dPF" = (
@@ -78250,6 +78251,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/paper/guides/jobs/medical/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vEj" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6978,6 +6978,7 @@
 /area/station/hallway/primary/central/fore)
 "aKV" = (
 /obj/structure/flora/bush/jungle/c/style_random,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
 "aKY" = (
@@ -7611,6 +7612,7 @@
 /area/station/medical/psychology)
 "aOb" = (
 /obj/structure/flora/bush/large/style_random,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
 "aOd" = (
@@ -25799,6 +25801,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood/parquet,
 /area/station/commons/fitness/recreation/entertainment)
 "cWX" = (
@@ -31153,6 +31158,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/commons/fitness/recreation/entertainment)
 "eRk" = (
@@ -33178,6 +33185,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/poster/official/help_others/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "fzm" = (
@@ -39738,6 +39746,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/station/commons/fitness/recreation/entertainment)
 "hUK" = (
@@ -57382,6 +57393,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "oiw" = (
@@ -80420,13 +80433,6 @@
 /obj/structure/cable,
 /turf/closed/wall/rust,
 /area/station/maintenance/department/electrical)
-"wic" = (
-/obj/structure/sign/warning/secure_area/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "wig" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -83617,7 +83623,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
 "xoK" = (
@@ -98250,7 +98255,7 @@ bDi
 bFD
 cRb
 bLq
-wic
+tSE
 pMK
 sLU
 bPG

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -194,6 +194,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "aaQ" = (
@@ -1053,7 +1054,7 @@
 "afm" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "afq" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -1159,11 +1160,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "afz" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "afA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -1668,7 +1669,7 @@
 /obj/item/clothing/shoes/sneakers/brown,
 /obj/effect/spawner/random/maintenance,
 /obj/item/clothing/under/rank/cargo/tech,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "ahD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1838,6 +1839,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"aii" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "aik" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -2124,7 +2129,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/electrical)
 "ajC" = (
 /turf/closed/wall/r_wall/rust,
@@ -2146,7 +2151,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/electrical)
 "ajG" = (
 /obj/structure/table,
@@ -2226,7 +2231,7 @@
 "akh" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "akl" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port/aft)
@@ -2249,13 +2254,8 @@
 /area/station/medical/psychology)
 "aky" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/shard,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "akA" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
@@ -2641,7 +2641,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "alU" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -2700,6 +2700,9 @@
 /obj/structure/cable,
 /obj/machinery/computer/prisoner/management,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "amf" = (
@@ -2891,7 +2894,11 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "anb" = (
@@ -2986,17 +2993,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "anD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/delivery,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "anF" = (
 /obj/machinery/flasher/portable,
@@ -3184,7 +3183,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "aoJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3349,7 +3348,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "apF" = (
 /obj/structure/chair{
@@ -3444,6 +3443,11 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/aft)
+"aqg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/vacuum/external/directional/east,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "aqh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3499,7 +3503,7 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "aqv" = (
 /obj/structure/transit_tube/junction,
@@ -3548,6 +3552,17 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"aqI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonblast";
+	name = "Prison Blast Door"
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "aqO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3966,14 +3981,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"asC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "asD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cook,
@@ -4025,6 +4032,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"asX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "asZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai)
@@ -4082,7 +4093,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "atl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4175,17 +4186,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
-"atG" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "atH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -4279,7 +4281,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
 "atS" = (
@@ -4599,7 +4600,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "avq" = (
 /obj/structure/sign/warning/no_smoking,
@@ -4688,7 +4689,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "avU" = (
 /obj/structure/table/wood,
@@ -5207,7 +5208,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "aze" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5255,9 +5256,6 @@
 "azi" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/effect/landmark/blobstart,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -5387,7 +5385,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "azZ" = (
 /obj/machinery/door/firedoor,
@@ -5518,10 +5516,10 @@
 "aAz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "aAB" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -5533,7 +5531,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "aAC" = (
 /turf/open/floor/iron/white,
@@ -5631,8 +5629,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/stairs/left{
-	dir = 4
+/turf/open/floor/iron/stairs/right{
+	dir = 8
 	},
 /area/station/hallway/primary/fore)
 "aBh" = (
@@ -5907,7 +5905,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/structure/sign/poster/official/wtf_is_co2/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -6215,6 +6212,7 @@
 "aEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aFa" = (
@@ -6228,7 +6226,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "aFe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6378,6 +6376,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"aGE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "aGI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -6686,6 +6691,15 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/hydroponics)
+"aJz" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "aJA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -6899,6 +6913,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"aKL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "aKN" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -7190,7 +7213,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "aLJ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -7446,7 +7469,7 @@
 "aNk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "aNn" = (
 /turf/closed/wall,
@@ -8002,6 +8025,14 @@
 /obj/structure/sign/poster/official/no_erp/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"aPZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/fore)
 "aQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8248,6 +8279,7 @@
 /area/station/hallway/primary/central/fore)
 "aRn" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "aRo" = (
@@ -8976,6 +9008,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "aTR" = (
@@ -9095,6 +9129,8 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "aUk" = (
@@ -9150,10 +9186,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"aUG" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/greater)
 "aUJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -9298,7 +9330,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "aVz" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -11040,7 +11072,7 @@
 /obj/item/seeds/tower{
 	pixel_y = -6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/bridge)
 "bdh" = (
 /turf/closed/wall/r_wall,
@@ -11064,11 +11096,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bdo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "bdp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11393,10 +11429,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "beO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "beR" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/tile/neutral,
@@ -11438,17 +11477,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"bfb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bfd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -11656,12 +11684,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "bgi" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/security)
 "bgj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12111,9 +12138,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plastic,
 /area/station/hallway/secondary/service)
-"bko" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/ore_box,
+"bkt" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bkx" = (
@@ -12157,6 +12185,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"bld" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "blf" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
@@ -12294,14 +12328,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"bmt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bmx" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/sand/plating,
@@ -12312,9 +12338,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
+/obj/machinery/computer/warrant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bmE" = (
@@ -12348,13 +12372,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
-"bmQ" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/execution/transfer)
 "bmT" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/north{
@@ -12391,15 +12410,17 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "bmU" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/clothing/suit/utility/fire/firefighter{
-	pixel_y = 5
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "bnb" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -12518,7 +12539,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "bon" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12540,10 +12561,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "bop" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/storage/medkit/o2,
-/obj/item/tank/internals/emergency_oxygen,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -12551,8 +12570,8 @@
 /area/station/maintenance/port/greater)
 "bos" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "boy" = (
@@ -12578,19 +12597,17 @@
 "boF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "boM" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 5
-	},
-/obj/item/flashlight,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "boN" = (
@@ -12655,7 +12672,9 @@
 /area/station/hallway/primary/starboard)
 "bpc" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/firecloset,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bpd" = (
@@ -12733,6 +12752,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/effect/spawner/random/medical/memeorgans,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bpq" = (
@@ -12776,6 +12797,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bpF" = (
@@ -12851,13 +12873,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bpP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bpS" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/decal/cleanable/dirt,
@@ -12972,8 +12992,9 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "brP" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass,
@@ -13012,17 +13033,6 @@
 /obj/structure/sign/departments/custodian,
 /turf/closed/wall,
 /area/station/maintenance/fore)
-"bsq" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/meter/layer4,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "bsw" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow,
@@ -13104,37 +13114,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"bth" = (
-/obj/structure/table,
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/clothing/shoes/sneakers/orange{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Prison Visitation";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/execution/transfer)
 "btC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -13465,10 +13444,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
-"bxp" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall,
-/area/station/maintenance/port/greater)
 "bxq" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -13482,6 +13457,13 @@
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"bxC" = (
+/obj/structure/rack,
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/wirecutters,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "bxD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13513,7 +13495,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "bxN" = (
 /obj/structure/table,
@@ -13862,18 +13844,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/server)
-"bzE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "bankshutter";
-	name = "Bank Shutter"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bzH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -13942,27 +13912,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bzX" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stock_parts/capacitor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"bzY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bAa" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -14320,12 +14273,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
-"bCe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "bCg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14372,8 +14319,8 @@
 "bCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "bCw" = (
 /obj/item/clothing/head/helmet/toggleable/justice/escape{
 	name = "justice helmet"
@@ -14497,8 +14444,8 @@
 "bDn" = (
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "bDo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14570,11 +14517,11 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
 "bEk" = (
-/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bEq" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall/rust,
@@ -14594,6 +14541,11 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"bEx" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "bEA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14685,13 +14637,13 @@
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "bEL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -14787,7 +14739,7 @@
 /obj/item/bodybag,
 /obj/item/shovel,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "bFh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14850,10 +14802,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
-"bFF" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
 /area/station/maintenance/port/greater)
 "bFG" = (
 /obj/structure/cable,
@@ -14960,19 +14908,9 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/aft)
 "bGa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-16"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
+/obj/docking_port/stationary/mining_home/common/kilo,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "bGc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15176,31 +15114,6 @@
 	name = "Chemistry Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"bGY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
-"bHb" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/folder/red,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "bHf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15501,14 +15414,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"bIR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "bIS" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -15539,7 +15444,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bJv" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -15555,10 +15460,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/tcommsat/computer)
-"bJz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/execution/transfer)
 "bJE" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -15606,11 +15507,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "bJX" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bJZ" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/frame/machine,
@@ -15641,7 +15544,16 @@
 "bKl" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
+"bKy" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/hallway/secondary/dock)
 "bKK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15653,7 +15565,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bKO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/rust,
@@ -15757,6 +15669,10 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Prison Hallway Port";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "bLS" = (
@@ -15811,11 +15727,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/chapel/office)
 "bMm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/pods/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "bMn" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -15934,9 +15850,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bNq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -15973,7 +15889,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bNH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/south{
@@ -15997,7 +15913,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bOb" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -16026,8 +15942,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
+"bOx" = (
+/obj/structure/lattice,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bOB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -16287,6 +16210,11 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"bPG" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "bPI" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16346,14 +16274,14 @@
 "bQb" = (
 /turf/closed/wall/rust,
 /area/station/hallway/primary/fore)
-"bQc" = (
-/mob/living/basic/syndicate/russian/ranged/lootless,
-/turf/open/space/basic,
-/area/space)
 "bQg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bQq" = (
@@ -16509,6 +16437,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/port)
 "bRd" = (
@@ -16615,7 +16544,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bRy" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -16639,7 +16568,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bRD" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
@@ -16647,6 +16576,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "bRE" = (
@@ -17099,14 +17029,15 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bUv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bUw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17245,7 +17176,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -17273,8 +17204,9 @@
 	},
 /obj/item/clothing/mask/gas,
 /obj/structure/sign/poster/contraband/random/directional/west,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bVs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17289,7 +17221,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bVu" = (
 /obj/structure/sign/warning/secure_area{
 	name = "WARNING: Station Limits"
@@ -17299,20 +17231,6 @@
 "bVv" = (
 /turf/closed/mineral/random/high_chance,
 /area/space/nearstation)
-"bVx" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 5
-	},
-/obj/item/crowbar/red,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "bVy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -17336,11 +17254,16 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bVB" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/machinery/door/airlock/highsecurity{
+	name = "Prison Visitation"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/poddoor{
+	id = "visitation_cool_door";
+	name = "Prison Visitation"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "bVE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17679,7 +17602,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "bWM" = (
 /obj/structure/sign/departments/cargo,
@@ -17711,7 +17634,7 @@
 	icon_state = "detective"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bWT" = (
 /turf/closed/wall/rust,
 /area/station/hallway/secondary/entry)
@@ -18130,7 +18053,7 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "bYx" = (
 /obj/effect/turf_decal/tile/blue{
@@ -18201,7 +18124,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "bZm" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -18449,23 +18372,15 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "bZX" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/item/clothing/under/rank/security/officer,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "bZY" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "cac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19493,7 +19408,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ced" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -19560,6 +19475,9 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
@@ -19828,8 +19746,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 7
+	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = -3
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "cfM" = (
@@ -20056,6 +19979,9 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cgX" = (
@@ -20127,7 +20053,6 @@
 /area/station/maintenance/fore)
 "chk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -20139,6 +20064,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "chn" = (
@@ -20496,6 +20422,17 @@
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"cjd" = (
+/obj/structure/chair/stool/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "cjh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20563,6 +20500,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "ckd" = (
@@ -20697,7 +20635,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "ckI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20737,22 +20675,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"ckR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
 "ckS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20801,7 +20723,7 @@
 "clh" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "clj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20974,7 +20896,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "cmg" = (
 /obj/structure/disposalpipe/segment{
@@ -21125,7 +21047,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "cmS" = (
 /obj/machinery/camera/directional/south{
@@ -21265,7 +21187,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "cnA" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -21283,7 +21205,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "cnF" = (
 /obj/effect/turf_decal/tile/red,
@@ -21307,9 +21229,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cnJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Escape Pod Access"
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "cnK" = (
@@ -21339,7 +21263,7 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/maintenance/department/security)
 "cnN" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/port/aft)
@@ -21349,15 +21273,10 @@
 "cnP" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
-"cnQ" = (
-/obj/structure/flora/rock/pile/style_random,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "cnR" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/maintenance/department/security)
 "cnS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21399,7 +21318,7 @@
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/maintenance/department/security)
 "cok" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -21439,17 +21358,21 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "cou" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/port/lesser)
-"cov" = (
-/obj/structure/disposaloutlet{
+/obj/machinery/newscaster/directional/east,
+/obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
+"cov" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/east{
+	pixel_y = -32
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "coy" = (
 /obj/structure/flora/rock/style_random,
@@ -21458,19 +21381,11 @@
 "coB" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/solars/port/aft)
-"coD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "coE" = (
 /obj/structure/flora/bush/pale/style_random,
-/obj/structure/sign/warning/electric_shock/directional/south,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/maintenance/department/security)
 "coF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21497,6 +21412,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "coO" = (
@@ -21674,17 +21590,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cpT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/structure/steam_vent,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "cpU" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -21743,42 +21657,29 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cqd" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "cql" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
+"cqs" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/folder/red,
+/obj/structure/spider/stickyweb,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
-"cqq" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
-"cqr" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
-"cqs" = (
-/turf/closed/wall/mineral/plastitanium,
 /area/station/maintenance/port/greater)
 "cqt" = (
-/obj/structure/sign/warning,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "cqu" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -21839,32 +21740,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
-"cqC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/stack/package_wrap,
-/obj/item/storage/box,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
-"cqD" = (
-/obj/structure/girder,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
-"cqI" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/lesser)
 "cqL" = (
-/obj/structure/girder,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "cqN" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Shuttle Airlock"
@@ -21873,10 +21755,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
-"cqT" = (
-/obj/structure/sign/warning/pods,
-/turf/closed/wall/rust,
+/area/station/hallway/secondary/dock)
+"cqS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "cqU" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -21949,10 +21835,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "crp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "crq" = (
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/wall/rust,
@@ -21983,17 +21872,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
-"crx" = (
-/obj/machinery/door/airlock/external{
-	name = "Medical Escape Pod";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "cry" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -22052,9 +21930,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "crV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "crW" = (
@@ -22124,12 +22007,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "csi" = (
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/tank_holder/extinguisher,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "csk" = (
@@ -22178,13 +22060,7 @@
 "csN" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
-"csS" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "csX" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/security{
@@ -22213,13 +22089,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
-"ctb" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
 "ctf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/showroomfloor,
@@ -22233,17 +22102,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
-"ctj" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet{
-	name = "suit closet"
-	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "ctn" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22387,35 +22248,19 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
-"cul" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/maintenance/port/lesser)
 "cum" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/structure/closet,
-/obj/item/stack/rods/ten,
-/obj/item/stock_parts/matter_bin,
+/obj/structure/rack,
+/obj/item/stack/package_wrap,
+/obj/item/storage/box,
+/obj/item/hand_labeler,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"cuo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "cup" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -22445,70 +22290,40 @@
 /area/station/hallway/secondary/entry)
 "cuw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
+"cuy" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
-"cuy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/poster/random_official{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/poster/random_official,
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/clothing/head/costume/festive{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/security)
 "cuE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/rack,
+/obj/item/clothing/suit/utility/fire/firefighter{
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/wallframe/airalarm,
-/turf/open/floor/iron/showroomfloor,
-/area/station/maintenance/port/lesser)
+/obj/item/clothing/mask/breath,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "cuF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/maintenance/port/lesser)
+/obj/item/crowbar/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "cuK" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
 "cuL" = (
@@ -22575,14 +22390,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"cvo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "cvp" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -22593,11 +22400,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
 "cvq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/loading_area,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "cvv" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
@@ -22648,6 +22455,9 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
+"cvH" = (
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/security)
 "cvX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -22786,7 +22596,7 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cwP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
@@ -23017,13 +22827,13 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/under/rank/engineering/engineer,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "cxP" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -23039,7 +22849,7 @@
 "cxS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "cxT" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -23125,7 +22935,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "greylair";
-	name = "Lair Privacy Shutter"
+	name = "Lair Privacy Shutter";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -23195,7 +23006,7 @@
 "cyy" = (
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cyz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
@@ -23270,7 +23081,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cyN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -23548,7 +23359,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal)
 "czI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23606,7 +23417,7 @@
 /obj/structure/closet/wardrobe/green,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "czR" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -23615,10 +23426,6 @@
 	},
 /obj/item/pen,
 /obj/item/storage/box/prisoner,
-/obj/machinery/camera/directional/south{
-	c_tag = "Prison Hallway Port";
-	network = list("ss13","prison")
-	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
@@ -23635,7 +23442,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23735,15 +23542,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "cBh" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/hallway/secondary/dock)
 "cBk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -23757,7 +23563,7 @@
 /obj/structure/grille,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cBn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/security/telescreen/prison{
@@ -23790,23 +23596,15 @@
 "cBv" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cBw" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cBx" = (
 /obj/structure/flora/bush/pale/style_random,
 /turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
-"cBy" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/pale/style_random,
-/turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cBC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -23828,10 +23626,7 @@
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
-"cBI" = (
-/turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cBK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -23848,11 +23643,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"cBN" = (
-/obj/structure/flora/bush/pale/style_random,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "cCi" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Shuttle Airlock"
@@ -23926,6 +23716,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "cCP" = (
@@ -24066,7 +23857,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/fore)
 "cDP" = (
 /obj/machinery/light/small/directional/east,
@@ -24349,7 +24140,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "cFk" = (
 /obj/structure/bookcase/random/fiction,
@@ -24415,15 +24206,17 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "cFR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/book/manual/wiki/engineering_hacking,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cFT" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -24561,14 +24354,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
-"cGH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "cGI" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Satellite External Starboard";
@@ -24593,10 +24378,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "cGV" = (
@@ -24913,7 +24698,7 @@
 "cJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "cJD" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -24974,7 +24759,7 @@
 /area/station/medical/medbay/central)
 "cJK" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "cJO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25131,7 +24916,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "cLd" = (
 /obj/machinery/door/airlock/external{
@@ -25317,7 +25102,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/electrical)
 "cMw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25415,7 +25200,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "cNH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25477,11 +25262,16 @@
 /turf/closed/wall,
 /area/station/maintenance/starboard)
 "cOd" = (
-/obj/docking_port/stationary/escape_pod{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "bankshutter";
+	name = "Bank Shutter"
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "cOg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25489,7 +25279,11 @@
 	name = "Cabin 3 Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
+"cOn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/commons/fitness/recreation/entertainment)
 "cOp" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
@@ -25605,7 +25399,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "cPH" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/cobweb,
@@ -25648,8 +25442,16 @@
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
 "cRb" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "cRp" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -25773,6 +25575,9 @@
 /area/station/security/prison/mess)
 "cTl" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "cTw" = (
@@ -25986,6 +25791,16 @@
 "cWK" = (
 /turf/closed/wall,
 /area/station/commons/storage/primary)
+"cWQ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "cWX" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -26123,13 +25938,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"dac" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/medical/memeorgans,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "daF" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank,
@@ -26256,6 +26064,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dcK" = (
@@ -26448,6 +26259,18 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/bar)
+"dfR" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/red/directional/south,
+/obj/machinery/meter/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/sign/poster/contraband/atmosia_independence/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "dgk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -26473,6 +26296,7 @@
 	name = "bar sorting disposal pipe"
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
+/obj/effect/spawner/random/entertainment/gambling,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "dgX" = (
@@ -26736,6 +26560,8 @@
 	name = "Morgue Requests Console";
 	department = "Medical"
 	},
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "djz" = (
@@ -26891,28 +26717,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"dmB" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
 "dmR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/station/hallway/primary/fore)
 "dnf" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "dns" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -26991,10 +26804,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"dop" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "dor" = (
 /obj/machinery/exodrone_launcher,
 /obj/effect/turf_decal/trimline/yellow,
@@ -27475,6 +27284,7 @@
 /area/station/service/theater)
 "dyu" = (
 /obj/structure/flora/bush/jungle/b,
+/obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
 "dyx" = (
@@ -27806,12 +27616,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/table,
 /obj/item/folder{
 	pixel_x = -4
 	},
 /obj/item/pai_card,
-/obj/machinery/light/directional/north,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -27913,6 +27723,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"dHb" = (
+/obj/structure/flora/rock/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/greater)
 "dHe" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -27950,7 +27764,7 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "dHI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28061,10 +27875,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+/obj/machinery/atmospherics/components/binary/pump/off/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "dJU" = (
 /obj/machinery/door/firedoor,
@@ -28189,6 +28004,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
+"dMa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/aft)
 "dMg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/barricade,
@@ -28221,7 +28046,16 @@
 	name = "Unit 2 Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
+"dMQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "dNg" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral{
@@ -28274,8 +28108,9 @@
 /area/station/commons/locker)
 "dNT" = (
 /obj/structure/closet/emcloset,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "dOh" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/radiation,
@@ -28333,22 +28168,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"dOZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "dPy" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -28418,6 +28237,11 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
+"dQn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
 "dQu" = (
 /obj/structure/table,
 /obj/machinery/requests_console/directional/east{
@@ -28496,6 +28320,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"dRq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "dRs" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/pipedispenser/disposal,
@@ -28522,6 +28356,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"dSQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "dTq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -28529,8 +28368,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dTv" = (
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "dTz" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -28810,7 +28651,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "dXq" = (
 /obj/structure/table/wood,
@@ -28843,6 +28684,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/storage/art)
+"dXV" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "dXW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29040,8 +28886,8 @@
 "ecF" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/greater)
 "ecO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29085,6 +28931,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/medical)
+"edM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/structure/closet{
+	name = "medical locker"
+	},
+/obj/item/storage/medkit/o2,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "eej" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -29164,8 +29022,14 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/dark,
+/obj/machinery/airalarm/directional/south,
+/obj/item/wallframe/airalarm,
+/obj/item/wrench,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/port/greater)
 "efC" = (
 /turf/closed/wall/r_wall,
@@ -29404,6 +29268,22 @@
 /mob/living/basic/syndicate/russian,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
+"ejy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/entertainment/gambling,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/greater)
 "ekn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
@@ -29432,6 +29312,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"ekt" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "kilo_cool_mining"
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "ekw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -29783,7 +29672,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "eoL" = (
 /obj/effect/turf_decal/bot,
@@ -29822,25 +29711,26 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"epS" = (
+/turf/closed/wall,
+/area/station/commons/fitness/recreation/entertainment)
 "eqk" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
-"eqm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "eqH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
+"eqY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "erd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -30063,7 +29953,7 @@
 "euE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/bridge)
 "euG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30105,7 +29995,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "evK" = (
 /obj/machinery/door/airlock/external{
@@ -30120,6 +30010,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "evL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "evT" = (
@@ -30167,15 +30061,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"ewJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "exk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/hydroponics/constructable,
@@ -30248,7 +30133,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "eyj" = (
 /obj/structure/cable,
@@ -30296,6 +30181,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"eyO" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "eyP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/fancy/blue,
@@ -30323,14 +30219,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"ezv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
+"ezt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ezM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -30355,7 +30248,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "eAv" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -30416,7 +30309,6 @@
 "eBf" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
@@ -30549,6 +30441,7 @@
 "eEc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/security/prison)
 "eEP" = (
@@ -30769,6 +30662,13 @@
 /mob/living/basic/syndicate/russian,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"eJt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "eJz" = (
 /obj/machinery/computer/station_alert{
 	dir = 8
@@ -30784,10 +30684,10 @@
 "eJC" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "eJD" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -30800,11 +30700,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
-"eJQ" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/execution/transfer)
 "eJV" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/xeno_mining/directional/west,
@@ -30959,8 +30854,28 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"eMw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/greater)
 "eMx" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/railing{
@@ -30992,22 +30907,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "eNm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/newscaster/directional/south,
-/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "eNx" = (
@@ -31101,6 +31013,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/security/prison/shower)
+"eOM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "eOO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -31166,7 +31089,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "eQf" = (
@@ -31226,9 +31148,13 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "eRj" = (
-/obj/docking_port/stationary/mining_home/common/kilo,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "eRk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/conveyor{
@@ -31357,7 +31283,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "eSG" = (
 /obj/machinery/computer/mecha{
@@ -31439,7 +31365,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "eUp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31563,6 +31489,16 @@
 	},
 /turf/closed/wall,
 /area/station/engineering/atmos)
+"eWk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/structure/noticeboard/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "eWs" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/power/terminal{
@@ -31674,22 +31610,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
-"eXA" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24;
-	req_access = list("brig")
-	},
-/obj/machinery/holopad,
-/obj/machinery/button/door/directional/north{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 8;
-	req_access = list("brig")
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/security/execution/transfer)
 "eXK" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -31802,6 +31722,13 @@
 /obj/structure/sign/poster/contraband/red_rum/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"eZx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "eZy" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -31836,11 +31763,6 @@
 "eZM" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/service/chapel/storage)
-"eZR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "eZS" = (
 /obj/machinery/door/window{
 	atom_integrity = 300;
@@ -31861,15 +31783,22 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
-"fal" = (
-/obj/effect/decal/cleanable/dirt,
+"fag" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
+"fal" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "faV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -31958,9 +31887,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/closet/boxinggloves,
 /obj/machinery/status_display/evac/directional/north,
-/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "fen" = (
@@ -32123,7 +32050,15 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonblast";
+	name = "Prison Blast Door"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "fhq" = (
 /obj/machinery/camera/directional/north{
@@ -32143,16 +32078,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/fore)
-"fhu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/closet{
-	name = "medical locker"
-	},
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "fhW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -32210,7 +32135,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "fjg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -32231,6 +32156,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"fjl" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "fjN" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -32491,6 +32422,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"fnQ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Recreation Area"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "fod" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -32644,7 +32585,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
 	},
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -32672,12 +32613,45 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"fqx" = (
+/obj/structure/table,
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/clothing/under/rank/prisoner{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Visitation";
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/noticeboard/directional/north,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "fqD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "fqF" = (
 /obj/structure/table,
@@ -32909,6 +32883,10 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fuy" = (
@@ -32922,6 +32900,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "fuC" = (
@@ -33073,6 +33052,9 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
+"fwl" = (
+/turf/closed/mineral/random/labormineral,
+/area/station/maintenance/department/security)
 "fwx" = (
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
@@ -33084,10 +33066,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"fxh" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/r_wall,
-/area/station/security/execution/transfer)
 "fxq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33115,7 +33093,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/computer/shuttle/mining/common,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -33214,7 +33191,7 @@
 	name = "Cell Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "fzA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33280,6 +33257,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"fBx" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "fBA" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/delivery,
@@ -33574,7 +33562,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "fFo" = (
 /obj/structure/plasticflaps/opaque,
@@ -33603,7 +33591,7 @@
 "fFD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal/incinerator)
 "fFH" = (
 /obj/structure/table/optable{
@@ -33659,6 +33647,12 @@
 "fGM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "fGN" = (
@@ -33784,7 +33778,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "fJz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -33870,7 +33864,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "fKu" = (
 /obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/delivery,
@@ -34135,7 +34129,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "fQZ" = (
 /obj/structure/plasticflaps,
@@ -34232,6 +34226,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
+"fSo" = (
+/obj/machinery/computer/shuttle/mining/common,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "fSq" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "permaouter";
@@ -34352,6 +34358,14 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
+"fUM" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security)
 "fVf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -34622,6 +34636,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
+"gdm" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/port/greater)
 "gdo" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -34692,6 +34719,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/storage/wallet,
 /obj/item/razor,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -34929,6 +34957,11 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"giG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "gjG" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -34956,6 +34989,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/nuke_storage)
+"gku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "gkx" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/structure/lattice/catwalk,
@@ -35132,7 +35173,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "gno" = (
 /obj/effect/turf_decal/tile/blue,
@@ -35170,7 +35211,7 @@
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "gnH" = (
 /obj/structure/sign/poster/official/wtf_is_co2,
 /turf/closed/wall,
@@ -35213,6 +35254,11 @@
 	dir = 8
 	},
 /area/station/service/chapel)
+"goH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "goJ" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -35393,7 +35439,7 @@
 	},
 /obj/structure/flora/bush/jungle/c/style_2,
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
 "gtk" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -35457,7 +35503,7 @@
 "gum" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "guq" = (
 /obj/effect/turf_decal/tile/blue,
@@ -35492,10 +35538,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
-"guv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard)
 "guM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -35532,6 +35574,9 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/hop)
+"gvc" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/space/nearstation)
 "gvk" = (
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
@@ -35567,7 +35612,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gvX" = (
@@ -35591,7 +35636,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "gwk" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -35713,18 +35758,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"gxA" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
 "gyf" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -36202,7 +36235,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/bridge)
 "gIh" = (
 /obj/structure/table,
@@ -36369,11 +36402,9 @@
 /turf/open/space/basic,
 /area/space)
 "gLe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/structure/sign/departments/security/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "gLm" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -36464,6 +36495,25 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/rust,
 /area/station/maintenance/starboard)
+"gMb" = (
+/obj/structure/table,
+/obj/item/clothing/under/rank/prisoner/skirt{
+	pixel_x = -13;
+	pixel_y = 5
+	},
+/obj/item/clothing/under/rank/prisoner/skirt{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/obj/item/clothing/under/rank/prisoner{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "gMi" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/delivery,
@@ -36477,16 +36527,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
-"gMj" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 24
+"gMz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/hallway/secondary/dock)
 "gNg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/emitter,
@@ -36532,13 +36584,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gNR" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/obj/structure/rack,
+/obj/machinery/light/small/directional/west,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "gNY" = (
 /obj/structure/marker_beacon/burgundy{
 	name = "landing marker"
@@ -36581,8 +36632,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "gOH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36709,8 +36760,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
@@ -36995,13 +37047,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gVT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "gVV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37429,6 +37480,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "hdT" = (
@@ -37484,7 +37538,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/insectguts,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
 "het" = (
@@ -37492,6 +37545,16 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"heU" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/shard,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "hfb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -37534,7 +37597,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -37542,6 +37604,7 @@
 	c_tag = "Recreation Fitness Ring";
 	name = "recreation camera"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "hgh" = (
@@ -37680,14 +37743,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hhT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/airlock/external{
+	name = "Medical Escape Pod";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "hiz" = (
 /obj/structure/sign/departments/custodian,
 /turf/closed/wall/rust,
@@ -37862,6 +37927,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/cult,
 /area/station/service/chapel/office)
+"hmh" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "hmp" = (
 /obj/item/clothing/suit/hooded/techpriest{
 	pixel_y = 8
@@ -37967,12 +38037,17 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
 "hoZ" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/structure/chair/sofa/bench/solo,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/dock)
 "hpd" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/delivery,
@@ -38148,6 +38223,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
+"hrj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "hrZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -38200,6 +38282,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/closed/wall/rust,
 /area/station/engineering/atmos)
+"hsA" = (
+/obj/machinery/door/airlock/external{
+	name = "Medical Escape Pod";
+	space_dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/dock)
 "hsE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38238,10 +38331,10 @@
 /turf/open/floor/plating/rust,
 /area/station/security/prison)
 "htK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "htX" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/spawner/random/structure/girder,
@@ -38348,7 +38441,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "hxk" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -38432,12 +38525,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
-"hyK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
 "hyP" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -38692,6 +38779,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hEm" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/hallway/secondary/dock)
 "hEn" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/green,
@@ -38704,7 +38800,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "hEv" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
@@ -38713,14 +38809,19 @@
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
 "hEM" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/electric_shock/directional/south,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
+"hFw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/aft)
 "hFx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -38746,7 +38847,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -38794,9 +38894,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -38854,7 +38952,7 @@
 /obj/structure/cable,
 /obj/machinery/meter/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "hGR" = (
 /obj/structure/table,
@@ -38906,16 +39004,22 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal)
 "hIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonblast";
+	name = "Prison Blast Door"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "hIH" = (
 /obj/structure/sign/warning/secure_area,
@@ -38930,7 +39034,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "hIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -39028,8 +39132,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hKh" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/lesser)
+/turf/closed/wall/r_wall/rust,
+/area/station/maintenance/department/security)
 "hKn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -39507,6 +39611,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"hSI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "hSN" = (
 /obj/structure/water_source/puddle,
 /obj/item/radio/intercom/directional/west,
@@ -39596,6 +39710,7 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
 "hTY" = (
@@ -39609,14 +39724,22 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/no_erp/directional/south,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "hUq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/bridge)
+"hUE" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "hUK" = (
 /obj/item/radio{
 	pixel_x = 5;
@@ -39654,10 +39777,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
-"hVl" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall,
-/area/station/maintenance/port/lesser)
 "hVG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -39717,17 +39836,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"hWX" = (
-/obj/machinery/door/airlock/external{
-	name = "Medical Escape Pod";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "hWZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -39771,6 +39879,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"hXR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/tank/internals/oxygen/red,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "hYb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -39836,6 +39959,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"hZi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "hZG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -40065,6 +40197,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"icU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/aft)
 "idD" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -40088,6 +40224,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"ien" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "ieq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40383,8 +40525,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "ikz" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
@@ -40493,6 +40635,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"imE" = (
+/turf/closed/wall/r_wall/rust,
+/area/station/security/prison/garden)
 "imG" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
@@ -40509,8 +40654,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "imQ" = (
+/obj/machinery/light/small,
 /turf/open/floor/iron/stairs/old{
-	dir = 8
+	dir = 4
 	},
 /area/station/maintenance/fore)
 "imV" = (
@@ -40580,8 +40726,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "ioc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -40622,8 +40769,13 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ioN" = (
 /obj/item/radio/intercom/directional/east,
 /turf/closed/wall,
@@ -40704,7 +40856,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "iqM" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -41134,7 +41286,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "iyc" = (
 /obj/effect/turf_decal/siding/wood{
@@ -41392,6 +41544,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"iDs" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
 "iDD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41578,6 +41734,15 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"iFG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/meter/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "iFL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -41857,17 +42022,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
-"iJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "iJZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office,
@@ -41884,7 +42038,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/meter/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
@@ -41892,13 +42045,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/machinery/light/small/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "iKn" = (
@@ -42004,6 +42157,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"iNo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/spawner/random/entertainment/lighter,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "iNC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral,
@@ -42061,6 +42221,10 @@
 /obj/item/seeds/watermelon,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"iOU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/bridge)
 "iPb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42281,9 +42445,9 @@
 /area/station/commons/storage/art)
 "iRv" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "iRD" = (
@@ -42457,14 +42621,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "iTK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "iTR" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -42485,7 +42649,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/fore)
 "iUa" = (
 /obj/effect/turf_decal/stripes/line{
@@ -42585,6 +42749,7 @@
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "iVb" = (
@@ -42616,17 +42781,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"iWH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"iVV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
+"iWH" = (
+/turf/closed/wall/rust,
+/area/station/hallway/secondary/dock)
 "iWN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42909,9 +43070,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "jaC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -42947,16 +43107,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"jbw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/landmark/blobstart,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "jbD" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan,
 /turf/closed/wall/r_wall/rust,
@@ -42987,7 +43137,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "jcI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43058,9 +43208,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "jdj" = (
-/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/landmark/blobstart,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jdy" = (
@@ -43174,6 +43326,7 @@
 /area/station/cargo/storage)
 "jfE" = (
 /obj/machinery/vending/sustenance,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "jfH" = (
@@ -43422,6 +43575,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison)
+"jmk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-16"
+	},
+/obj/structure/sign/warning/secure_area/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/greater)
 "jmm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43436,7 +43604,6 @@
 /area/station/service/janitor)
 "jmy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -43799,8 +43966,11 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/south{
+	pixel_x = 32
+	},
+/obj/structure/sign/calendar/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "jsj" = (
@@ -44069,13 +44239,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"jwZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+"jxg" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/turf/open/space/basic,
+/area/space)
 "jxm" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -44137,9 +44306,31 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "jyL" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/structure/closet/boxinggloves,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/bot_white,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"jyQ" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
+"jyR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/fore)
 "jyV" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/captain/private)
@@ -44204,7 +44395,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "jAe" = (
@@ -44253,16 +44444,17 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "jBp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "jBs" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/tile/neutral{
@@ -44307,6 +44499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/sign/warning/vacuum/external/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jCj" = (
@@ -44464,7 +44657,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "jHj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
@@ -44493,6 +44686,11 @@
 /obj/effect/spawner/random/decoration/carpet,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"jHP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "jIo" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -44638,6 +44836,16 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
+"jKu" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/warrant{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "jKx" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
@@ -44670,6 +44878,9 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
 /area/station/maintenance/starboard)
+"jLv" = (
+/turf/closed/wall/r_wall/rust,
+/area/station/maintenance/department/security/brig)
 "jLy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -44860,7 +45071,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "jPc" = (
 /obj/effect/turf_decal/delivery,
@@ -45188,15 +45399,9 @@
 /area/station/command/heads_quarters/cmo)
 "jWe" = (
 /turf/open/floor/iron/stairs/medium{
-	dir = 4
+	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"jWm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "jWq" = (
 /obj/item/toy/plush/pkplush{
 	desc = "Give HUG-E a hug!";
@@ -45237,14 +45442,14 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "jWU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "jWX" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
@@ -45529,13 +45734,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "kbG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/folder,
+/obj/item/pen,
+/obj/item/hand_labeler,
+/obj/effect/spawner/random/entertainment/deck,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "kbO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45731,12 +45942,9 @@
 /area/station/command/teleporter)
 "keP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "keT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -45771,7 +45979,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "kfm" = (
 /obj/machinery/door/airlock/external{
@@ -45786,7 +45994,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
+"kfs" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/secondary/dock)
 "kfE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45994,9 +46205,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "kjL" = (
-/obj/machinery/light/small/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sign/departments/security/directional/west,
+/obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "kjN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/deathsposal{
@@ -46016,16 +46229,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "kki" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "kkp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -46033,6 +46243,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kkr" = (
@@ -46068,6 +46283,7 @@
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	name = "old sink"
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/security/prison)
 "kkL" = (
@@ -46363,7 +46579,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "kqR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46386,7 +46602,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "krq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46416,7 +46632,7 @@
 /obj/item/stack/package_wrap,
 /obj/item/storage/bag/trash,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal)
 "krL" = (
 /obj/machinery/power/tracker,
@@ -46442,7 +46658,6 @@
 "ksw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
 	id_tag = "justicedoor";
@@ -46911,6 +47126,11 @@
 /obj/item/stamp/head/hos,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
+"kyL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "kyS" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -46934,7 +47154,12 @@
 	c_tag = "Port Hallway Firelock";
 	name = "port camera"
 	},
-/obj/machinery/bluespace_vendor/directional/west,
+/obj/structure/sign/directions/lavaland/directional/west{
+	pixel_y = -6
+	},
+/obj/structure/sign/directions/dorms/directional/west{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -46945,6 +47170,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
+"kzF" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/security)
 "kzS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -47167,6 +47398,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "kDq" = (
@@ -47335,13 +47567,12 @@
 	name = "Unit 1 Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "kGg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "kGl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47452,8 +47683,9 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "kID" = (
+/obj/machinery/light/small,
 /turf/open/floor/iron/stairs/old{
-	dir = 4
+	dir = 8
 	},
 /area/station/maintenance/port/fore)
 "kII" = (
@@ -47466,7 +47698,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "kIJ" = (
 /obj/effect/turf_decal/tile/red,
@@ -47624,7 +47856,7 @@
 	icon_state = "fernybush_3"
 	},
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
 "kLB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47679,15 +47911,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/hop)
 "kNH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kNN" = (
@@ -47785,7 +48013,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "holodeck"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "kPC" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -47807,7 +48035,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
+"kPO" = (
+/obj/structure/table,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/screwdriver,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "kPS" = (
 /obj/structure/railing{
 	dir = 8
@@ -47950,7 +48191,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "kRu" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -48068,6 +48309,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"kTb" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "kTl" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/item/stack/sheet/mineral/plasma{
@@ -48219,6 +48466,7 @@
 	pixel_y = 4
 	},
 /obj/item/lighter,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "kVb" = (
@@ -48538,13 +48786,11 @@
 "lbY" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
-"lcd" = (
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/area/station/maintenance/department/security/brig)
 "lcf" = (
 /obj/structure/rack,
 /obj/item/rcl/pre_loaded,
@@ -48618,6 +48864,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
+"lee" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "leq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48936,6 +49189,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"llh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "llp" = (
 /obj/machinery/ai_slipper{
 	uses = 8
@@ -48959,7 +49218,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "llv" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/radio/intercom/directional/west,
@@ -49134,7 +49393,7 @@
 	},
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "los" = (
 /obj/effect/turf_decal/bot,
@@ -49247,7 +49506,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "lpk" = (
 /obj/effect/turf_decal/tile/brown,
@@ -49370,6 +49629,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"lrk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "lrp" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/railing/corner,
@@ -49704,7 +49972,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lwv" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49715,6 +49982,7 @@
 /obj/machinery/computer/holodeck{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot/left,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -49741,6 +50009,11 @@
 /obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"lwU" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/commons/fitness/recreation/entertainment)
 "lxe" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison)
@@ -49821,7 +50094,7 @@
 "lza" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "lzj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49866,6 +50139,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"lzl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "lzo" = (
 /obj/machinery/door/poddoor{
 	id = "trash";
@@ -49883,6 +50163,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"lAR" = (
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
 "lBj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50274,7 +50557,7 @@
 	},
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "lJQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -50370,6 +50653,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "lMx" = (
@@ -50540,6 +50825,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"lOT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "lPu" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Captain's Office";
@@ -50589,7 +50879,7 @@
 /area/station/service/library)
 "lPU" = (
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "lPX" = (
 /obj/effect/turf_decal/tile/blue{
@@ -50644,16 +50934,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lQG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "lQS" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -51050,6 +51338,12 @@
 /mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"lXj" = (
+/obj/docking_port/stationary/escape_pod{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lXq" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
@@ -51072,7 +51366,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lXv" = (
@@ -51206,7 +51500,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "lZL" = (
@@ -51508,7 +51804,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "mgL" = (
 /turf/closed/wall,
@@ -51767,14 +52063,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mlF" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "mlI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
@@ -51851,14 +52148,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"mnc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "mnt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -51931,6 +52220,18 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"moO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
+"mpc" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "mpx" = (
 /turf/closed/wall,
 /area/station/engineering/storage_shared)
@@ -51955,7 +52256,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "mqu" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52077,6 +52378,9 @@
 	id = "teleshutter";
 	name = "Teleporter Shutter Toggle";
 	req_access = list("command")
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_y = 35
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -52236,6 +52540,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"mut" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "muA" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -52435,7 +52747,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/electrical)
 "mxG" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52457,6 +52769,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/hallway)
+"mxV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "myb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -52577,7 +52900,7 @@
 	},
 /obj/structure/flora/bush/ferny,
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
 "mzw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/closed/wall,
@@ -52797,7 +53120,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "mCW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -52867,6 +53190,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mEu" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "mEy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52893,7 +53222,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/fore)
 "mFX" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -52963,7 +53292,6 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -53268,10 +53596,14 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "mKK" = (
-/turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "mLa" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/yellow{
@@ -53372,7 +53704,7 @@
 "mNe" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "mNf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53430,7 +53762,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "mNY" = (
 /turf/closed/wall,
@@ -53579,21 +53911,8 @@
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "mQh" = (
-/obj/structure/table,
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = -13;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner/skirt{
-	pixel_x = 9;
-	pixel_y = 5
-	},
-/obj/item/clothing/under/rank/prisoner{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "mQv" = (
@@ -53773,17 +54092,17 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
 "mSv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonblast";
+	name = "Prison Blast Door"
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "mSA" = (
 /turf/closed/wall,
@@ -53931,6 +54250,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
+"mUO" = (
+/obj/structure/chair/stool/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "mUS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -53945,7 +54274,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
@@ -53989,17 +54317,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "mWo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -54158,6 +54479,17 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"mYE" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/greater)
 "mYN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -54377,16 +54709,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/service/chapel/dock)
-"nev" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "ney" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral,
@@ -54412,6 +54734,9 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"nff" = (
+/turf/closed/wall,
+/area/station/maintenance/department/security/brig)
 "nfn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54561,8 +54886,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "nhC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
@@ -54689,15 +55015,15 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "nlo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "nlE" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -54732,7 +55058,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "nlZ" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood/end,
@@ -54759,6 +55085,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
@@ -54788,8 +55117,11 @@
 /area/station/cargo/storage)
 "nnN" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "nod" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
@@ -54991,7 +55323,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "nrG" = (
 /obj/effect/turf_decal/delivery,
@@ -55254,6 +55586,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"nwU" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nxa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -55262,17 +55601,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
-"nxi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "nxT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -55315,6 +55643,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/solars/port/aft)
+"nyM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "nyP" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/right/directional/north{
@@ -55329,6 +55664,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/sign/clock/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "nyV" = (
@@ -55367,7 +55703,7 @@
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "nzw" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -55414,6 +55750,12 @@
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"nAQ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "nAR" = (
 /obj/effect/landmark/start/ordnance_tech,
 /turf/open/floor/iron/white,
@@ -55433,7 +55775,7 @@
 	dir = 9
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "nBj" = (
 /obj/structure/sign/warning/electric_shock,
@@ -55480,13 +55822,18 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/girder/displaced,
 /obj/structure/grille/broken,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/girder,
+/obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nBD" = (
@@ -55821,7 +56168,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "nJY" = (
 /turf/closed/wall/rust,
@@ -56044,7 +56391,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "nOQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -56112,6 +56459,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"nPM" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "nPY" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -56264,6 +56617,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"nTq" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/greater)
 "nTA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -56374,7 +56731,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/fore)
 "nVs" = (
 /obj/structure/table/wood/fancy,
@@ -56414,7 +56771,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "nWj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56446,11 +56803,8 @@
 /area/station/security/office)
 "nXe" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "nXj" = (
@@ -56801,6 +57155,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"odB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "odG" = (
 /turf/closed/wall/rust,
 /area/station/medical/paramedic)
@@ -56946,12 +57308,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"ohr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "ohC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -57021,11 +57377,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ois" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Dock"
+/obj/machinery/door/airlock/public/glass{
+	name = "Arcade"
 	},
-/turf/open/floor/plating,
-/area/station/commons/fitness/recreation)
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation/entertainment)
 "oiw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -57205,6 +57563,10 @@
 /area/station/service/chapel/dock)
 "olb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "old" = (
@@ -57356,14 +57718,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"onf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "onn" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -57397,6 +57751,12 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
+"onW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "onY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57442,13 +57802,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"ooM" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "opx" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/punching_bag,
@@ -57641,6 +57994,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
 "osw" = (
@@ -57923,11 +58277,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"oys" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "oyx" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -58072,6 +58421,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"oAo" = (
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/greater)
 "oAB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -58271,6 +58625,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"oCT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "oCZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58333,7 +58693,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "oEo" = (
@@ -58713,7 +59072,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "oKR" = (
@@ -58792,11 +59153,27 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
+"oMB" = (
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/port/greater)
 "oMU" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/asteroid,
 /area/station/hallway/secondary/exit/departure_lounge)
+"oMW" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/port/greater)
 "oNc" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -58926,6 +59303,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "oPH" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
 "oPT" = (
@@ -58953,8 +59331,11 @@
 "oQq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "oQw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58970,6 +59351,7 @@
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/contraband/prison,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "oQC" = (
@@ -58983,10 +59365,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
-"oQI" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/lesser)
 "oRa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/hydroponics/constructable,
@@ -58997,6 +59375,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"oRc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/vacuum/external/directional/west,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "oRo" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -59037,17 +59420,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"oRL" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Connector"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
 "oRZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59066,6 +59438,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"oSA" = (
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "oSS" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
@@ -59155,6 +59531,11 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"oUk" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/commons/fitness/recreation/entertainment)
 "oUl" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral{
@@ -59811,6 +60192,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
+"pfT" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/dock)
 "pgf" = (
 /obj/machinery/firealarm/directional/west,
 /obj/item/reagent_containers/cup/bottle/ammonia,
@@ -60092,7 +60484,7 @@
 /area/station/security/execution/transfer)
 "pls" = (
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "plP" = (
 /obj/structure/cable,
@@ -60335,7 +60727,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "poZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -60487,9 +60879,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/warning/no_smoking{
-	pixel_x = -30
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -60660,7 +61050,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ptV" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -60953,6 +61343,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "pyM" = (
@@ -60989,6 +61380,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/sign/clock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "pAa" = (
@@ -61186,7 +61578,7 @@
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "pDu" = (
 /obj/structure/closet{
@@ -61232,7 +61624,7 @@
 	name = "Cabin 4 Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "pEb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -61418,6 +61810,17 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"pHz" = (
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "pHG" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line,
@@ -61699,6 +62102,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"pMK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "pMS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61812,6 +62221,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"pPk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/execution/transfer)
 "pPr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -61842,6 +62261,14 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"pPT" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "pPX" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall,
@@ -62109,12 +62536,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "pTY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/turf_decal/bot,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "pUp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62268,6 +62696,19 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
+"pWS" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/aft)
 "pXb" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -62292,6 +62733,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"pXu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/fore)
 "pXO" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -62353,6 +62801,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"pZd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/port/greater)
 "pZk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/electrolyzer,
@@ -62390,6 +62848,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"pZV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/dock)
 "qab" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/newscaster/directional/east,
@@ -62476,12 +62940,11 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "qaG" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "qaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62552,10 +63015,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "qcn" = (
@@ -62577,7 +63039,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "qcT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62708,7 +63170,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plating/rust,
-/area/station/maintenance/department/security)
+/area/station/maintenance/department/security/brig)
 "qgx" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line{
@@ -63282,9 +63744,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/components/binary/pump/on/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/binary/pump/off/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qpy" = (
@@ -63339,7 +63800,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/meter/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "qsb" = (
 /turf/closed/wall/r_wall,
@@ -63434,6 +63895,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"qth" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "qtx" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/misc/asteroid/airless,
@@ -63537,13 +64003,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"qvb" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/storage/backpack/satchel/eng,
-/obj/item/wirecutters,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "qvp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63875,6 +64334,7 @@
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/west,
+/obj/structure/sign/clock/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "qCt" = (
@@ -63955,6 +64415,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"qEO" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "qEQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64018,6 +64484,17 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/exam_room)
+"qFd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/aft)
 "qFo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -64034,15 +64511,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "qFu" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "qFx" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/bot,
@@ -64194,6 +64670,10 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qHe" = (
@@ -64303,13 +64783,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qJj" = (
-/obj/structure/sign/warning/no_smoking{
-	pixel_x = 30
-	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "qJk" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -64746,13 +65226,16 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "qRu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "qRE" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/service/chapel/office)
@@ -64789,6 +65272,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"qRT" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/dim/directional/east,
+/obj/item/clipboard,
+/obj/item/paper,
+/obj/item/pen/blue,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "qSo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -64904,7 +65400,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "qUF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65141,7 +65637,7 @@
 "rbw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "rbD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65307,6 +65803,11 @@
 /obj/structure/sign/poster/contraband/missing_gloves,
 /turf/closed/wall/rust,
 /area/station/maintenance/port/greater)
+"reb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/aft)
 "ref" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65641,15 +66142,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rhZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "ria" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
@@ -65848,12 +66340,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rkz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/item/clothing/under/rank/security/officer,
+/obj/effect/spawner/random/clothing/twentyfive_percent_cyborg_mask,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "rkR" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -65987,6 +66479,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "rmH" = (
@@ -66118,6 +66611,14 @@
 /obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"rnL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/fore)
 "rnV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -66420,11 +66921,13 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "rsn" = (
-/obj/structure/chair/stool/bar/directional/west,
+/obj/structure/chair/stool/bar/directional/west{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "rsC" = (
 /obj/structure/chair{
 	dir = 4
@@ -66441,6 +66944,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"rsJ" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
 "rtp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66448,7 +66955,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Port Hallway Chemistry Desk";
 	name = "port camera"
@@ -66641,10 +67147,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ryM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/rods/lava,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/servo,
+/obj/structure/closet,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ryU" = (
@@ -67093,7 +67601,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "rGe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -67105,7 +67613,7 @@
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/chair,
 /turf/open/misc/asteroid,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "rHd" = (
 /obj/machinery/power/tracker,
 /obj/effect/turf_decal/box,
@@ -67116,6 +67624,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "rHf" = (
@@ -67159,9 +67668,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"rHo" = (
-/turf/closed/wall/r_wall/rust,
-/area/station/maintenance/port/lesser)
 "rIb" = (
 /obj/machinery/power/turbine/turbine_outlet,
 /turf/open/floor/engine,
@@ -67236,7 +67742,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "rJl" = (
 /obj/effect/turf_decal/tile/brown,
@@ -67305,7 +67811,7 @@
 	dir = 6
 	},
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/aft)
 "rKf" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -67320,8 +67826,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "rKp" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -67434,8 +67939,19 @@
 /area/station/service/chapel)
 "rLU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/item/poster/random_official{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/poster/random_official,
+/obj/effect/turf_decal/stripes/corner,
+/obj/item/clothing/head/costume/festive{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rMc" = (
@@ -67489,7 +68005,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "rNg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -67536,7 +68052,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "rOe" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -67545,7 +68060,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "rOJ" = (
@@ -67608,10 +68123,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "rQf" = (
 /obj/effect/turf_decal/tile/blue{
@@ -67768,7 +68280,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/built/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal/incinerator)
 "rTw" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -67855,17 +68367,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rUR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "rVj" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 8
@@ -68449,9 +68950,12 @@
 "scJ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "scK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -68480,20 +68984,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"scV" = (
-/obj/structure/table,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/gloves/color/black,
-/obj/item/crowbar/red,
-/obj/item/flashlight/seclite,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
 "sdw" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -68686,15 +69176,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
-"seL" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/small/directional/north,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
 "seQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68930,6 +69411,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"siP" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/eighties,
+/area/station/commons/fitness/recreation/entertainment)
 "sjJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68983,6 +69469,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/departments/medbay/alt/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ski" = (
@@ -69032,7 +69521,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "sln" = (
 /obj/machinery/firealarm/directional/west,
@@ -69052,12 +69541,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "smG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69322,6 +69809,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"sse" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "ssy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -69501,10 +69997,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"swn" = (
-/obj/structure/sign/warning/electric_shock,
-/turf/closed/wall/rust,
-/area/station/maintenance/port/lesser)
 "swt" = (
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/cult,
@@ -69526,6 +70018,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"swL" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security/brig)
 "swO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69652,7 +70152,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "szy" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -69693,7 +70193,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "sAD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69709,6 +70209,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "sBa" = (
@@ -69989,6 +70491,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"sFx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Recreation Area"
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "sFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70047,6 +70556,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"sGk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "sGl" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -70117,7 +70631,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/port/greater)
 "sHe" = (
 /obj/machinery/door/airlock/external{
@@ -70167,6 +70685,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/dresser,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "sIP" = (
@@ -70326,6 +70845,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"sLU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "sMk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -70521,7 +71047,7 @@
 "sQW" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/closed/wall,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "sQX" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/security)
@@ -70763,6 +71289,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"sVw" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "sVH" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -70792,7 +71327,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "sWr" = (
@@ -70810,6 +71344,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"sWR" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "sWY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70853,6 +71391,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"sYp" = (
+/obj/structure/table,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/parquet,
+/area/station/commons/fitness/recreation/entertainment)
 "sYB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70931,6 +71478,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "sZW" = (
@@ -71151,7 +71699,7 @@
 "tcq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal/incinerator)
 "tcu" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
@@ -71432,7 +71980,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "tje" = (
 /obj/structure/sign/warning/engine_safety,
@@ -71494,14 +72042,12 @@
 /area/station/engineering/supermatter/room)
 "tjK" = (
 /obj/structure/closet/crate/engineering,
-/obj/item/stack/sheet/mineral/plasma/thirty{
-	amount = 50
-	},
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/chapel/monastery)
 "tkg" = (
@@ -71737,10 +72283,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "tog" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -71796,8 +72339,18 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
+"toH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_y = 1;
+	pixel_x = -4
+	},
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "toK" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
@@ -71834,6 +72387,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"tpa" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/aft)
 "tpk" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -71856,17 +72421,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"tqo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "tqC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -71909,10 +72463,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "tsk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71928,13 +72481,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
-"tsP" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
 "tsV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -71989,8 +72535,8 @@
 /obj/structure/sign/departments/holy{
 	pixel_y = 30
 	},
-/turf/open/floor/iron/stairs/right{
-	dir = 4
+/turf/open/floor/iron/stairs/left{
+	dir = 8
 	},
 /area/station/hallway/primary/fore)
 "ttO" = (
@@ -72132,14 +72678,14 @@
 "tvd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/hallway/secondary/dock)
 "tvf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72241,7 +72787,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "tvU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -72282,8 +72828,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/meter/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
+"txo" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "txu" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -72299,7 +72850,7 @@
 "txC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/bridge)
 "txI" = (
 /obj/effect/turf_decal/tile/blue,
@@ -72422,6 +72973,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "tzO" = (
@@ -72486,6 +73041,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/construction/mining/aux_base)
+"tAP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "tBc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -72703,7 +73269,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "tFc" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -72924,6 +73490,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"tJn" = (
+/obj/machinery/newscaster/directional/north,
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/commons/fitness/recreation/entertainment)
 "tJA" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 4
@@ -72963,6 +73535,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/sign/calendar/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "tJV" = (
@@ -73047,17 +73620,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"tLz" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/greater)
 "tLC" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/mess)
@@ -73153,17 +73715,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "tNI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Dock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "kilo_cool_mining"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/sign/poster/contraband/random/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "tNL" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -73622,6 +74183,14 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"tUS" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/misc/asteroid,
+/area/station/maintenance/department/security)
 "tUT" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -74017,15 +74586,9 @@
 /area/station/service/hydroponics)
 "uaZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ubi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral,
@@ -74315,6 +74878,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
+/obj/structure/sign/clock/directional/north,
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
 "uhd" = (
@@ -74433,20 +74997,21 @@
 /turf/open/floor/engine/telecomms,
 /area/station/tcommsat/server)
 "ujD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"ujF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "ujR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74717,7 +75282,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
@@ -74735,6 +75299,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"uoZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/aft)
 "upa" = (
 /turf/closed/wall,
 /area/station/science/ordnance/freezerchamber)
@@ -74984,7 +75553,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "uuQ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -75244,7 +75813,7 @@
 	name = "Unit 3 Privacy Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "uAg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -75552,8 +76121,12 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
+"uFh" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/station/hallway/secondary/dock)
 "uFB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -75634,7 +76207,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "uGZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75785,6 +76358,7 @@
 /obj/structure/bed,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "uKm" = (
@@ -75930,6 +76504,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/meter/layer4,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "uMr" = (
@@ -76085,12 +76660,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uOW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/screwdriver{
-	pixel_y = 18
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -76098,6 +76667,10 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/dice,
+/obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "uPV" = (
@@ -76162,6 +76735,12 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/rust,
 /area/station/maintenance/disposal)
+"uQt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard/aft)
 "uQv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -76191,6 +76770,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"uRD" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/dock)
 "uRK" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/directional/east,
@@ -76201,6 +76789,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"uSa" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/black,
+/obj/item/crowbar/red,
+/obj/item/flashlight/seclite,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/greater)
 "uSp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance"
@@ -76250,14 +76853,14 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "uTO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/aft)
 "uTP" = (
 /obj/machinery/camera/directional/east{
@@ -76357,8 +76960,14 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/security/prison/garden)
 "uXa" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/rust,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot_red,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "uXc" = (
 /obj/effect/turf_decal/tile/blue{
@@ -76411,7 +77020,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/department/crew_quarters/bar)
 "uYY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -76569,16 +77178,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plating/plasma/rust,
 /area/station/maintenance/space_hut/plasmaman)
-"vbK" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "vbL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76599,8 +77198,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "vbU" = (
 /obj/structure/flora/grass/jungle/a/style_random,
@@ -76740,7 +77340,7 @@
 	},
 /obj/structure/flora/grass/jungle/b/style_5,
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
 "vdS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -76755,17 +77355,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"vee" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "ver" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -76783,6 +77372,11 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"veF" = (
+/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "veJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77069,7 +77663,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/chair/stool,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "vjy" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -77228,7 +77822,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/fore)
 "vmU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -77273,9 +77867,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light/small/directional/west,
 /obj/machinery/meter/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vnv" = (
@@ -77427,7 +78021,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "vpk" = (
@@ -77750,18 +78343,17 @@
 /mob/living/basic/mouse/brown/tom{
 	name = "Jerm"
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
 "vwn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "vwG" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/command/heads_quarters/ce)
@@ -77801,7 +78393,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard/fore)
 "vxA" = (
 /obj/structure/table,
@@ -77841,6 +78433,7 @@
 	id = "medbaydeskshutters";
 	name = "Medical Surgery Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
 "vxT" = (
@@ -78044,6 +78637,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"vAK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "vAL" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
@@ -78073,7 +78672,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "vAY" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -78127,12 +78726,11 @@
 /turf/open/floor/iron/dark,
 /area/station/construction/mining/aux_base)
 "vBT" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "vCk" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/tile/neutral{
@@ -78313,14 +78911,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vFo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/preopen,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vFw" = (
@@ -78365,7 +78958,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78380,14 +78972,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/table,
 /obj/item/storage/crayons,
 /obj/item/clothing/under/color/grey{
 	pixel_x = 4;
 	pixel_y = 4
 	},
 /obj/item/clothing/under/color/grey,
-/obj/machinery/light/directional/south,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -78431,6 +79023,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"vGO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "vHh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -78672,6 +79272,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
+"vKK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/port/greater)
 "vLb" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -78900,6 +79508,18 @@
 /obj/structure/grille,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
+"vQN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "bankshutter";
+	name = "Bank Shutter"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/noticeboard/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "vRk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -78931,14 +79551,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"vRA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "vRC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -78946,6 +79558,9 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"vRI" = (
+/turf/closed/wall/rust,
+/area/station/maintenance/department/security/brig)
 "vRY" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-18"
@@ -79016,7 +79631,7 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal/incinerator)
 "vSW" = (
 /obj/structure/table/reinforced,
@@ -79205,7 +79820,7 @@
 	icon_state = "genericbush_1"
 	},
 /turf/open/misc/asteroid,
-/area/space/nearstation)
+/area/station/maintenance/port/greater)
 "vVZ" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -79356,6 +79971,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/library)
+"vYG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/crew_quarters/bar)
 "vZl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -79369,6 +79988,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"wai" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "waA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -79712,7 +80340,6 @@
 "wgo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "justiceshutter";
@@ -79793,6 +80420,13 @@
 /obj/structure/cable,
 /turf/closed/wall/rust,
 /area/station/maintenance/department/electrical)
+"wic" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "wig" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -79968,6 +80602,17 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
+"wkV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "wle" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80114,6 +80759,14 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"wnx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/starboard)
 "wnR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -80150,6 +80803,15 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
+"wow" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/sign/warning/pods/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "woB" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
@@ -80319,19 +80981,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/satellite)
-"wrr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "bankshutter";
-	name = "Bank Shutter"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/noticeboard/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
 "wrz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80909,6 +81558,9 @@
 	},
 /turf/closed/wall,
 /area/station/engineering/atmos)
+"wEn" = (
+/turf/closed/wall/rust,
+/area/station/commons/fitness/recreation)
 "wEq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80941,7 +81593,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "wFD" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -80951,7 +81607,7 @@
 /obj/structure/cable,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "wFL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -80964,8 +81620,17 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"wGd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "wGn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80990,6 +81655,12 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/port)
+"wGu" = (
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security)
 "wGv" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Transit Intersection"
@@ -81006,6 +81677,16 @@
 "wGF" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/station/maintenance/port/aft)
+"wGG" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "wGT" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
@@ -81215,15 +81896,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/hallway/secondary/dock)
 "wLp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -81256,7 +81935,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -81302,6 +81981,7 @@
 /area/station/commons/vacant_room/commissary)
 "wMA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
 "wMD" = (
@@ -81562,6 +82242,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/calendar/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "wPI" = (
@@ -81634,7 +82315,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/masks,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "wRB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -81839,6 +82520,14 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"wUS" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security)
 "wVb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -81882,10 +82571,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/port/greater)
 "wVJ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -81957,6 +82644,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wWu" = (
@@ -82039,16 +82730,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "wWY" = (
-/obj/structure/girder/displaced,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "wXo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82186,10 +82877,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xad" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/rock/pile/style_random,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/maintenance/department/security)
 "xaf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82200,6 +82891,9 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"xaz" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/brig)
 "xaH" = (
 /obj/structure/punching_bag,
 /obj/structure/cable,
@@ -82459,6 +83153,11 @@
 /obj/machinery/status_display/shuttle,
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
+"xeI" = (
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/commons/fitness/recreation/entertainment)
 "xfH" = (
 /obj/structure/cable,
 /obj/machinery/computer/atmos_alert{
@@ -82501,8 +83200,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
+/obj/machinery/bluespace_vendor/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -82523,10 +83222,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"xhX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/science/genetics)
 "xii" = (
 /obj/structure/chair/pew{
 	dir = 8
@@ -82723,16 +83418,20 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xkx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
+"xlh" = (
+/obj/structure/sign/warning/secure_area/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/port/greater)
 "xlm" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -82885,7 +83584,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "xof" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -83178,21 +83877,24 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
-"xsR" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "xsS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/disposal)
+"xsT" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/dock)
 "xsU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83221,9 +83923,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "xtk" = (
+/obj/effect/spawner/random/structure/steam_vent,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "xtl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -83345,6 +84048,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"xuY" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xvd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -83536,7 +84244,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/starboard)
 "xxU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -83556,7 +84264,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "xyd" = (
 /obj/effect/turf_decal/delivery,
@@ -83676,8 +84384,11 @@
 /area/station/tcommsat/computer)
 "xzE" = (
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "xzI" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Prison Cells";
@@ -83885,7 +84596,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "xCt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/hydroponics/constructable,
@@ -83945,6 +84656,28 @@
 /obj/item/hand_labeler,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"xCI" = (
+/obj/machinery/button/door/directional/north{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 8;
+	req_access = list("brig")
+	},
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = 24;
+	req_access = list("brig")
+	},
+/obj/machinery/button/door/directional/north{
+	id = "visitation_cool_door";
+	name = "Visitation Public Entrance";
+	pixel_x = 8;
+	req_access = list("brig");
+	pixel_y = 34
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "xDG" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -84005,6 +84738,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"xEN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/station/maintenance/disposal/incinerator)
 "xFp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -84291,7 +85028,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
 "xKT" = (
-/obj/item/storage/medkit/regular,
 /obj/machinery/light/directional/east,
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -84299,6 +85035,7 @@
 	},
 /obj/machinery/newscaster/directional/east,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/item/storage/medkit/emergency,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "xKX" = (
@@ -84371,13 +85108,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xMG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/dock)
 "xNd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84456,9 +85194,8 @@
 /turf/closed/wall/rust,
 /area/station/service/janitor)
 "xOv" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "xOC" = (
@@ -84526,8 +85263,8 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/turf/open/floor/plating/rust,
+/area/station/maintenance/department/security)
 "xPt" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/power/emitter,
@@ -84733,7 +85470,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "xTA" = (
@@ -84874,6 +85610,11 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/fore)
+"xUY" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "xVk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -84895,7 +85636,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/rust,
 /area/station/maintenance/aft)
 "xWb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84963,6 +85704,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
+"xXA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/execution/transfer)
 "xXV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85005,6 +85750,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
+"xYn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "xYt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -85226,7 +85980,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
+/area/station/maintenance/department/security)
 "ycO" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -85260,6 +86014,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
+/obj/effect/spawner/random/engineering/flashlight,
+/obj/effect/spawner/random/clothing/gloves,
+/obj/effect/spawner/random/clothing/beret_or_rabbitears,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ydo" = (
@@ -85709,6 +86466,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"yls" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "ylv" = (
 /turf/closed/wall/rust,
 /area/station/service/chapel/storage)
@@ -91577,7 +92340,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaB
 aaa
 aaa
 aeu
@@ -91602,7 +92365,7 @@ moy
 moy
 moy
 lxe
-lxe
+ldG
 aeu
 aeu
 aeU
@@ -92365,7 +93128,7 @@ cpx
 nzQ
 cpx
 lxe
-lxe
+ldG
 lBX
 xQj
 xQj
@@ -92620,7 +93383,7 @@ rHe
 cPa
 oQz
 rHe
-cpx
+cPa
 aaa
 moy
 xGF
@@ -92629,7 +93392,7 @@ qGP
 oBY
 chR
 mMN
-lxe
+ldG
 lxe
 aeU
 asO
@@ -92862,7 +93625,7 @@ aaa
 aaa
 aaa
 aaa
-aaB
+aaa
 aaa
 aaa
 aaa
@@ -92889,7 +93652,7 @@ mMN
 lxe
 aeU
 aeU
-aav
+imE
 jTJ
 fLV
 rnG
@@ -93125,9 +93888,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 alm
+aaa
+aaa
 ivj
 anu
 anu
@@ -93363,6 +94126,7 @@ aaa
 aaa
 aaa
 aaa
+aaB
 aaa
 aaa
 aaa
@@ -93381,9 +94145,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+acK
+acm
 acm
 acm
 acm
@@ -93639,12 +94402,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 acm
 aaa
 aaa
-acK
+aaa
+aaa
+acm
 aaa
 aaa
 aaa
@@ -93657,10 +94420,10 @@ xFp
 lxe
 chR
 mMN
-aav
+imE
 aau
 aau
-aav
+imE
 qoJ
 vOv
 pGW
@@ -93874,7 +94637,6 @@ aaa
 aaa
 aaa
 aaa
-bQc
 aaa
 aaa
 aaa
@@ -93887,10 +94649,6 @@ aaa
 aaa
 aaa
 aaa
-aeU
-aeu
-aeu
-aeU
 aaa
 aaa
 aaa
@@ -93898,7 +94656,12 @@ aaa
 aaa
 aaa
 aaa
-acm
+aaa
+aaa
+aaa
+acK
+aaa
+aaa
 aaa
 aaa
 acK
@@ -93911,7 +94674,7 @@ cEt
 vaj
 cEt
 cEt
-cEt
+vaj
 eys
 vDc
 lxe
@@ -94143,19 +94906,19 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aeU
-aeu
-aeu
+aeU
 aUz
 aeU
-aeU
-aeU
-aeU
+aaa
 aaa
 aaa
 aaa
 aaa
 acm
+aaa
+aaa
 aaa
 aaa
 acm
@@ -94171,16 +94934,16 @@ pwv
 cEt
 tFc
 jou
-lxe
+ldG
 lxe
 lxe
 aav
 aau
-aav
+imE
 bMJ
 gCJ
 irF
-aav
+imE
 aeU
 aeu
 aeu
@@ -94399,20 +95162,20 @@ aaa
 aaa
 aaa
 aaa
-aeu
-aeu
-aeu
-aeu
 aeU
 aeU
-aeu
-aeu
+aeU
+aeU
+aeU
 aeU
 aeU
 aaa
 aaa
 aaa
-acm
+aaa
+acK
+aaa
+aaa
 aaa
 aaa
 qJs
@@ -94437,7 +95200,7 @@ aau
 uXc
 uIs
 eyc
-aav
+imE
 cui
 aeU
 aeu
@@ -94653,32 +95416,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aeu
 aeu
 aeu
 aeu
-aeu
+coy
+oSA
 aeU
-aeu
-aeu
-aeu
-aeu
 aeU
-aaa
-aaa
-acm
-aaa
+aeU
+aeU
+aeU
+oSA
+aeU
 aaa
 acm
 aaa
 aaa
 aaa
 aaa
+acm
 aaa
-cEt
+aaa
+aaa
+aaa
+aaa
+vaj
 wuY
 kgG
 lpY
@@ -94691,7 +95454,7 @@ moy
 aeU
 aUz
 asO
-aav
+imE
 aau
 aau
 aav
@@ -94910,23 +95673,23 @@ aaa
 aaa
 aeu
 aeu
+aeu
+aeu
+aeu
+aeu
+aeu
+anH
+cmU
+cmU
+cmU
+cmU
+cmU
+anH
 aeU
+aUz
+acK
 aaa
 aaa
-aeU
-aeu
-aeu
-aeu
-ahV
-ahV
-amz
-amz
-ahV
-aeu
-aeu
-aeu
-aaa
-acm
 aaa
 aaa
 acK
@@ -95164,28 +95927,28 @@ aaa
 aaa
 aaa
 aeU
-aeu
-aeu
-aeu
-aeU
-aaa
-aaa
 aeU
 aeu
 aeu
 aeu
-ahV
-bBK
-byO
-uVc
-ahV
 aeu
 aeu
 aeu
 aeu
-alm
-aUz
-aaa
+cok
+aeU
+aeU
+aeU
+aeU
+aeU
+cuo
+coy
+aeU
+qJs
+acK
+acm
+acK
+qJs
 acK
 aaa
 aaa
@@ -95200,8 +95963,8 @@ lNB
 lTW
 gBM
 lxe
-lxe
-lxe
+ldG
+ldG
 aeU
 aeU
 aeU
@@ -95419,30 +96182,30 @@ aaa
 aaa
 aaa
 aaa
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
 aeU
-aaa
-aaa
+aUz
 aeU
 aeu
 aeu
-amz
-oAm
-bzY
-bFf
-amz
 aeu
 aeu
-mKK
-akh
-mKK
-cou
-mKK
+aeu
+aeu
+aeu
+kAy
+aeU
+aeU
+aeU
+aeU
+aeU
+cuo
+cmU
+cmU
+gvc
+beK
+cGA
+beK
+gvc
 acK
 aaa
 aaa
@@ -95459,7 +96222,7 @@ mMN
 lxe
 kkI
 lxe
-lxe
+ldG
 nBj
 cmU
 cmU
@@ -95677,29 +96440,29 @@ amA
 amA
 acm
 alm
+aeU
 aeu
 aeu
 aeu
 aeu
 aeu
 aeu
-aaa
-aaa
 aeu
 aeu
-aeu
-ahV
-ahV
-bBm
-bFF
-amz
-aeu
-aeu
-cou
-seL
-cvo
-jbw
-hVl
+cok
+aeU
+aeU
+aeU
+aeU
+aeU
+rbw
+rbw
+rbw
+uFh
+cry
+cry
+cry
+ckn
 acm
 aaa
 aaa
@@ -95707,7 +96470,7 @@ aaa
 aaa
 aaa
 ivj
-cpx
+cPa
 mAI
 cpx
 cpx
@@ -95933,30 +96696,30 @@ mlu
 lum
 amR
 aaa
+anH
+aeu
+aeu
+aeu
+aeu
+aeu
+ahV
+ahV
+amz
+amz
+ahV
 aeU
-aeu
-aeu
-aeu
-aeu
-aeu
-alm
-aeo
-aeo
-aeu
-aeu
-aeu
-amA
-suu
-bDC
+aeU
+aeU
+aeU
 bGa
-amA
-amA
-amA
-mKK
-ctb
-bsq
-onf
-mKK
+ekt
+aKL
+hSI
+cqt
+cry
+cry
+cry
+anH
 qJs
 aaa
 aaa
@@ -96189,38 +96952,38 @@ ioT
 fyu
 ybC
 amA
-aaa
-aUz
 aeU
-aeu
-aeu
-aeu
-aeu
-aaQ
-aaa
-aaa
-aaa
-alm
-aeu
+amA
+amA
 amR
-scV
-ckR
-peP
-bGY
-bLq
+amA
+aeu
+aeu
+ahV
+bBK
+byO
+uVc
+ahV
+aeU
+aeU
+aeU
+aeU
+aeU
+rbw
+xsT
 nlo
-mKK
-cou
-mKK
-oRL
-cou
-acm
+iWH
+cry
+cry
+cry
+anH
+bOx
 aaa
 aaa
 bpm
 aaa
-aaa
-cpx
+jxg
+cPa
 hel
 yau
 kzW
@@ -96445,39 +97208,39 @@ vaK
 jSw
 hEn
 xRx
-amA
+amR
+aeU
+amR
+gdm
+oMW
+amR
+aeu
+aeu
+amz
+oAm
+ejy
+bFf
+amz
 aeU
 aeU
-alm
-aeu
-aeu
-aeu
-aeu
-qJs
-acK
-acm
-acK
-qJs
-aeu
-amA
-cxp
-bDi
-bFD
-bHb
-cni
+aeU
+aeU
+aeU
+rbw
+fSo
 wWY
-mKK
-ctj
-cou
-bCe
-mKK
-acm
+cqt
+cry
+lXj
+cry
+agt
+xuY
 acm
 rbw
 cqN
 rbw
 cov
-cpx
+cPa
 cuK
 yau
 oNc
@@ -96703,41 +97466,41 @@ nCo
 amA
 mGQ
 amA
-aeU
-aeu
-aeu
-aeu
-wDI
-aeu
-aeu
-aDT
-beK
-cGA
-beK
-sRm
-aeu
+wGG
+amA
+heU
+dfR
 amR
 amA
-bzE
-wrr
-amA
-amA
+aeu
+ahV
+ahV
+bBm
+ahV
+amz
+aeU
+aeU
+aeU
+aeU
+aeU
+kfs
+rbw
 tNI
-gxA
-ewJ
+cqt
+rbw
 hhT
-eqm
-mKK
+rbw
+cqt
 cqt
 rbw
 rbw
 wLo
 rbw
-coD
-oQI
+flf
+cpx
 cpx
 fSq
-cpx
+cPa
 cpx
 jfE
 ycs
@@ -96953,47 +97716,47 @@ aeu
 aeu
 amA
 amA
-amR
+csr
 amR
 qMJ
 yjz
 gur
 jOI
 amA
+nyM
 amR
-amA
-amA
-amR
-amA
+eWk
+pHz
+pZd
 amA
 aeu
-aDU
-aaa
-aaa
-aaa
-aoe
-aeu
 amA
-knN
-mvi
-bCB
-amA
+suu
+bDC
+jmk
+ahV
+ahV
+csr
+csr
+csr
+amz
+ahV
 hoZ
 jBp
-amR
+iWH
 pTY
-qRu
+pZV
 kki
-rUR
-mKK
+cqt
+hXR
 bmU
-cqI
+rbw
 jaA
-afm
-bVx
-hKh
-bmQ
-fhl
+rbw
+nUO
+nPM
+cam
+fag
 qFC
 xdX
 fVr
@@ -97224,31 +97987,31 @@ vnq
 sHb
 rdO
 aeu
+amR
+uSa
+eMw
+peP
 cqs
-aaa
-aaa
-aaa
-cqs
-aeu
 amA
+bkt
 anD
-mGX
-tRg
-amR
-cnL
+bEx
+qEO
+amA
+pfT
 cBh
-amR
-mKK
-cou
-mKK
+cqt
+rbw
+hsA
+rbw
 iWH
-cou
+sse
 crp
 qFu
 mlF
 jWU
-mnc
-hKh
+nUO
+pPT
 xOv
 mZV
 czR
@@ -97475,39 +98238,39 @@ ejk
 kUP
 amA
 nBC
-bxp
+amA
 jGI
 dJI
 eff
 amA
 aeu
-aUG
-aaa
-aaa
-aaa
+amA
+cxp
+bDi
+bFD
 cRb
-aeu
-amA
+bLq
+wic
+pMK
+sLU
+bPG
 amR
-ohD
-amA
-amA
 bMm
-vee
-amA
-jWm
-asC
-eZR
+vBT
+tvd
+tvd
+tvd
+tvd
 tvd
 vBT
 qJj
 xMG
 qaG
 gLe
-atG
-hKh
-eJQ
-mZV
+flf
+hmh
+xXA
+lzl
 bLH
 flf
 lvo
@@ -97738,33 +98501,33 @@ rmx
 sbR
 amR
 amA
-amA
-aaa
-cOd
-aaa
 amR
 amA
+cOd
+vQN
 amA
+amA
+xlh
 mWo
 kNH
 ujD
 cpT
 fal
-bfb
-amA
-dac
-rhZ
+vBT
+cvq
+cvq
+cvq
 cvq
 gVT
-mKK
-mKK
+sWR
+vGO
 cqL
 xkx
 bZX
 bVB
-hKh
-bJz
-mZV
+xXA
+cam
+lzl
 rBi
 cGD
 cSZ
@@ -97988,41 +98751,41 @@ amR
 amA
 amA
 amA
-qHd
+tAP
 sjZ
 aTP
 lLY
 aUi
-bQg
+mut
 qHd
 amA
-csr
-crx
-csr
+knN
+mvi
+bCB
 amA
 ydd
-nxi
-tof
+ujD
 amA
-tLz
-amR
-cpX
+amA
+amA
+amA
+hEm
 beO
-amA
-cou
-mKK
-mKK
-gVT
+osY
+miS
+osY
+fUM
+osY
 qRu
 cou
-mKK
+qRT
 lQG
 mKK
-cou
-hKh
-eXA
-cam
-rBi
+flf
+xCI
+xXA
+dXV
+mUO
 bNH
 hVb
 wHU
@@ -98252,34 +99015,34 @@ ahV
 ahV
 ahV
 bQg
-amR
+amA
 kbG
-bmt
-cGH
-amA
+mGX
+tRg
 amR
-dOZ
-amA
+amR
+ujD
+cqS
 bzX
 ryM
-amA
-amA
-beO
-cqC
+amR
+bKy
+uRD
+osY
 cuy
-cou
-xsR
-qvb
-rkz
-cqD
-mKK
-vRA
-cul
-mKK
+ien
+bRJ
+miS
+miS
+osY
+osY
+miS
+miS
 hKh
-bth
-cam
-rBi
+fqx
+xXA
+xXA
+cjd
 oEx
 cIp
 cIL
@@ -98510,30 +99273,30 @@ voc
 amz
 wFO
 amA
-csr
-hWX
-csr
 amR
+ohD
+amA
+amA
 nXe
-iJP
-amR
+ujD
+amA
 cum
 rLU
-bIR
-amR
+amA
+gMz
 bdo
-bdo
+miS
 bgi
 cqd
 bpP
-cqq
-qRu
-ezv
+osY
+bxC
+aky
 gNR
 aky
 cuE
-hKh
-hKh
+sQX
+gMb
 mQh
 olb
 nmp
@@ -98765,7 +99528,7 @@ tFy
 wyV
 sEI
 ahV
-bQg
+mxV
 amR
 bop
 bmJ
@@ -98777,24 +99540,24 @@ amA
 amA
 amR
 amA
-amA
-amR
-amA
-amA
-mKK
+sFx
+fnQ
+osY
+osY
+miS
 cql
-cou
+osY
 rkz
-nev
-cou
+aky
+uaZ
 keP
 cuF
 hKh
 ana
-cam
-cam
+jKu
+aqI
 fhl
-flf
+nUO
 acK
 acK
 acK
@@ -99022,39 +99785,39 @@ cMe
 lxH
 qwV
 ahV
-qHd
+wkV
 amA
 bos
-crP
-cBh
-ohr
+jHP
+lrk
+lTU
 cpX
 beX
 cnL
 amA
 jIQ
-gQR
-gQR
+wow
+dMQ
 qci
 gQR
 uOW
-cou
+miS
 xtk
-ooM
-cqr
-mKK
-mKK
-mKK
-mKK
-hKh
+osY
+miS
+osY
+wUS
+osY
+miS
+sQX
 hKh
 hKh
 cEY
 kRH
-sQX
-cyN
-cyN
-sQX
+jLv
+dSQ
+dSQ
+xaz
 acm
 acm
 aeo
@@ -99279,12 +100042,12 @@ cvz
 cvz
 mXn
 amz
-wFO
+crV
 amA
 amA
-cqT
-dmB
+amR
 amA
+mYE
 amA
 mtp
 crP
@@ -99296,26 +100059,26 @@ oKO
 lZI
 eMl
 scJ
-xtk
-fje
-cuw
-dTv
-dTv
-dTv
-dTv
+oCT
+hrj
+gku
+mpc
+txo
+nAQ
+mEu
 dTv
 kjL
-dop
+sTQ
 evL
 tzJ
-sQX
+xaz
 dNT
-nnN
-sQX
-sQX
-sQX
+yls
+jLv
+jLv
+jLv
 lza
-sQX
+xaz
 aeU
 aeu
 aeu
@@ -99537,42 +100300,42 @@ cvz
 tnS
 ahV
 kkp
-bko
+wrV
+aii
 amA
-gMj
 vFo
 boM
 bpc
-amA
-amR
-amA
+hBN
+wEn
+hBN
 ich
 kPB
 ich
 ich
 kPB
 ich
-mKK
-cou
-mKK
+hBN
+wEn
+hBN
 nlV
 ikv
-htK
+fjl
 kGg
 htK
 htK
 xzE
 poT
 cTl
-tzJ
+pPk
 nhB
-nnN
-nnN
+kTb
+swL
 lbY
 oQq
 nnN
-cyN
-cmU
+vAK
+nwU
 aeU
 aeU
 aeu
@@ -99795,12 +100558,12 @@ bdl
 beN
 wWo
 wLF
-vbK
+hFM
 hFM
 rPI
 crV
-crP
-amA
+moO
+hBN
 bJv
 bJv
 bJv
@@ -99811,24 +100574,24 @@ bJv
 bJv
 bJv
 bJv
-mKK
+hBN
 cFR
 cuw
-htK
-xad
-adf
-cou
-swn
-hKh
+miS
+osY
+cyN
+miS
+miS
+sQX
 cEY
 kRH
-sQX
+xaz
 qgh
-bRJ
-sTQ
+wGd
+veF
 mNe
 mNe
-cyN
+dSQ
 cmU
 aeU
 coy
@@ -100052,12 +100815,12 @@ crv
 ahV
 amA
 pyF
-cpX
+amA
 amA
 jdj
+wai
 amR
-bxq
-amA
+hBN
 bJv
 bJv
 bJv
@@ -100068,24 +100831,24 @@ bJv
 bJv
 bJv
 bJv
-cou
+wEn
 bJX
-ikv
-htK
-xad
-cnQ
+toH
+osY
+fwl
+ezt
 coE
 flf
 abp
 mSv
 hIk
-osY
-miS
+nff
+vRI
 iPQ
 dnf
-miS
-miS
-osY
+vRI
+vRI
+nff
 cmU
 cmU
 dKE
@@ -100288,9 +101051,9 @@ aeU
 aeu
 aeu
 aeu
-aeu
-aeu
+amR
 amA
+amR
 amA
 amA
 hHe
@@ -100307,14 +101070,14 @@ cMe
 cvz
 crv
 ahV
-yil
+sGk
 laA
 wRx
-lcd
-crP
+amA
+giG
 crP
 qcT
-amR
+wEn
 bJv
 bJv
 omO
@@ -100325,12 +101088,12 @@ bJv
 bJv
 bJv
 bJv
-mKK
+hBN
 inZ
 hEM
-cou
-aeu
-acW
+miS
+fwl
+tUS
 xad
 xdX
 ame
@@ -100545,11 +101308,11 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
-amR
-vpk
+amA
+onW
+hZi
+kyL
+goH
 tSE
 ahV
 vUt
@@ -100569,9 +101332,9 @@ vbP
 amR
 amA
 iUR
-crP
-qcT
-amA
+asX
+iNo
+hBN
 bJv
 bJv
 bJv
@@ -100582,13 +101345,13 @@ bJv
 bJv
 bJv
 bJv
-mKK
+hBN
 xCm
-cou
-mKK
-aeu
-aeu
-xad
+miS
+osY
+fwl
+fwl
+ezt
 xdX
 bNj
 bYr
@@ -100802,11 +101565,11 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
 amA
-oys
+eJt
+dRq
+bld
+crP
 pUp
 ahV
 xTX
@@ -100827,8 +101590,8 @@ cCR
 amA
 csr
 csr
-amA
-amA
+csr
+hBN
 bJv
 bJv
 bJv
@@ -100839,13 +101602,13 @@ omO
 bJv
 bJv
 bJv
-cou
+wEn
 ikv
 bCt
 sQW
-aeu
-add
-cnQ
+fwl
+kzF
+xad
 nUO
 abp
 cet
@@ -101059,14 +101822,14 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
 amA
-cwy
+amR
+amA
+amA
+amA
 xQt
-vEl
-vEl
+ahV
+ahV
 gOH
 cMl
 uvb
@@ -101082,7 +101845,7 @@ cAv
 rJf
 csk
 cyb
-aaO
+nTq
 ecF
 kLy
 ich
@@ -101096,14 +101859,14 @@ bJv
 bJv
 bJv
 bJv
-rbw
-ikv
+ich
+aGE
 rsn
-htK
-xad
-aDQ
+cyN
+ezt
+cvH
 cBD
-fxh
+flf
 bRD
 coH
 fuy
@@ -101339,7 +102102,7 @@ brF
 iJZ
 csk
 cyb
-rWg
+oMB
 ecF
 gtd
 ich
@@ -101353,13 +102116,13 @@ bJv
 bJv
 bJv
 bJv
-rbw
-ikv
+ich
+aGE
 cyL
-htK
-xad
+cyN
+ezt
 cnM
-xad
+ezt
 xdX
 cdT
 ceu
@@ -101610,13 +102373,13 @@ bJv
 bJv
 bJv
 bJv
-rbw
-inZ
+ich
+odB
 kPE
-htK
+cyN
+ezt
 xad
-cnQ
-aeu
+fwl
 nUO
 uoN
 cig
@@ -101843,7 +102606,7 @@ wLp
 raL
 cvE
 ahV
-lTU
+tof
 cCO
 fck
 mfY
@@ -101852,7 +102615,7 @@ amA
 sDs
 hdX
 csl
-cyb
+amA
 mzt
 ecF
 vdK
@@ -101867,13 +102630,13 @@ bJv
 bJv
 bJv
 bJv
-cou
-ikv
+wEn
+aGE
 bDn
-mKK
-aeu
+osY
+fwl
 cnR
-aeu
+fwl
 flf
 pWK
 cwH
@@ -102110,11 +102873,11 @@ amR
 amA
 amA
 amA
-csr
-csr
-amA
-amA
-amA
+oAo
+ecF
+dHb
+hBN
+hBN
 ich
 ich
 waA
@@ -102123,14 +102886,14 @@ ich
 waA
 ich
 ich
-mKK
-mKK
+hBN
+hBN
 llt
-mKK
-mKK
-aeu
+osY
+osY
+fwl
 cog
-cBN
+coE
 flf
 bWr
 hRZ
@@ -102150,7 +102913,7 @@ crc
 cgi
 ctn
 ctU
-aLu
+dMa
 ajd
 aeu
 aeu
@@ -102364,14 +103127,14 @@ nJS
 tiX
 ksR
 skO
+crP
 rbF
 amA
-wrV
-wrV
-wrV
-wrV
-wrV
-amA
+cOn
+cOn
+cOn
+epS
+epS
 jyL
 dEO
 nzm
@@ -102380,16 +103143,16 @@ wtq
 nzm
 vGa
 uXa
-mKK
+osY
 bKN
 ikv
 bEk
-cou
-aeu
-aeu
+miS
+fwl
+fwl
 cBD
-add
-hKh
+kzF
+sQX
 fKw
 tbB
 ajx
@@ -102554,9 +103317,9 @@ aeu
 aeu
 aeu
 aeu
-aeU
-aeU
-aeU
+cmU
+cmU
+cmU
 aaa
 aaa
 xdy
@@ -102620,15 +103383,15 @@ amA
 lkk
 amA
 amA
-asg
+xYn
+beX
 szD
 amA
-wrV
-wrV
-wrV
-wrV
-wrV
-amA
+eyO
+aJz
+aJz
+kPO
+epS
 xTu
 gNO
 veJ
@@ -102637,16 +103400,16 @@ uaJ
 vdd
 faV
 vpg
-mKK
-cou
-inZ
+osY
+miS
+odB
 eJC
-mKK
-mKK
-cou
-htK
-mKK
-mKK
+osY
+osY
+miS
+cyN
+osY
+osY
 jmf
 kAX
 iPo
@@ -102878,14 +103641,14 @@ nxa
 xHq
 amA
 asg
-fhu
-csr
-wrV
-wrV
-wrV
-wrV
-wrV
-csr
+asX
+beX
+cnJ
+xeI
+xeI
+xeI
+hUE
+cOn
 jzS
 iNC
 mXt
@@ -102894,9 +103657,9 @@ pNx
 vmb
 kGr
 cfH
-mKK
-ioK
-cuw
+osY
+wGu
+gku
 bUq
 brJ
 vwn
@@ -103134,13 +103897,13 @@ euH
 uBI
 tfS
 amR
-asg
-jwZ
+vKK
+cnL
+edM
 amA
-wrV
-wrV
-wrV
-wrV
+siP
+oUk
+oUk
 eRj
 ois
 hcO
@@ -103155,12 +103918,12 @@ bNo
 bOp
 gOB
 lJH
-mKK
-tqo
+osY
+fje
 bZY
 uaZ
 rMX
-hKh
+sQX
 plq
 feu
 ajx
@@ -103393,13 +104156,13 @@ aPW
 amA
 nMI
 csi
-csr
-wrV
-wrV
-wrV
-wrV
-wrV
-csr
+llh
+amA
+tJn
+lwU
+lwU
+cWQ
+cOn
 fxH
 ney
 vqR
@@ -103408,16 +104171,16 @@ hWZ
 sbG
 lEI
 hfQ
-mKK
+osY
 afm
 szW
 akh
-rHo
 hKh
+sQX
+sQX
+sQX
 hKh
-hKh
-rHo
-hKh
+sQX
 dZN
 quQ
 ajx
@@ -103651,12 +104414,12 @@ amA
 ist
 amR
 amA
-wrV
-wrV
-wrV
-wrV
-wrV
 amA
+fBx
+sVw
+sVw
+sYp
+epS
 fdS
 iNC
 vnx
@@ -103665,7 +104428,7 @@ ucW
 xaQ
 hDA
 jzZ
-mKK
+osY
 afy
 kRc
 mCS
@@ -103907,13 +104670,13 @@ aOZ
 qsn
 mwd
 eNm
-amA
-wrV
-wrV
-wrV
-wrV
-wrV
-amA
+tpa
+aQN
+cOn
+cOn
+cOn
+epS
+epS
 gvU
 rpq
 edb
@@ -103922,11 +104685,11 @@ ykU
 wBr
 mZB
 jsb
-cou
+miS
 afz
 bRw
-cou
-mKK
+miS
+osY
 cwN
 ddN
 agq
@@ -104163,14 +104926,14 @@ aVC
 aVC
 wYL
 rDL
-tsP
-amA
-amA
-csr
-csr
-csr
-csr
-amA
+mwh
+pWS
+aQN
+acm
+oxC
+acm
+coy
+epS
 xKT
 fZM
 sRc
@@ -104179,11 +104942,11 @@ hjY
 kmj
 tuH
 rOe
-mKK
+osY
 csN
 bRB
 ycI
-mKK
+osY
 wRJ
 wRJ
 wRJ
@@ -104436,9 +105199,9 @@ tfC
 kdG
 uNe
 hBN
-cou
-csS
-cBI
+miS
+kzF
+cvH
 bUv
 szb
 oZs
@@ -104695,7 +105458,7 @@ flj
 hqe
 uzL
 cBv
-cBy
+tUS
 bUv
 szb
 cwR
@@ -104950,11 +105713,11 @@ fJK
 uMr
 fuK
 lSH
-mKK
+osY
 cBw
 csN
 rFD
-mKK
+osY
 wRJ
 kZz
 wRJ
@@ -105464,9 +106227,9 @@ fJK
 ohC
 fuK
 fuK
-mKK
-cBy
-cBI
+osY
+tUS
+cvH
 bUv
 szb
 cwR
@@ -105725,7 +106488,7 @@ kGa
 csN
 cBw
 cPE
-cou
+miS
 wRJ
 wRJ
 wRJ
@@ -105978,9 +106741,9 @@ msd
 eej
 tNZ
 wEY
-mKK
-mKK
-csS
+osY
+osY
+kzF
 bUv
 szb
 fOP
@@ -106494,9 +107257,9 @@ pCB
 efZ
 ppf
 pDX
-csS
+kzF
 uGP
-mKK
+osY
 wRJ
 wRJ
 wRJ
@@ -106750,8 +107513,8 @@ oVx
 tNZ
 tNZ
 tNZ
-cou
-cBI
+miS
+cvH
 bUv
 szb
 sMr
@@ -107265,9 +108028,9 @@ rES
 efZ
 sgm
 cOg
-cBy
+tUS
 jcx
-mKK
+osY
 kZz
 wRJ
 wRJ
@@ -107521,7 +108284,7 @@ tNZ
 wEY
 tNZ
 ykN
-mKK
+osY
 csN
 bUv
 szb
@@ -107778,7 +108541,7 @@ riz
 xNl
 jin
 hQc
-cou
+miS
 cBw
 bUv
 szb
@@ -108035,13 +108798,13 @@ yki
 tNZ
 ymb
 qab
-mKK
+osY
 afz
 kfm
+sQX
 hKh
-rHo
-hKh
-hKh
+sQX
+sQX
 wRJ
 jWS
 xjq
@@ -108292,13 +109055,13 @@ hTZ
 tNZ
 wEY
 tNZ
-mKK
+osY
 bNP
 bVo
 krd
 tsf
 bVq
-hKh
+sQX
 hek
 xAo
 mOD
@@ -108549,13 +109312,13 @@ riz
 qqe
 shg
 coo
-mKK
-mKK
-cou
+osY
+osY
+miS
 afm
 vAQ
 bVt
-rHo
+hKh
 vUn
 rsC
 dwU
@@ -108806,13 +109569,13 @@ gkT
 tNZ
 cKI
 gYB
-cou
+miS
 czP
-cou
+miS
 bEI
 cea
 cyy
-hKh
+sQX
 imD
 xqF
 dmh
@@ -108851,7 +109614,7 @@ utB
 rfJ
 sfI
 vqb
-sfI
+xEN
 sfI
 tcq
 pTf
@@ -109063,13 +109826,13 @@ bCH
 tNZ
 tNZ
 tNZ
-mKK
+osY
 fje
 mKG
 fje
 ptS
-ioK
-hKh
+wGu
+sQX
 lqm
 fqI
 dwU
@@ -109320,13 +110083,13 @@ bCL
 xgx
 bCL
 psj
-mKK
+osY
 atk
-mKK
+osY
 cAb
 vAQ
 uTL
-hKh
+sQX
 tCd
 dhR
 jOf
@@ -109363,14 +110126,14 @@ aaa
 acm
 lbb
 amY
-njj
+iVV
 fxf
 iLk
 kCA
 iMg
 llT
 njj
-tNt
+lAR
 lbb
 aeU
 aeU
@@ -109579,15 +110342,15 @@ aYs
 bIc
 xsr
 bHh
-mKK
-cou
+osY
+miS
 cwO
 gnE
-rHo
 hKh
+sQX
 aVw
-hKh
-hKh
+sQX
+sQX
 bmz
 tRS
 arq
@@ -109626,7 +110389,7 @@ sRp
 oyx
 lYd
 jGy
-kpf
+iDs
 njj
 aFI
 aeu
@@ -109837,14 +110600,14 @@ aYs
 aYs
 bIc
 kBH
-mKK
-mKK
+osY
+osY
 xnR
 fKt
-cou
+miS
 dHC
 bZh
-mKK
+osY
 bpl
 bBr
 cdj
@@ -109877,7 +110640,7 @@ aaa
 qJs
 utB
 qES
-kpf
+iDs
 iLk
 nDy
 szy
@@ -110095,8 +110858,8 @@ bpH
 bHk
 bHI
 oAl
-mKK
-mKK
+osY
+osY
 tER
 cea
 cea
@@ -110141,7 +110904,7 @@ mqF
 hzc
 njj
 iLk
-iLk
+rsJ
 iLk
 aFI
 aeu
@@ -110353,12 +111116,12 @@ aYs
 aYs
 bIc
 bOQ
-mKK
-cou
-mKK
+osY
+miS
+osY
 nzp
 cBm
-mKK
+osY
 bws
 iAy
 iAy
@@ -110391,10 +111154,10 @@ aaa
 acm
 lbb
 kxF
-sIT
+dQn
 sIT
 njj
-njj
+iVV
 nju
 tNt
 sIT
@@ -110611,11 +111374,11 @@ vtp
 aYs
 bOR
 bGg
-mKK
+osY
 bWR
 fje
-mKK
-mKK
+osY
+osY
 izm
 abU
 aci
@@ -110650,10 +111413,10 @@ aFJ
 vbL
 piY
 sIT
-sIT
+dQn
 nju
 njj
-njj
+iVV
 lVA
 nju
 gyE
@@ -110868,10 +111631,10 @@ uNB
 xyM
 bOT
 bRb
-mKK
-cou
+osY
+miS
 bNF
-mKK
+osY
 eiB
 jfJ
 rRF
@@ -110909,7 +111672,7 @@ oGc
 vSH
 njj
 njj
-njj
+iVV
 njj
 tcG
 nju
@@ -111110,7 +111873,7 @@ cnc
 cjG
 unh
 ghP
-hCn
+vYG
 aWe
 izJ
 kdP
@@ -111166,10 +111929,10 @@ tNt
 svX
 svX
 svX
-pXb
+jyQ
 pXb
 tvC
-iLk
+rsJ
 ujW
 bKO
 aFO
@@ -111911,7 +112674,7 @@ cpN
 csp
 bFa
 lwO
-bGG
+icU
 bET
 idD
 lHG
@@ -112877,7 +113640,7 @@ vxg
 osF
 aqm
 aqs
-kAm
+aPZ
 dHI
 cBf
 mpG
@@ -113966,7 +114729,7 @@ bHm
 bFa
 bOB
 bFa
-wwV
+reb
 ljT
 ira
 kgn
@@ -114445,7 +115208,7 @@ rnF
 sRn
 lSc
 aeU
-paZ
+oRc
 bUE
 kmK
 tPZ
@@ -117015,7 +117778,7 @@ aLX
 dWL
 lSc
 xbG
-paZ
+aqg
 cmU
 bPK
 tPZ
@@ -117247,7 +118010,7 @@ xsU
 aoI
 atl
 atl
-atl
+rnL
 kTx
 cFT
 aXW
@@ -119331,7 +120094,7 @@ jFn
 deT
 uuQ
 rJz
-hZG
+xUY
 hUq
 jyV
 muW
@@ -120102,7 +120865,7 @@ mgL
 vxV
 vLb
 oUO
-rJz
+iOU
 nqD
 gSP
 bAQ
@@ -121131,7 +121894,7 @@ wIJ
 oFH
 qMc
 ljM
-rJz
+iOU
 ely
 hUq
 oYi
@@ -121349,14 +122112,14 @@ pwz
 elW
 ixZ
 mNf
-ghs
+pXu
 ixZ
 ghs
 yko
-ghs
+pXu
 wGn
 mNf
-aoO
+jyR
 lpT
 lpT
 iTj
@@ -122127,7 +122890,7 @@ ayv
 bhu
 iTj
 dab
-aoO
+jyR
 lpT
 aWV
 aXb
@@ -123216,7 +123979,7 @@ bEg
 ckY
 mlE
 bSI
-bGr
+uoZ
 bGr
 bEg
 tON
@@ -123438,7 +124201,7 @@ aZo
 bev
 thz
 eoB
-bjs
+lee
 iod
 ctz
 cXH
@@ -123471,7 +124234,7 @@ qZi
 mtP
 ckC
 dzk
-vDB
+hFw
 dzk
 wpH
 bSI
@@ -123670,7 +124433,7 @@ cHF
 aeQ
 ads
 tYM
-xhX
+aWY
 iRb
 rlr
 auJ
@@ -123737,7 +124500,7 @@ gmW
 vDB
 jAE
 grD
-iBe
+qFd
 uuH
 sSF
 iBe
@@ -123927,7 +124690,7 @@ alR
 kuB
 cMF
 nSm
-guv
+kuB
 kuB
 aZF
 auO
@@ -124196,7 +124959,7 @@ vlS
 vlS
 vlS
 vlS
-njW
+eOM
 bbl
 wJd
 bgj
@@ -124269,7 +125032,7 @@ bEg
 bOb
 vRC
 gSi
-gSi
+uQt
 mKE
 ilE
 krA
@@ -124722,7 +125485,7 @@ hYj
 bkd
 bdz
 aim
-aim
+wnx
 bkd
 oHM
 leq
@@ -124953,7 +125716,7 @@ bfq
 uaH
 bft
 kuB
-aim
+wnx
 bkd
 ykB
 kuB
@@ -125713,18 +126476,18 @@ aeu
 aeu
 bkd
 abi
-cLg
+lOT
 wzn
 bEq
 ePc
-aim
+wnx
 kqQ
 hae
 aim
 aim
 wFD
 hae
-hae
+iFG
 apu
 txm
 arJ
@@ -125749,7 +126512,7 @@ wbL
 beJ
 kGY
 kuB
-bjs
+lee
 wuI
 bkd
 kOi
@@ -125971,7 +126734,7 @@ bkd
 ava
 bkd
 agb
-bjs
+lee
 agD
 aim
 hae
@@ -125983,12 +126746,12 @@ hIT
 fsW
 eUc
 ctI
-hyK
+ayp
 xxH
 bkd
 jdN
 alT
-hae
+ujF
 ayj
 rGo
 aXA
@@ -126482,7 +127245,7 @@ aaa
 aaa
 bFQ
 cLd
-btR
+eqY
 lqi
 agg
 abt
@@ -126760,7 +127523,7 @@ cNE
 cNO
 cNR
 aim
-ayp
+qth
 rGo
 tlV
 bbS
@@ -127292,7 +128055,7 @@ hqK
 hqK
 kuB
 kuB
-aim
+wnx
 vIt
 loE
 nxZ
@@ -128557,7 +129320,7 @@ muA
 kEu
 ily
 kuB
-aim
+wnx
 hae
 hae
 hae
@@ -128577,7 +129340,7 @@ uOG
 vnQ
 kuB
 aim
-aim
+wnx
 bkd
 qJs
 gNE
@@ -128821,7 +129584,7 @@ iQm
 xJo
 bjs
 agD
-aim
+wnx
 hae
 oKy
 dKu
@@ -129082,7 +129845,7 @@ cmy
 aKl
 cOv
 ava
-wEq
+eZx
 xXa
 qav
 qlH
@@ -129090,7 +129853,7 @@ pbw
 pgB
 dHO
 rGo
-hae
+ujF
 gUF
 aaa
 aaa
@@ -129853,7 +130616,7 @@ gUF
 qgy
 gUF
 bkd
-wEq
+eZx
 kuB
 aUZ
 ksx
@@ -130368,14 +131131,14 @@ aaa
 aaa
 bhq
 wEq
-wEq
+eZx
 xRa
 tEz
 iTI
 jOW
 pSE
 djz
-hae
+ujF
 ava
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1072,6 +1072,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "afr" = (
@@ -1086,7 +1087,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/scientist,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -1321,6 +1321,7 @@
 /area/station/maintenance/starboard)
 "agl" = (
 /obj/machinery/smartfridge,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "agm" = (
@@ -1905,12 +1906,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aiN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "aiO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -2002,7 +2002,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/landmark/start/scientist,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -2395,23 +2394,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"ale" = (
-/turf/open/floor/iron/stairs/old,
-/area/station/maintenance/port/fore)
 "alf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "alg" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "all" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -2722,6 +2715,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "amg" = (
@@ -2738,15 +2732,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "amh" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aml" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -2914,13 +2906,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ang" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "anh" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3050,19 +3041,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "anX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "anY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -3460,15 +3445,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/aft)
 "aqh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "aqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3589,16 +3571,16 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aqR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Coroner's Office"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
+/area/station/medical/morgue)
 "aqT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -5190,6 +5172,14 @@
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ayS" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "ayU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5255,11 +5245,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/sink/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "azi" = (
@@ -5409,6 +5399,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aAc" = (
@@ -6399,8 +6390,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7646,6 +7635,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aOh" = (
@@ -7790,6 +7781,8 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "aOK" = (
@@ -7802,7 +7795,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "aOO" = (
@@ -7836,6 +7830,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aOY" = (
@@ -8902,6 +8898,27 @@
 "aTx" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery/aft)
+"aTy" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "aTF" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -9271,8 +9288,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
@@ -9512,17 +9527,21 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aWw" = (
-/obj/structure/table,
-/obj/machinery/computer/records/medical/laptop,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/paper/guides/jobs/medical/morgue,
+/obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aWx" = (
@@ -9824,6 +9843,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/ordnance_tech,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "aYd" = (
@@ -11390,6 +11410,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "beV" = (
@@ -11768,6 +11789,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bha" = (
@@ -12282,7 +12304,8 @@
 /area/station/maintenance/port/greater)
 "bmx" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/misc/asteroid/airless,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "bmz" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -12491,6 +12514,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
+"bof" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "bon" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13445,6 +13474,14 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"bxy" = (
+/obj/item/trash/candy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "bxD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -13594,6 +13631,7 @@
 "byx" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/transit_tube/crossing,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "byA" = (
@@ -14029,6 +14067,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/bridge_officer,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bAz" = (
@@ -14388,15 +14427,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "bCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/meter/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bCL" = (
@@ -16986,6 +17022,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"bUa" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/coin/twoheaded,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "bUb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -19456,10 +19505,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20489,6 +20534,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Hallway"
 	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "cjD" = (
@@ -20836,6 +20882,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"clr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "clt" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/delivery,
@@ -20952,11 +21003,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cmm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cmo" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -21952,26 +22003,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/medical)
-"crB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/coin/twoheaded{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
 "crG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
@@ -22677,11 +22708,11 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/port/fore)
 "cwp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/fancy/candle_box,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/mannequin/skeleton,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cwq" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/fore)
@@ -22762,13 +22793,13 @@
 /area/station/medical/chemistry)
 "cwQ" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "cwR" = (
@@ -23203,22 +23234,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"cyH" = (
-/obj/structure/sign/warning/electric_shock/directional/north,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/port/fore)
 "cyI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen/directional/south{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/landmark/blobstart,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/light/dim/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard/directional/north,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cyJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23252,68 +23281,39 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
-"cyR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
-"cyS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
 "cyT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/light/small/directional/east,
+/obj/structure/table/wood,
+/obj/item/clipboard{
+	pixel_x = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/item/stack/spacecash/c50{
+	pixel_y = 8
+	},
+/obj/item/stack/spacecash/c50,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
-"cyU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "cyX" = (
+/obj/structure/closet{
+	name = "chapel locker"
+	},
+/obj/item/clothing/shoes/sandal,
+/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/assist,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/punch_shit/directional/east,
-/turf/open/floor/iron/dark,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cyY" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -23448,20 +23448,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "czu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/pen,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "czv" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -23604,18 +23592,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "czL" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
+/area/station/medical/morgue)
 "czP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -23668,6 +23652,7 @@
 "cAs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
+/obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cAv" = (
@@ -24730,6 +24715,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"cIg" = (
+/obj/structure/transit_tube/crossing,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cIi" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/sign/plaques/kiddie/library{
@@ -25150,6 +25141,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
+"cLe" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/toy/plush/lizard_plushie/green{
+	name = "Embraces-Nostalgia"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "cLg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -25902,8 +25900,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/effect/landmark/blobstart,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -26724,6 +26720,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"djv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/camera/directional/north{
+	c_tag = "Secure Morgue";
+	name = "medical camera";
+	network = list("ss13","medical")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/requests_console/directional/north{
+	name = "Morgue Requests Console";
+	department = "Medical"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "djz" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Mass Driver Intersection"
@@ -26891,6 +26905,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
+"dmR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/station/hallway/primary/fore)
 "dnf" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -28185,7 +28203,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -28426,6 +28443,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
+"dQz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "dQJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -29314,6 +29337,14 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
+"eiF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "eiK" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -29917,6 +29948,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "esi" = (
@@ -30351,8 +30383,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -30735,6 +30765,7 @@
 "eIR" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
+/mob/living/basic/syndicate/russian,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "eJz" = (
@@ -30885,7 +30916,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "eLX" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -30894,6 +30924,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/deepfryer,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "eMc" = (
@@ -31319,6 +31350,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"eSv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "eSG" = (
 /obj/machinery/computer/mecha{
 	dir = 1
@@ -31789,6 +31828,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"eZJ" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/closed/wall,
+/area/space/nearstation)
 "eZM" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/service/chapel/storage)
@@ -31982,6 +32025,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
+"ffr" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ffO" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -32403,6 +32450,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"fnc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "fnj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -32696,6 +32759,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"fro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/coin/twoheaded{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "frw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33215,6 +33299,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
+"fBG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "fBN" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/blue,
@@ -33240,13 +33328,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/construction/mining/aux_base)
-"fBZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "fCd" = (
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
@@ -33372,14 +33453,10 @@
 "fDL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fDR" = (
@@ -33424,20 +33501,14 @@
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
 "fEB" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/steam_vent,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "fEH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/xeno_mining/directional/north,
@@ -33538,13 +33609,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "fFH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	name = "chapel locker"
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
 	},
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/bot_white,
+/obj/item/toy/figure/coroner,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "fFQ" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -34112,6 +34185,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/hallway)
+"fRF" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "fRH" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -34818,7 +34903,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -35286,6 +35370,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"gsT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "gsY" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -35338,6 +35432,7 @@
 	name = "Morgue"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gtL" = (
@@ -36073,16 +36168,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gGG" = (
-/obj/structure/closet{
-	name = "chapel locker"
-	},
-/obj/item/storage/backpack/cultpack{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/under/color/black,
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/reagent_containers/cup/beaker,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gHj" = (
@@ -36933,6 +37023,7 @@
 /obj/structure/transit_tube/crossing,
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "gWN" = (
@@ -36999,6 +37090,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/storage/art)
+"gYl" = (
+/obj/structure/transit_tube,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gYq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -37235,13 +37332,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hcl" = (
@@ -37303,6 +37400,7 @@
 /obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/fore)
 "hdc" = (
@@ -37732,7 +37830,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "hlc" = (
@@ -38293,6 +38393,8 @@
 	cycle_id = "chem-passthrough"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "hyj" = (
@@ -39009,6 +39111,7 @@
 "hMl" = (
 /obj/machinery/smartfridge,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "hMn" = (
@@ -39045,7 +39148,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/west,
+/obj/structure/item_dispenser/bodybag{
+	pixel_x = -29
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hMK" = (
@@ -40330,9 +40435,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/noticeboard/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/smartfridge/organ,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ilq" = (
@@ -41443,12 +41548,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iFv" = (
@@ -41731,10 +41831,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iJq" = (
@@ -41759,6 +41857,7 @@
 	dir = 1
 	},
 /obj/structure/chair/office/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "iJP" = (
@@ -42370,6 +42469,20 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"iTR" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "iTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43803,6 +43916,25 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
+"jui" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/contraband/punch_shit/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "jun" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44134,6 +44266,17 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"jBs" = (
+/obj/machinery/computer/slot_machine,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "jBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -44485,6 +44628,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/teleporter)
+"jKp" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "jKx" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
@@ -45384,6 +45540,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"kbO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mopbucket,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "kbZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45442,6 +45604,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"kcS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "kdd" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green{
@@ -46219,6 +46390,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"krq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "krv" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -46297,6 +46478,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"ksL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "ksR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -46862,6 +47052,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"kBs" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/closed/wall,
+/area/station/maintenance/port/fore)
 "kBH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47004,19 +47198,24 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"kDX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "kEg" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/item/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/bodybags{
 	pixel_y = 2
 	},
-/obj/machinery/light/small/directional/east,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -47255,6 +47454,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
+"kID" = (
+/turf/open/floor/iron/stairs/old{
+	dir = 4
+	},
+/area/station/maintenance/port/fore)
 "kII" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47460,7 +47664,8 @@
 "kNc" = (
 /obj/structure/transit_tube,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "kNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -47522,7 +47727,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
@@ -47769,6 +47973,11 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/left/directional/west{
+	name = "Morgue Disposal Chute";
+	req_one_access = list("morgue", "medical")
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kRv" = (
@@ -48415,6 +48624,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "leq" = (
@@ -48715,8 +48925,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "lkk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance"
 	},
@@ -49075,6 +49283,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "lpH" = (
@@ -49285,9 +49496,6 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron/freezer,
@@ -50527,7 +50735,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lSf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -50537,8 +50744,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/paramedic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "lSk" = (
@@ -53423,6 +53632,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"mQU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "mQV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -53438,7 +53656,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -54124,6 +54341,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"ndw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "ndE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54538,6 +54771,14 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
+"nmC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "nnD" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -54697,25 +54938,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
-"nqp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "nqr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54857,8 +55079,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -54870,6 +55090,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"nsY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "nto" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -55041,8 +55268,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
@@ -55193,6 +55418,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"nAs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
+"nAR" = (
+/obj/effect/landmark/start/ordnance_tech,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance)
 "nAW" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/small/directional/north,
@@ -55395,6 +55629,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nEN" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "nER" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55431,6 +55676,13 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/hallway)
+"nFD" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/asset_protection,
+/turf/open/floor/iron,
+/area/station/security/courtroom)
 "nFQ" = (
 /obj/item/canvas/nineteen_nineteen,
 /obj/structure/easel,
@@ -55449,10 +55701,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/service/chapel/office)
 "nHd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood,
+/obj/effect/landmark/blobstart,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "nHf" = (
 /obj/structure/railing,
@@ -55524,16 +55775,17 @@
 	},
 /area/station/ai_monitored/turret_protected/ai_upload)
 "nIy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/coroner,
+/obj/structure/chair/office,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "nIM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -55569,10 +55821,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "nJS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -57432,6 +57682,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "oth" = (
@@ -57609,7 +57860,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "oxa" = (
-/obj/machinery/griddle,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -57618,6 +57868,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "oxC" = (
@@ -58094,13 +58345,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"oEk" = (
+"oEo" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/fore)
+/area/station/maintenance/port/fore)
 "oEt" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -58434,10 +58685,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oJY" = (
@@ -58610,6 +58859,11 @@
 "oOf" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"oOl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "oOR" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 5
@@ -59407,7 +59661,6 @@
 /area/station/engineering/atmos)
 "pdi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -59847,14 +60100,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "pls" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "plP" = (
@@ -60023,7 +60269,6 @@
 /area/station/cargo/sorting)
 "poa" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -60087,7 +60332,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/grille/broken,
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/broken_floor,
@@ -60262,6 +60506,13 @@
 "prS" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
+"psd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "psj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60436,6 +60687,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "puj" = (
@@ -60768,6 +61020,19 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
+"pAL" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/bodybag{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "pAP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -62204,6 +62469,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "qaA" = (
@@ -62566,6 +62832,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -63079,6 +63347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/meter/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qsb" = (
@@ -63091,6 +63360,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qsj" = (
@@ -63241,27 +63511,9 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "quv" = (
-/obj/item/trash/candy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/maintenance/port/fore)
-"quw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "quC" = (
@@ -63481,7 +63733,6 @@
 /area/station/service/bar/atrium)
 "qyv" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -63713,6 +63964,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"qEQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "qES" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64248,6 +64506,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"qLQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/aft)
 "qMa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -64350,9 +64613,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -65582,6 +65844,17 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall/rust,
 /area/station/engineering/atmos)
+"rks" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "rkz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66014,11 +66287,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/camera/directional/north{
-	c_tag = "Morgue";
-	name = "medical camera";
-	network = list("ss13","medical")
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66059,6 +66327,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -67266,13 +67536,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rNH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Hallway"
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "rOe" = (
@@ -67288,6 +67556,20 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"rOJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/garden)
 "rOO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -67323,7 +67605,6 @@
 /area/station/command/heads_quarters/captain)
 "rPu" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67375,6 +67656,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"rQu" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "rQB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -67452,6 +67740,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
+"rSF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "rSK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral{
@@ -68543,7 +68838,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "shg" = (
@@ -68643,11 +68938,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"siT" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/fore)
 "sjJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68898,19 +69188,20 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "soP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/sink/kitchen/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"spa" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "Emergency Research Blast Door"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "spr" = (
 /obj/structure/chair/sofa/left/brown{
 	color = "#c45c57";
@@ -69203,9 +69494,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -69263,6 +69553,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"sxH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "sxI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -69291,6 +69592,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"sxV" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/musician,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "syg" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -69976,9 +70287,7 @@
 /area/station/engineering/storage_shared)
 "sLw" = (
 /obj/structure/transit_tube/crossing,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "sLz" = (
@@ -70021,6 +70330,8 @@
 	dir = 10
 	},
 /mob/living/simple_animal/bot/cleanbot/medbay,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "sMk" = (
@@ -70191,12 +70502,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "sQA" = (
@@ -70425,7 +70736,6 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -70781,13 +71091,6 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
-"tbR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "tbU" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -71143,6 +71446,24 @@
 /obj/structure/sign/warning/engine_safety,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"tjj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "tjl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -71228,13 +71549,10 @@
 /turf/closed/wall/rust,
 /area/station/science/xenobiology)
 "tky" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "tkH" = (
@@ -71546,20 +71864,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
-"tpU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
 "tqo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72595,17 +72899,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tJb" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/paper/guides/jobs/medical/morgue,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/pen,
-/obj/machinery/light/small/directional/south,
+/obj/structure/sink/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tJc" = (
@@ -72799,24 +73099,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"tMj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
 "tMH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -73494,9 +73776,6 @@
 	},
 /area/station/hallway/primary/central/fore)
 "tXA" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -73506,6 +73785,9 @@
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/directional/north,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "tXD" = (
@@ -73954,19 +74236,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/security/brig)
-"ufc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/hallway/primary/fore)
 "ufi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -74105,8 +74374,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -74546,16 +74815,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
-"uqW" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "urc" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/stripes/corner,
@@ -74580,7 +74839,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "usk" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -74589,19 +74847,21 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/random/directional/north,
+/obj/machinery/griddle,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "usm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "usn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -75110,8 +75370,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -75951,21 +76209,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"uSo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "uSp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance"
@@ -76075,6 +76318,18 @@
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"uVQ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet{
+	name = "chapel locker"
+	},
+/obj/item/clothing/under/color/black,
+/obj/item/storage/backpack/cultpack{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "uWd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76216,6 +76471,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
+"uZQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "uZY" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -76360,6 +76632,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Hallway"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "vce" = (
@@ -76445,6 +76720,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"vdh" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "vdu" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
@@ -76791,6 +77070,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"vjx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "vjy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -76851,6 +77138,11 @@
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"vll" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "vlM" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
@@ -76937,6 +77229,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
+"vmL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "vmU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -77117,6 +77416,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"vpc" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "vpg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -77165,17 +77472,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "vqk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "vqR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -77219,10 +77523,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Morgue";
+	name = "medical camera";
+	network = list("ss13","medical")
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vsY" = (
@@ -77946,6 +78255,8 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vEj" = (
@@ -78086,6 +78397,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"vGb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/assist,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/fore)
 "vGl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -78665,6 +78992,13 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"vSi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "vSu" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
@@ -78857,6 +79191,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"vVS" = (
+/obj/structure/transit_tube,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "vVX" = (
@@ -79279,6 +79621,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
+"wff" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "wfg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -79335,7 +79687,6 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -79596,22 +79947,6 @@
 /obj/item/toy/figure/hos,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
-"wkw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "wkB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -79685,6 +80020,19 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
+"wlU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "wlV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -79703,30 +80051,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
-"wmi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/obj/structure/table/wood,
-/obj/item/clipboard{
-	pixel_x = 4
-	},
-/obj/item/stack/spacecash/c50{
-	pixel_y = 8
-	},
-/obj/item/stack/spacecash/c50,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/fore)
 "wmz" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Supply Door Airlock"
@@ -79788,8 +80112,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "wnR" = (
@@ -79910,7 +80236,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -80384,6 +80709,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "wCe" = (
@@ -80454,7 +80780,6 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/primary/fore)
 "wCs" = (
@@ -81155,6 +81480,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "wOF" = (
@@ -81566,7 +81892,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wVJ" = (
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -81619,7 +81944,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "wWn" = (
-/obj/machinery/oven,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -81627,6 +81951,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "wWo" = (
@@ -81684,6 +82009,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Hallway"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "wWN" = (
@@ -81783,9 +82110,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "wXY" = (
-/obj/structure/sign/departments/holy,
-/turf/closed/wall,
-/area/station/maintenance/port/fore)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/morgue)
 "wYz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -82335,6 +82662,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"xjQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/closet_private,
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "xjT" = (
 /obj/machinery/flasher/directional/west{
 	id = "AI";
@@ -83246,13 +83580,16 @@
 	network = list("ss13","medical")
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/item_dispenser/latex{
+	pixel_y = 30;
+	pixel_x = -5
+	},
+/obj/structure/item_dispenser/mask{
+	pixel_y = 30;
+	pixel_x = 7
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
-"xyi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "xyJ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -83562,6 +83899,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"xCu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "xCv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -83683,6 +84030,16 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
+"xFR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/port/fore)
 "xFU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -83750,6 +84107,12 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/security/prison/safe)
+"xHj" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "xHo" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -83825,22 +84188,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "xIH" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/bodybag{
-	pixel_y = 5
-	},
-/obj/item/shovel,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/dark,
+/obj/item/storage/fancy/candle_box,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xIW" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -85221,8 +85572,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Hallway"
@@ -85368,17 +85717,11 @@
 /turf/closed/wall/rust,
 /area/station/service/chapel/storage)
 "ylI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ylV" = (
@@ -101986,8 +102329,8 @@ aPt
 aPt
 aPt
 rDD
+rDD
 uLE
-aeu
 aeu
 aeu
 aeu
@@ -102242,9 +102585,9 @@ aaa
 aaa
 aaa
 acm
-cmU
+aaa
+aeU
 sks
-aeu
 aeu
 aeu
 aeu
@@ -102500,8 +102843,8 @@ aaa
 aaa
 acm
 aaa
+aeU
 sks
-aeu
 aeu
 aeu
 aeu
@@ -102757,8 +103100,8 @@ acm
 acm
 acK
 acm
+eZJ
 sks
-aeU
 aeu
 aeu
 aeu
@@ -103013,14 +103356,14 @@ aaa
 aaa
 aaa
 acm
-aaa
-sks
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+anH
+eZJ
+kDX
+anH
+anH
+vdh
+anH
+anH
 cwy
 aol
 ade
@@ -103269,15 +103612,15 @@ aaa
 aaa
 aaa
 aaa
-acm
-aeU
-sks
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+cwy
+cwq
+alc
+ndw
+cyY
+cWg
+czj
+cvg
+cwq
 cwy
 vyI
 cxa
@@ -103526,15 +103869,15 @@ aaa
 aaa
 aaa
 aaa
-cmU
-aeU
-sks
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+cwy
+jhL
+aRi
+fnc
+cyZ
+czl
+czk
+cvk
+sGL
 cwq
 tFL
 cxb
@@ -103782,16 +104125,16 @@ acm
 aaa
 aaa
 aaa
-aaa
-aUz
-aeU
-sks
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+fBG
+cwy
+vll
+aTT
+aTy
+bES
+sRz
+czx
+ajI
+gai
 cwy
 cvX
 cwT
@@ -104039,16 +104382,16 @@ acK
 acm
 acm
 acm
-cmU
-aeU
-aeU
-sks
-aeu
-aeu
-aeu
-cwy
-cwq
-cwy
+fBG
+cyE
+cyQ
+bAa
+tjj
+czb
+czh
+czm
+cvv
+pSl
 cwy
 cwq
 cwq
@@ -104296,22 +104639,22 @@ acm
 aaa
 aaa
 aaa
-aeU
-aeU
-aeU
-sks
-aeu
-aeu
+fBG
+fro
+cyJ
+mGA
+fRF
+cme
+cme
+cme
+cvk
+klu
+xjQ
 cwy
-cwq
-alc
-cyR
-cyY
-cWg
-czj
-cvg
-cwq
-cwy
+wff
+ksL
+eiF
+sxH
 fDL
 eWy
 cwy
@@ -104553,22 +104896,22 @@ acm
 aaa
 aaa
 aaa
-aaa
-aeU
-aeU
-sks
-aeu
-aeu
-cwy
-jhL
-aRi
-cyS
-cyZ
-czl
-czk
-cvk
-sGL
-cwy
+fBG
+jBs
+rQX
+rfq
+wlU
+sxV
+apF
+pAL
+wqH
+svC
+qEQ
+jKp
+kcS
+eSv
+rQu
+nsY
 pls
 ail
 cwq
@@ -104810,22 +105153,22 @@ acm
 aaa
 aaa
 aaa
-aaa
-aeU
-aeU
-sks
-aeu
+fBG
 cwq
-cwy
-cyH
-aTT
+oTv
+vSi
+xFR
+cop
+cvf
+cvf
+bxy
 cyT
-bES
-sRz
-czx
-ajI
-gai
-cwq
+bUa
+cwy
+vjx
+psd
+cwy
+rks
 ylI
 cwy
 cwy
@@ -105068,20 +105411,20 @@ aaa
 aaa
 aaa
 aaa
-aeU
-aeU
-sks
-aeu
+cwy
 cwq
-cyE
-cyQ
-bAa
-cyU
-czb
-czh
-czm
-cvv
-pSl
+cwy
+vGb
+jui
+tvJ
+czn
+oTL
+cwq
+cwy
+cwy
+vpc
+nmC
+cwy
 amh
 soP
 cwy
@@ -105325,22 +105668,22 @@ acm
 acm
 acm
 acm
-acm
-cmU
-uqW
-uLE
-tbR
-crB
-cyJ
-mGA
-cme
-cme
-cme
-cme
-cvk
-klu
+ffr
+kBs
 cwy
-quw
+oEo
+cwy
+cwy
+cwy
+cwy
+kbO
+nAs
+cwy
+vmL
+bof
+cwy
+gsT
+cwy
 cwq
 rai
 aqo
@@ -105583,22 +105926,22 @@ aaa
 aaa
 aaa
 aaa
-aeU
-aeU
+aeu
+aeu
 xiR
-xyi
-cyE
-rQX
-rfq
+aeu
+cwy
+uVQ
+clr
 alg
+rSF
+nEN
 ang
-apF
-ang
-wqH
-svC
+oOl
+cwy
 czL
 anX
-cwq
+aNN
 aqP
 ass
 atS
@@ -105841,21 +106184,21 @@ aaa
 aaa
 aaa
 aeU
-aeU
+aeu
 xiR
+aeu
 cwy
-cwq
-oTv
+xHj
 nHd
 cmm
-cop
-cvf
-cvf
+cwy
+cwy
+cwy
 quv
-wmi
 cwy
+xCu
 fEB
-cwy
+aNu
 vZv
 aOx
 wVJ
@@ -106098,22 +106441,22 @@ gJB
 aaa
 aaa
 aaa
-aeu
+aeU
 xiR
-aeu
-cwy
+aeU
 cwq
+cwy
 xIH
 cyX
-tMj
-tvJ
-czn
+cwy
+cLe
+cwy
 czu
 cwy
-cwq
+krq
 usm
-cwy
-cwy
+aNu
+aNu
 aNN
 aNu
 aNN
@@ -106365,7 +106708,7 @@ cwq
 cwq
 cwy
 cwy
-cwq
+kID
 cwy
 cyI
 vqk
@@ -106375,7 +106718,7 @@ aVY
 she
 hMH
 ilo
-aJU
+aNu
 aJU
 kjF
 kzU
@@ -106620,11 +106963,11 @@ aeu
 aeu
 aeu
 aeu
+aeu
 cwy
-fBZ
 dMx
-ale
-cxN
+cwy
+djv
 nIy
 aqh
 aqR
@@ -106632,7 +106975,7 @@ ghK
 cVz
 wpD
 aWv
-aJU
+aNu
 dcT
 aOI
 hQY
@@ -106877,19 +107220,19 @@ aeu
 aeu
 aeu
 aeu
-cwq
+agt
 cwq
 gEQ
 cwy
 cwp
 fFH
-cwy
-cwq
+ayS
+wXY
 rpx
 aWg
 iJp
 aWw
-odG
+aNN
 mVT
 aOK
 lSf
@@ -107129,25 +107472,25 @@ acm
 gJB
 aaa
 cmU
-oeg
-jsV
-jsV
-jsV
-jsV
+xiR
+cmU
+aeU
+aeU
+aeU
 poa
-siT
-oEk
-cwq
-cwq
-oTL
-cwy
-cwy
+vdu
+gqh
+sfS
+bQb
+dmR
+tZe
+tZe
 vsH
 aWh
 mQV
 tJb
-aJU
-aJU
+aNu
+aNu
 dgk
 sQs
 iJF
@@ -107386,9 +107729,9 @@ acm
 acm
 xdy
 fRa
-kNc
-kNc
-fRa
+vVS
+gYl
+cIg
 kNc
 kNc
 gWM
@@ -107644,7 +107987,7 @@ acm
 acm
 cmU
 cmU
-aeU
+cnR
 aeU
 aeU
 aeU
@@ -107913,8 +108256,8 @@ ttJ
 jWe
 aBg
 bQb
-aNu
-aNN
+tZe
+bQb
 kRu
 cAZ
 kEg
@@ -108171,7 +108514,7 @@ iZW
 rAU
 tXD
 ePI
-aNu
+tZe
 aNN
 gtw
 aNu
@@ -108935,19 +109278,19 @@ aeu
 wLn
 aeu
 sfS
-cCU
+dQz
 sfS
 tSn
 iZW
 wOC
-ufc
+qOk
 qho
 wWK
 rra
 swc
-ufc
-ufc
-ufc
+qOk
+qOk
+qOk
 qOk
 qho
 vcc
@@ -109197,19 +109540,19 @@ sfS
 mDu
 wCc
 rHi
-uSo
-wkw
+iZW
+eAU
 rNH
 nsr
-wmT
-wmT
-wmT
-wmT
+uZQ
+iZW
+iTR
+iZW
 wmT
 eAU
 yjT
 aGI
-nqp
+eFl
 pMo
 lhj
 bdU
@@ -109460,8 +109803,8 @@ oLl
 bLc
 viU
 viU
-viU
 pET
+viU
 viU
 wOO
 cju
@@ -109717,8 +110060,8 @@ sfS
 bAF
 ncR
 duZ
+rOJ
 ncR
-tpU
 duZ
 sjJ
 gJo
@@ -113083,7 +113426,7 @@ kCt
 joA
 wLR
 kbu
-bAx
+nFD
 bAx
 omt
 asF
@@ -113102,7 +113445,7 @@ dOq
 bOX
 cbi
 xWc
-ceS
+qLQ
 cgk
 rvw
 cao
@@ -113562,7 +113905,7 @@ aaa
 acm
 aaa
 cDk
-aqm
+mQU
 cDk
 aDQ
 add
@@ -117728,7 +118071,7 @@ lXt
 bZG
 ccI
 xWc
-ceS
+qLQ
 cgk
 chd
 chd
@@ -122317,7 +122660,7 @@ bai
 aZS
 aZr
 ajL
-ajL
+spa
 ajL
 aDI
 ayU
@@ -127461,7 +127804,7 @@ uUX
 uUX
 uUX
 uUX
-uUX
+nAR
 jiA
 upa
 thv

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -37484,9 +37484,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"nrn" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/medbay/central)
 "nrx" = (
 /obj/structure/cable,
 /obj/structure/chair/office,
@@ -37654,9 +37651,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"nuS" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/morgue)
 "nvb" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/lobby)
@@ -42045,6 +42039,8 @@
 	department = "Medical";
 	name = "Morgue Requests Console"
 	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oUk" = (
@@ -169243,8 +169239,8 @@ pJR
 pJR
 hVB
 nhw
-nuS
-nuS
+hVB
+hVB
 rGO
 fEH
 anl
@@ -170014,11 +170010,11 @@ hPH
 hPH
 lpr
 uta
-nuS
-nuS
-nuS
-nuS
-nuS
+hVB
+hVB
+hVB
+hVB
+hVB
 kCy
 iLK
 sXB
@@ -170272,7 +170268,7 @@ hPH
 bGI
 shX
 ruC
-nrn
+xNZ
 iLh
 mef
 rjj
@@ -171261,7 +171257,7 @@ aHn
 aHn
 aHn
 rNX
-aHn
+sEg
 sEg
 sEg
 sEg
@@ -171518,7 +171514,7 @@ mwg
 wyW
 boG
 mua
-aHn
+sEg
 wox
 wox
 wox
@@ -171775,7 +171771,7 @@ chV
 oKy
 geq
 cWu
-aHn
+sEg
 wox
 wox
 wox
@@ -172032,7 +172028,7 @@ pRk
 qTf
 oKy
 jTv
-aHn
+sEg
 wox
 wox
 wox
@@ -172289,7 +172285,7 @@ pRk
 qTf
 pvs
 jTv
-aHn
+sEg
 wox
 wox
 wox
@@ -172546,7 +172542,7 @@ qpy
 pvs
 qTf
 mRW
-aHn
+sEg
 wox
 wox
 wox
@@ -172803,7 +172799,7 @@ fnr
 oKy
 oKy
 vUH
-aHn
+sEg
 wox
 wox
 wox
@@ -173060,7 +173056,7 @@ fnr
 oKy
 qTf
 gbl
-aHn
+sEg
 wox
 wox
 wox
@@ -173317,7 +173313,7 @@ fnr
 xLK
 qTf
 tpN
-aHn
+sEg
 wox
 wox
 wox
@@ -173574,7 +173570,7 @@ fnr
 fyA
 oKy
 qrU
-aHn
+sEg
 wox
 wox
 wox
@@ -173831,7 +173827,7 @@ xyJ
 qTf
 oKy
 wvE
-aHn
+sEg
 sEg
 sEg
 sEg

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -657,6 +657,8 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aoj" = (
@@ -2062,9 +2064,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aQq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -2072,6 +2071,7 @@
 /obj/structure/item_dispenser/bodybag{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aQP" = (
@@ -8259,6 +8259,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ddz" = (
@@ -15151,6 +15154,16 @@
 "fEE" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/tcommsat/oldaisat/stationside)
+"fEH" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "fEI" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -33753,6 +33766,9 @@
 	},
 /obj/effect/landmark/start/coroner,
 /obj/structure/chair/office,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mez" = (
@@ -35736,6 +35752,8 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mOC" = (
@@ -40364,6 +40382,14 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
+"oqT" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "oqU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -168938,8 +168964,8 @@ hVB
 nkg
 aoe
 mOB
-nDo
-nDo
+oqT
+oqT
 huO
 kCy
 osx
@@ -169196,7 +169222,7 @@ nhw
 nuS
 nuS
 rGO
-nDo
+fEH
 anl
 kCy
 hLH

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -2068,10 +2068,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/item_dispenser/bodybag{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_y = 32;
+	pixel_x = 6
+	},
+/obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aQP" = (
@@ -4609,11 +4611,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
 	dir = 5;
 	network = list("ss13","medbay")
+	},
+/obj/structure/item_dispenser/bodybag{
+	pixel_y = -31
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -5619,6 +5623,15 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"cgp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/bodycontainer/morgue,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cgr" = (
 /obj/machinery/flasher/portable,
 /obj/structure/cable,
@@ -20853,6 +20866,17 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage)
+"hHH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/closet{
+	name = "janitorial supplies"
+	},
+/obj/item/storage/box/bodybags,
+/obj/item/pushbroom,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hIa" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat - Foyer";
@@ -23857,8 +23881,8 @@
 /area/station/security/prison/rec)
 "iLh" = (
 /obj/machinery/vending/drugs,
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -167677,11 +167701,11 @@ clv
 xqI
 hVB
 aah
-nDl
+hHH
 miY
 jzr
 jzr
-jzr
+cgp
 kCy
 cAi
 cAi
@@ -168443,7 +168467,7 @@ wdQ
 pJR
 wVK
 hBh
-hBI
+pJR
 hBh
 rHE
 hVB

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -5806,13 +5806,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
-"ckA" = (
-/obj/machinery/bluespace_vendor/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper)
 "ckU" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -34050,6 +34043,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/spawner/directional/north,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mjc" = (
@@ -41552,6 +41546,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"oMi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/bluespace_vendor/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/upper)
 "oMn" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -42016,7 +42017,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Medical";
+	name = "Morgue Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oUk" = (
@@ -50260,6 +50264,10 @@
 	pixel_x = -7
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rGZ" = (
@@ -54547,15 +54555,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
-"taf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/bodycontainer/morgue,
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "tak" = (
 /obj/machinery/computer/exodrone_control_console{
 	dir = 1
@@ -54580,6 +54579,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/operating,
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "taB" = (
@@ -167165,11 +167165,11 @@ bJv
 gzx
 nIo
 csX
-fcB
 gzx
+fcB
+oMi
 gzx
 hBp
-ckA
 cDU
 oek
 nIo
@@ -167680,7 +167680,7 @@ aah
 nDl
 miY
 jzr
-taf
+jzr
 jzr
 kCy
 cAi

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13481,8 +13481,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
 "aUX" = (
-/obj/machinery/icecream_vat,
 /obj/machinery/light/directional/west,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "aUZ" = (
@@ -13858,7 +13858,7 @@
 	},
 /area/station/service/hydroponics)
 "aVW" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/machinery/icecream_vat,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "aVZ" = (
@@ -15618,12 +15618,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bce" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bcg" = (
@@ -16338,7 +16334,9 @@
 	name = "Kitchen Window Shutters Control";
 	req_access = list("kitchen")
 	},
-/obj/machinery/oven,
+/obj/structure/rack,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "bfr" = (
@@ -19853,6 +19851,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -31684,10 +31683,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "cpq" = (
-/obj/machinery/deepfryer,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cpt" = (
@@ -31695,8 +31698,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "cpu" = (
-/obj/machinery/deepfryer,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cpw" = (
@@ -31726,14 +31733,8 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"cpy" = (
-/obj/machinery/food_cart,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "cpz" = (
-/obj/structure/rack,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
+/obj/machinery/deepfryer,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cpA" = (
@@ -44514,6 +44515,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"lFN" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/station/medical/morgue)
 "lGp" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -46885,6 +46895,7 @@
 "nAZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "nBt" = (
@@ -51130,6 +51141,14 @@
 "qOE" = (
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/library/lounge)
+"qOR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/food_cart,
+/turf/open/floor/iron/showroomfloor,
+/area/station/service/kitchen/coldroom)
 "qPu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -52008,16 +52027,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rxV" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/requests_console/directional/north{
 	department = "Kitchen";
 	name = "Kitchen Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ryC" = (
@@ -85300,7 +85315,7 @@ fno
 lNd
 guE
 bqV
-bso
+lFN
 tqC
 rMZ
 bye
@@ -89904,7 +89919,7 @@ aRO
 aSH
 wRf
 iNR
-iNR
+qOR
 afu
 hwo
 sJO
@@ -90684,7 +90699,7 @@ bbg
 jks
 jks
 sTY
-cpy
+cpA
 bgk
 nHc
 ble
@@ -91198,7 +91213,7 @@ cpn
 bch
 bdq
 sUg
-cpA
+cpz
 bgk
 jmf
 ble

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -11112,7 +11112,8 @@
 "aLa" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutter";
-	name = "EVA Storage Shutters"
+	name = "EVA Storage Shutters";
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
@@ -18340,15 +18341,18 @@
 "bmT" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_half{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/textured/dark,
+/obj/effect/turf_decal/textured/dark{
 	dir = 1
 	},
+/obj/effect/turf_decal/textured/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/textured/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "bmU" = (
 /obj/machinery/rnd/server,
@@ -18549,15 +18553,18 @@
 /area/station/science/server)
 "bnU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_half{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/textured/dark,
+/obj/effect/turf_decal/textured/dark{
 	dir = 1
 	},
+/obj/effect/turf_decal/textured/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/textured/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "bnW" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -18806,6 +18813,9 @@
 "boY" = (
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/station/science/robotics)
 "boZ" = (
@@ -18876,10 +18886,11 @@
 /obj/structure/closet{
 	name = "janitorial supplies"
 	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/pushbroom,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/item/storage/box/bodybags,
+/obj/item/pushbroom,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bpy" = (
@@ -19134,9 +19145,6 @@
 /area/station/science/robotics)
 "bqi" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -34344,9 +34352,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/edge,
 /area/station/science/robotics)
 "dfU" = (
@@ -37583,15 +37588,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"fIH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/edge,
-/area/station/science/robotics)
 "fIN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -39887,6 +39883,10 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/paper/guides/jobs/medical/morgue{
+	pixel_y = 4;
+	pixel_x = -10
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hDG" = (
@@ -43050,6 +43050,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -45600,13 +45603,15 @@
 /area/station/science/genetics)
 "mzO" = (
 /obj/structure/table,
-/obj/item/storage/box/bodybags,
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/item_dispenser/bodybag{
 	pixel_y = 28;
 	pixel_x = 1
 	},
+/obj/item/clipboard,
+/obj/item/paper,
+/obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mAi" = (
@@ -48316,7 +48321,7 @@
 /area/station/commons/storage/emergency/starboard)
 "oFq" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/large,
@@ -55434,7 +55439,6 @@
 	},
 /area/station/hallway/primary/central)
 "tUr" = (
-/obj/structure/table/optable,
 /obj/machinery/computer/operating,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
@@ -58011,6 +58015,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/security/detectives_office/bridge_officer_office)
+"vMg" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics)
 "vMt" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos{
@@ -98934,7 +98948,7 @@ blG
 bmO
 bnQ
 boY
-fIH
+dfM
 brz
 bta
 bkt
@@ -99190,7 +99204,7 @@ bkw
 blJ
 bmP
 bnR
-bnR
+vMg
 bqj
 brA
 btb

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -18181,6 +18181,8 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bmi" = (
@@ -103783,9 +103785,9 @@ aiS
 aiS
 aiS
 sFK
-aiS
-aiS
-aiS
+atn
+atn
+atn
 avm
 axy
 avm
@@ -104040,7 +104042,7 @@ aaa
 aaa
 aiT
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -104051,7 +104053,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 aEj
 aEj
 aEj
@@ -104297,7 +104299,7 @@ aaa
 aaa
 aiT
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -104308,7 +104310,7 @@ aur
 aur
 aur
 hRG
-aEj
+atn
 aFN
 aGK
 aHs
@@ -104554,7 +104556,7 @@ aht
 aht
 aiS
 asm
-aiS
+atn
 aur
 aur
 aur
@@ -104565,7 +104567,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 aFO
 aGL
 aHt
@@ -104811,7 +104813,7 @@ aaa
 aaa
 aiT
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -104822,7 +104824,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 aFP
 aGM
 aFi
@@ -105068,7 +105070,7 @@ aaa
 aaa
 aiT
 sFK
-aiS
+atn
 uSL
 aur
 aur
@@ -105079,7 +105081,7 @@ aur
 aur
 aur
 qJP
-aEj
+atn
 aFQ
 aGN
 aGN
@@ -105325,7 +105327,7 @@ aht
 aht
 aiS
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -105336,7 +105338,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 aEj
 aEj
 aEj
@@ -105582,7 +105584,7 @@ aaa
 aaa
 aiT
 asm
-aiS
+atn
 aur
 aur
 aur
@@ -105593,7 +105595,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 noT
 aFi
 aFi
@@ -105839,7 +105841,7 @@ aaa
 aaa
 aiT
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -105850,7 +105852,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 odG
 aFi
 yiL
@@ -106096,7 +106098,7 @@ aaa
 aaa
 aiS
 sFK
-aiS
+atn
 aur
 aur
 aur
@@ -106107,7 +106109,7 @@ aur
 aur
 aur
 aur
-aEj
+atn
 aEj
 aEj
 sSs
@@ -106353,18 +106355,18 @@ aaa
 aaa
 aiT
 sFK
-aiS
-aiS
-aiS
-aiS
+atn
+atn
+atn
+atn
 ngO
 avm
 avm
 ngO
-aEj
-aEj
-aEj
-aEj
+atn
+atn
+atn
+atn
 yiL
 yiL
 yiL

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16293,7 +16293,7 @@
 "bfb" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/secondary/entry)
 "bfe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -16751,12 +16751,13 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/wrench,
-/obj/item/screwdriver,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/item/storage/secure/briefcase,
+/obj/item/stack/sheet/iron/five,
+/obj/item/stack/cable_coil/five,
+/obj/item/wrench,
+/obj/item/screwdriver,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bgV" = (
@@ -16787,9 +16788,6 @@
 	c_tag = "Vacant Commissary";
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -16807,7 +16805,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/requests_console/directional/north{
 	name = "Commissary Requests Console"
@@ -16815,6 +16812,18 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/east{
 	name = "Light Switch"
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
+/obj/machinery/button/door/directional/east{
+	id = "commissaryshutters";
+	name = "Commissary Shutters Control";
+	pixel_x = 36
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -16993,14 +17002,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/sign/poster/official/random/directional/west,
+/obj/item/storage/secure/briefcase,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bhJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/primary/central)
 "bhK" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -17097,20 +17107,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
-"bib" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
+"bic" = (
+/obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/iron/five,
-/obj/item/stack/cable_coil/five,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
-"bic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bie" = (
@@ -17124,12 +17129,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutters";
-	name = "Vacant Commissary Shutter"
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutters";
+	name = "Vacant Commissary Shutter";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bij" = (
@@ -17299,50 +17305,28 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"biL" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
-"biM" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
 "biN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
+/area/station/medical/morgue)
 "biO" = (
-/obj/structure/sign/poster/official/random/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "biP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -17453,8 +17437,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "bjK" = (
-/turf/closed/wall,
-/area/station/commons/vacant_room/commissary)
+/obj/structure/table,
+/obj/item/storage/belt/fannypack/red,
+/obj/item/food/lollipop,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "bjL" = (
 /turf/closed/wall,
 /area/station/medical/cryo)
@@ -17541,6 +17530,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/paramedic)
 "bjZ" = (
@@ -17780,45 +17770,20 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/entry)
-"bkT" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/secondary/entry)
 "bkW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/blue/half,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
 "bkX" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
-"bkY" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 2
-	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -4
-	},
-/turf/open/floor/plating,
-/area/station/medical/cryo)
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "bkZ" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/smartfridge{
@@ -17836,26 +17801,16 @@
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "bla" = (
-/obj/structure/closet/crate/medical,
-/obj/item/storage/box/rxglasses{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/storage/box/syringes,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "blb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "blc" = (
@@ -17906,7 +17861,6 @@
 /area/station/medical/medbay/central)
 "bli" = (
 /obj/structure/bed/roller,
-/obj/machinery/newscaster/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -18205,45 +18159,39 @@
 /area/station/science/xenobiology)
 "bmc" = (
 /obj/structure/table,
-/obj/item/reagent_containers/cup/glass/mug/britcup{
-	desc = "Kingston's personal cup."
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
-/obj/machinery/light/small/directional/north,
+/obj/item/reagent_containers/cup/glass/mug/britcup{
+	desc = "Kingston's personal cup.";
+	pixel_x = -7
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
 "bmh" = (
 /obj/structure/table,
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/machinery/computer/records/medical/laptop{
+	dir = 8
 	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
+/obj/machinery/requests_console/directional/east{
+	department = "Medical";
+	name = "Morgue Requests Console"
 	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/reagent_containers/dropper{
-	pixel_y = 6
-	},
-/obj/item/wrench/medical,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "bmi" = (
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "bml" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
+/obj/item/wrench/medical,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "bmn" = (
@@ -18469,12 +18417,17 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/large,
 /area/station/hallway/secondary/entry)
 "bnu" = (
 /obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/dark,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/camera{
+	c_tag = "Morgue";
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
 "bny" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine,
@@ -18691,22 +18644,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bor" = (
-/obj/structure/table/optable,
-/obj/effect/mapping_helpers/dead_body_placer,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bos" = (
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"bot" = (
-/obj/machinery/camera{
-	c_tag = "Morgue";
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bou" = (
@@ -18722,7 +18669,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "boz" = (
 /obj/machinery/door/airlock/maintenance{
@@ -18928,9 +18875,13 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bpu" = (
-/obj/structure/table,
-/obj/item/storage/belt/fannypack/red,
-/obj/item/food/lollipop,
+/obj/structure/closet{
+	name = "janitorial supplies"
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/pushbroom,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bpy" = (
@@ -19441,14 +19392,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bqV" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "bqX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19897,18 +19850,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bso" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"bsq" = (
-/obj/structure/closet{
-	name = "janitorial supplies"
+/obj/structure/bodycontainer/morgue{
+	dir = 1
 	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/pushbroom,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "bsr" = (
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -19953,6 +19900,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/blue/half,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
 "bsF" = (
@@ -20289,13 +20237,13 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "btS" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/machinery/light_switch/directional/south{
-	name = "Light Switch"
+/obj/structure/bodycontainer/morgue{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "btV" = (
 /obj/structure/disposalpipe/segment,
@@ -20320,6 +20268,26 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/reagent_containers/dropper{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/cryo)
 "btZ" = (
@@ -20610,7 +20578,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bvl" = (
@@ -20969,6 +20936,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
+/obj/item/clothing/gloves/latex/nitrile,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/storage)
 "bwB" = (
@@ -21550,7 +21518,7 @@
 	},
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -29
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -21566,13 +21534,10 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/structure/noticeboard/cmo{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -22098,6 +22063,10 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 4
 	},
+/obj/structure/noticeboard/cmo{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
 	},
@@ -22406,10 +22375,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bBk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "bBo" = (
@@ -23037,7 +23014,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/east{
+	name = "Light Switch"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bDy" = (
@@ -23366,6 +23345,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bEF" = (
@@ -28989,6 +28969,10 @@
 "bZY" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
+"caa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/station/hallway/secondary/entry)
 "cab" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -33114,14 +33098,17 @@
 	},
 /area/station/security/prison)
 "cxq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/requests_console/directional/east{
-	department = "Medical";
-	name = "Morgue Requests Console"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "cxt" = (
 /obj/effect/turf_decal/tile/purple,
@@ -34201,9 +34188,9 @@
 /turf/open/floor/iron,
 /area/station/security)
 "cUb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
 "cVa" = (
 /obj/effect/turf_decal/tile/neutral/anticorner{
@@ -34494,11 +34481,8 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "dmI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
 "dmP" = (
 /obj/structure/chair{
@@ -34951,7 +34935,6 @@
 	},
 /area/station/service/library/artgallery)
 "dGH" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue/half{
@@ -35479,9 +35462,19 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/research)
 "efC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/right/directional/west{
+	name = "Cornoner's Office";
+	req_access = list("morgue_secure")
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "efU" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -35954,6 +35947,13 @@
 	dir = 8
 	},
 /area/station/medical/surgery)
+"eCj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "eCm" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -36062,9 +36062,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/light_switch/directional/west{
-	name = "Light Switch"
-	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "eFj" = (
@@ -36489,8 +36486,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/entry)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "eUK" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel/funeral)
@@ -36673,6 +36670,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/science/xenobiology)
+"faP" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/poster/official/safety_report/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "faT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -37051,12 +37057,11 @@
 	},
 /area/station/medical/medbay/lobby)
 "fno" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/machinery/computer/operating{
+	dir = 1
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "fnK" = (
 /turf/open/floor/iron/dark/smooth_corner{
@@ -38475,8 +38480,7 @@
 	},
 /area/station/engineering/atmos)
 "guE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "guO" = (
@@ -38517,12 +38521,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/primary)
-"gvu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "gvN" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/sign/flag/nanotrasen/directional/north,
@@ -38715,6 +38713,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
 	},
+/obj/item/clothing/gloves/latex/nitrile,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 8
 	},
@@ -39882,6 +39881,13 @@
 	dir = 8
 	},
 /area/station/security/prison)
+"hDp" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction"
@@ -41127,6 +41133,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
+"iGg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/chair/office,
+/obj/effect/landmark/start/coroner,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "iGp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/crossing/horizontal,
@@ -41327,8 +41345,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "iOj" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -42013,6 +42031,7 @@
 	name = "Central Access"
 	},
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -42069,13 +42088,10 @@
 /area/station/hallway/secondary/entry)
 "jzF" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/primary/central)
 "jAx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -42233,8 +42249,8 @@
 /area/station/engineering/supermatter/room)
 "jMD" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/smooth_half,
 /area/station/medical/morgue)
 "jMS" = (
 /obj/effect/spawner/xmastree,
@@ -42801,6 +42817,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/service/abandoned_gambling_den)
+"kpz" = (
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
+/obj/effect/turf_decal/tile/blue/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "kpE" = (
 /obj/structure/chair{
 	dir = 4
@@ -42921,6 +42945,9 @@
 	},
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 8
+	},
+/obj/structure/item_dispenser/mask{
+	pixel_x = -26
 	},
 /turf/open/floor/iron/white/smooth_half{
 	dir = 1
@@ -43277,6 +43304,14 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"kHh" = (
+/obj/structure/item_dispenser/radio{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/hallway/secondary/entry)
 "kHv" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -43373,6 +43408,15 @@
 /obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"kKW" = (
+/obj/structure/bodycontainer/morgue,
+/obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/tile/blue/half,
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/medical/morgue)
 "kLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -43513,7 +43557,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kSO" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
@@ -44620,6 +44663,10 @@
 	dir = 1
 	},
 /area/station/service/chapel/funeral)
+"lNd" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/morgue)
 "lNm" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -45541,6 +45588,17 @@
 	dir = 8
 	},
 /area/station/science/genetics)
+"mzO" = (
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/item_dispenser/bodybag{
+	pixel_y = 28;
+	pixel_x = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mAi" = (
 /obj/item/retractor,
 /obj/item/hemostat,
@@ -46791,6 +46849,7 @@
 /obj/machinery/light_switch/directional/south{
 	name = "Light Switch"
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "nyB" = (
@@ -46823,6 +46882,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/edge,
 /area/station/commons/dorms)
+"nAZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -47086,6 +47150,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"nLV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "papersplease";
+	name = "Security Shutters";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/customs)
 "nMG" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
@@ -47195,6 +47268,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nQX" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "nRV" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
@@ -47740,11 +47820,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "omu" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "omS" = (
@@ -48061,8 +48144,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/storage/primary)
 "oyH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ozc" = (
@@ -48356,6 +48440,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"oOj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/station/medical/morgue)
 "oOo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -48456,6 +48552,14 @@
 /area/station/hallway/primary/central)
 "oRF" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oRX" = (
@@ -48749,6 +48853,31 @@
 	dir = 1
 	},
 /area/station/science/server)
+"pdQ" = (
+/obj/structure/closet/crate/medical,
+/obj/item/storage/box/rxglasses{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 2
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "pec" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50349,7 +50478,7 @@
 "qoh" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/primary/central)
 "qoi" = (
 /obj/machinery/vending/medical,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -50826,9 +50955,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "qIl" = (
@@ -51084,27 +51210,6 @@
 	dir = 8
 	},
 /area/station/engineering/supermatter/room)
-"qUe" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/east{
-	id = "commissaryshutters";
-	name = "Commissary Shutters Control"
-	},
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
 "qUk" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/stripes/corner{
@@ -51726,11 +51831,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"rsK" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "rsR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
@@ -51747,20 +51847,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/tcommsat/computer)
-"rtd" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_half{
-	dir = 1
-	},
-/area/station/medical/medbay/central)
 "rtk" = (
 /obj/structure/sign/poster/official/work_for_a_future/directional/north,
 /obj/effect/turf_decal/siding/wood{
@@ -51776,11 +51862,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
-"rtD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/medbay/central)
 "rtG" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -52242,6 +52323,14 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"rIL" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/airlock/hatch{
+	name = "Morgue"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "rIP" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -52413,6 +52502,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"rNH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/secondary/entry)
 "rNJ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -52907,6 +53009,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central)
+"sjQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/secondary/entry)
 "skj" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -53064,6 +53178,9 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"sqI" = (
+/turf/open/floor/iron/dark/smooth_half,
+/area/station/medical/morgue)
 "srf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54109,15 +54226,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"tbS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Morgue"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "tcm" = (
 /obj/structure/bed/roller,
 /turf/open/floor/iron/dark/smooth_large,
@@ -54247,19 +54355,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"tfS" = (
-/obj/structure/sign/poster/official/random/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
-/area/station/hallway/secondary/entry)
 "tgb" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/start/hangover,
@@ -55714,6 +55809,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
+"ugC" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/large,
+/area/station/hallway/secondary/entry)
 "ugM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -55828,6 +55928,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/item_dispenser/latex{
+	pixel_x = -26
+	},
+/obj/structure/item_dispenser/mask{
+	pixel_x = -38
+	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/medical/virology)
 "ukz" = (
@@ -55857,6 +55963,7 @@
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/medbay/central)
 "ulq" = (
@@ -56132,7 +56239,9 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "uwj" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/mannequin/skeleton,
+/obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uwF" = (
@@ -56247,6 +56356,9 @@
 /area/station/tcommsat/computer)
 "uzr" = (
 /obj/effect/turf_decal/tile/blue/full,
+/obj/structure/item_dispenser/latex{
+	pixel_x = 26
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/paramedic)
 "uzx" = (
@@ -56662,7 +56774,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/engine)
 "uQo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -57029,8 +57141,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vav" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/coroner,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vaF" = (
@@ -57518,9 +57635,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
 "vtX" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "vuQ" = (
@@ -57586,6 +57704,16 @@
 /obj/effect/turf_decal/tile/yellow/half,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/medical/chemistry)
+"vyi" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "vyn" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -57757,6 +57885,8 @@
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "vIa" = (
 /obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vIc" = (
@@ -58666,10 +58796,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"wns" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
 "wnt" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/corner,
@@ -58735,14 +58861,17 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wqC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/station/medical/morgue)
 "wrU" = (
 /obj/machinery/photocopier,
@@ -83101,7 +83230,7 @@ oPg
 bop
 bop
 bop
-anW
+kHh
 beY
 anW
 qiz
@@ -83363,14 +83492,14 @@ lmU
 lmU
 pMG
 qdO
-tfS
 lmU
+rNH
 uxF
-bkT
+iCx
 iCx
 xjZ
 iCx
-iCx
+sjQ
 hGq
 bsm
 pjb
@@ -83617,19 +83746,19 @@ aXH
 bdc
 xtD
 bfa
-bjK
-bjK
-bjK
-bjK
-bjK
-bjK
 hXW
+hXW
+hXW
+hXW
+hXW
+hXW
+ugC
 bmc
 bnt
 sKe
-aYG
-aYG
-bBX
+hXW
+hXW
+bva
 nta
 bBX
 bBX
@@ -83877,14 +84006,14 @@ pEK
 bfb
 bgU
 bhF
-bib
 biK
-bjK
-aYG
-aYG
-aYG
-aYG
-aYG
+biY
+biY
+rIL
+biY
+biY
+biY
+biY
 eUe
 bva
 rbu
@@ -84123,7 +84252,7 @@ oEA
 dpa
 ihM
 fEh
-aXI
+nLV
 aYI
 aZI
 baR
@@ -84135,9 +84264,9 @@ bga
 bgV
 qIf
 bBk
-biL
+biY
 bjK
-iOj
+bos
 cUb
 jMD
 bnu
@@ -84387,17 +84516,17 @@ baS
 bbV
 hNF
 qSx
-jVo
-bjK
+nQX
+hXW
 bgW
 bhK
 bic
-biM
-bjK
+biY
+mzO
 iOj
-gvu
+sqI
 dmI
-oyH
+sqI
 oyH
 uok
 bva
@@ -84637,7 +84766,7 @@ oEA
 aML
 ihM
 fEh
-aXI
+nLV
 aYJ
 tdj
 baT
@@ -84645,15 +84774,15 @@ aXI
 hNF
 wCm
 jVo
-bjK
+hXW
 bgX
 eBf
 omu
-qUe
-bjK
-iOj
+biY
+hDp
+eCj
 oRF
-bos
+bor
 bor
 vav
 wqC
@@ -84902,18 +85031,18 @@ aXK
 bfe
 baV
 juU
-bjK
-biN
+hXW
+caa
 bie
 bie
 biN
-bjK
-iOj
+biY
+kKW
 efC
 uwj
-bos
+lNd
 guE
-wqC
+oOj
 btS
 tqC
 bwu
@@ -85159,19 +85288,19 @@ aXK
 gJJ
 yiR
 dNA
-bjK
+hXW
 bhJ
 qoh
 qoh
 jzF
-tbS
+biY
 bkW
 cxq
 fno
-bot
-rsK
+lNd
+guE
 bqV
-bsq
+bso
 tqC
 rMZ
 bye
@@ -85421,10 +85550,10 @@ gAK
 gAK
 ptL
 biO
-bjL
-bjL
-biY
-biY
+vyi
+nAZ
+iGg
+kpz
 biY
 vIa
 bou
@@ -85678,11 +85807,11 @@ bgZ
 ugM
 pkj
 biP
-bjL
+biY
 bkX
 bmh
-xyK
-bjL
+faP
+biY
 bpy
 biv
 bsr
@@ -85935,11 +86064,11 @@ xvO
 bhL
 vHr
 sSj
-bjL
-bkY
-bmi
-wns
-bjL
+biY
+biY
+biY
+biY
+biY
 mgW
 bCd
 bvL
@@ -86193,8 +86322,8 @@ ble
 eIv
 bij
 bjL
+pdQ
 bkZ
-bmi
 xyK
 bjL
 mgW
@@ -86458,7 +86587,7 @@ bvc
 bqY
 tnd
 mEo
-rtd
+tpy
 tpy
 koW
 bzK
@@ -86715,7 +86844,7 @@ spo
 bqZ
 knx
 htK
-rtD
+tWt
 tWt
 tWt
 pPN


### PR DESCRIPTION
Adds Coroner Offices to Kilostation*, Limastation**, and Pubbystation***

<details>

<Summary> Picture </summary>

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/f09c4aa8-a2cc-402a-b6c9-136e08f483ca)

</details>

<details>

<Summary> Picture </summary>

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/d01245f3-23af-43d1-b332-0324f705dc76)

</details>

<details>

<Summary> Picture </summary>

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/681b9659-aad6-45d2-bdef-19559284eda7)

</details>

*Shuffled around a ton of Kilostation maintenance, also adds Ranges to the kitchen, proper spawnpoints for modular jobs, and a little bit more of misc mapping
**I gave Lima a Coroner's Office during the big merge but I'm showing it here for posterity. 
***Also fixed a lot of Active Turfs of Pubby, adds Ranges to the kitchen, and some minor misc remapping