### PR TITLE
Adds autopsy scanners to the morgue and robotics

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5401,6 +5401,7 @@
 #include "maplestation_modules\code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "maplestation_modules\code\game\objects\items\devices\radio\encryptionkey.dm"
 #include "maplestation_modules\code\game\objects\items\devices\radio\headset.dm"
+#include "maplestation_modules\code\game\objects\items\devices\scanners\autopsy_scanner.dm"
 #include "maplestation_modules\code\game\objects\items\other_loadout_items\loadout_inhand_items.dm"
 #include "maplestation_modules\code\game\objects\items\other_loadout_items\loadout_pocket_items.dm"
 #include "maplestation_modules\code\game\objects\items\storage\belt.dm"

--- a/maplestation_modules/code/game/objects/items/devices/scanners/autopsy_scanner.dm
+++ b/maplestation_modules/code/game/objects/items/devices/scanners/autopsy_scanner.dm
@@ -1,0 +1,13 @@
+// Spawn an autopsy scanner in robotics and the morgue
+
+/obj/item/mmi/Initialize(mapload)
+	. = ..()
+	var/static/robotics_scanner_spawned = FALSE
+	if(mapload && !robotics_scanner_spawned && istype(get_area(src), /area/station/science/robotics))
+		new /obj/item/autopsy_scanner(loc)
+		robotics_scanner_spawned = TRUE
+
+/obj/item/storage/backpack/duffelbag/med/surgery/PopulateContents()
+	. = ..()
+	if(istype(get_area(src), /area/station/medical/morgue)) // Can't check for roundstart due to PopulateContents, but this would only really affect admin spawns anyway
+		new /obj/item/autopsy_scanner(src)


### PR DESCRIPTION
Adds a couple of autopsy scanners roundstart to make dissections less of a pain when there isn't a coroner around

Morgue
![image](https://github.com/MrMelbert/MapleStationCode/assets/138069572/e4ef2673-3df6-4b2f-8b73-930c31fe59db)
Robotics
![image](https://github.com/MrMelbert/MapleStationCode/assets/138069572/3be469dc-6727-4daa-adc0-0e91068e8ef3)