### PR TITLE
Adds a pref to modify frequency of speech sounds

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5487,6 +5487,7 @@
 #include "maplestation_modules\code\modules\client\preferences\multiline_preferences.dm"
 #include "maplestation_modules\code\modules\client\preferences\name_preferences.dm"
 #include "maplestation_modules\code\modules\client\preferences\runechat_color.dm"
+#include "maplestation_modules\code\modules\client\preferences\sound_frequency.dm"
 #include "maplestation_modules\code\modules\client\preferences\toggle_radio.dm"
 #include "maplestation_modules\code\modules\client\preferences\toggle_speech.dm"
 #include "maplestation_modules\code\modules\client\preferences\species\lizard.dm"

--- a/maplestation_modules/code/modules/client/preferences/_preferences.dm
+++ b/maplestation_modules/code/modules/client/preferences/_preferences.dm
@@ -29,3 +29,53 @@
 /// See above. Called at the very end of player initialization.
 /datum/preference/proc/after_apply_to_human(mob/living/carbon/human/target, datum/preferences/prefs, value)
 	return
+
+/// Extension of preferences/ui_act to do more actions when new preferences are added.
+/datum/preferences/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if (.)
+		return
+
+	var/mob/user = usr
+	switch (action)
+		// Loadout UI
+		if ("open_loadout_manager")
+			if(parent.open_loadout_ui)
+				parent.open_loadout_ui.ui_interact(user)
+			else
+				var/datum/loadout_manager/tgui = new(user)
+				tgui.ui_interact(user)
+			return TRUE
+		// Language UI
+		if ("open_language_picker")
+			var/datum/language_picker/tgui = new(user)
+			tgui.ui_interact(user)
+			return TRUE
+		// Spellbook UI
+		if ("open_spellbook")
+			if(parent.open_spellbook_ui)
+				parent.open_spellbook_ui.ui_interact(user)
+			else
+				var/datum/spellbook_manager/tgui = new(user)
+				tgui.ui_interact(user)
+			return TRUE
+		// Playing test sounds from speech frequency pref
+		if ("play_test_speech_sound")
+			var/mob/living/carbon/human/dummy = character_preview_view?.body
+			if(isnull(dummy))
+				return TRUE // ???
+
+			var/list/speech_sounds_to_try = dummy.get_speech_sounds()
+			if(!length(speech_sounds_to_try))
+				return
+
+			var/picked_sound = pick(speech_sounds_to_try)
+			var/speech_vol = speech_sounds_to_try[picked_sound]
+			var/speech_freq_to_try = round((get_rand_frequency() + get_rand_frequency()) / 2) * dummy.speech_sound_frequency_modifier
+			user.playsound_local(
+				turf_source = get_turf(user),
+				soundin = picked_sound,
+				vol = speech_vol,
+				vary = TRUE,
+				frequency = speech_freq_to_try,
+			)

--- a/maplestation_modules/code/modules/client/preferences/loadout_preference.dm
+++ b/maplestation_modules/code/modules/client/preferences/loadout_preference.dm
@@ -34,30 +34,3 @@
 
 /datum/preference/loadout/is_valid(value)
 	return isnull(value) || islist(value)
-
-/// Extension of preferences/ui_act to open the loadout manager.
-/datum/preferences/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	if (.)
-		return
-
-	switch (action)
-		if ("open_loadout_manager")
-			if(parent.open_loadout_ui)
-				parent.open_loadout_ui.ui_interact(usr)
-			else
-				var/datum/loadout_manager/tgui = new(usr)
-				tgui.ui_interact(usr)
-			return TRUE
-		if ("open_language_picker")
-			var/datum/language_picker/tgui = new(src)
-			tgui.ui_interact(usr)
-			return TRUE
-		if ("open_spellbook")
-			if(parent.open_spellbook_ui)
-				parent.open_spellbook_ui.ui_interact(usr)
-			else
-				var/datum/spellbook_manager/tgui = new(usr)
-				tgui.ui_interact(usr)
-			return TRUE
-

--- a/maplestation_modules/code/modules/client/preferences/sound_frequency.dm
+++ b/maplestation_modules/code/modules/client/preferences/sound_frequency.dm
@@ -1,0 +1,14 @@
+/datum/preference/numeric/frequency_modifier
+	savefile_key = "speech_sound_frequency_modifier"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	can_randomize = FALSE
+	minimum = 0.5
+	maximum = 2
+	step = 0.05
+
+/datum/preference/numeric/frequency_modifier/apply_to_human(mob/living/carbon/human/target, value)
+	target.speech_sound_frequency_modifier = value
+
+/datum/preference/numeric/frequency_modifier/create_default_value()
+	return 1

--- a/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
+++ b/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
@@ -3,6 +3,15 @@
 /// Default, middle frequency
 #define DEFAULT_FREQUENCY 44100
 
+/mob/living
+	/// Modifier to speech sounds frequency
+	/// Lower = longer, deeper speech sounds
+	/// Higher = quicker, higher-pitch speech sounds
+	var/speech_sound_frequency_modifier = 1
+
+/mob/living/silicon
+	speech_sound_frequency_modifier = -1 // is set from preferences when we first speak.
+
 /**
  * Gets the sound this mob plays when they speak
  *
@@ -77,6 +86,12 @@
 		else
 			sound_type = SOUND_NORMAL
 			sound_frequency = round((get_rand_frequency() + get_rand_frequency()) / 2) //normal speaking is just the average of 2 random frequencies (to trend to the middle)
+
+	// [speech_sound_frequency_modifier] is set directly for humans via pref [apply_to_humans], but for other mobs we need to double-check
+	if(speech_sound_frequency_modifier == -1)
+		speech_sound_frequency_modifier = client?.prefs?.read_preference(/datum/preference/numeric/frequency_modifier) || 1
+
+	sound_frequency *= speech_sound_frequency_modifier
 
 	var/list/sound_pool = get_speech_sounds(sound_type)
 	if(!LAZYLEN(sound_pool))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/_speech_frequency.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/_speech_frequency.tsx
@@ -1,0 +1,27 @@
+import { FeatureNumeric, FeatureNumericData, FeatureNumberInput, FeatureValueProps } from '../base';
+import { Stack, Button } from '../../../../../components';
+
+const FeatureSpeechSoundFrequency = (
+  props: FeatureValueProps<number, number, FeatureNumericData>
+) => {
+  return (
+    <Stack>
+      <Stack.Item>
+        <Button
+          onClick={() => {
+            props.act('play_test_speech_sound');
+          }}
+          icon="play"
+        />
+      </Stack.Item>
+      <Stack.Item grow>
+        <FeatureNumberInput {...props} />
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+export const speech_sound_frequency_modifier: FeatureNumeric = {
+  name: 'Speech Sound Frequency',
+  component: FeatureSpeechSoundFrequency,
+};


### PR DESCRIPTION
Adds a character pref to modify frequency of speech sounds. 

Players can modify their speech between 0.5x and 2x frequency -
0.5x being twice as slow / twice as deep, and 2x being twice as fast / twice as high pitched. 

This pref has a "test sound" button in the preference menu. Find the perfect one today. 