### PR TITLE
Fixes language picker

### DIFF
--- a/maplestation_modules/code/modules/client/preferences/_preferences.dm
+++ b/maplestation_modules/code/modules/client/preferences/_preferences.dm
@@ -48,7 +48,7 @@
 			return TRUE
 		// Language UI
 		if ("open_language_picker")
-			var/datum/language_picker/tgui = new(user)
+			var/datum/language_picker/tgui = new(src)
 			tgui.ui_interact(user)
 			return TRUE
 		// Spellbook UI

--- a/maplestation_modules/code/modules/client/preferences/languages.dm
+++ b/maplestation_modules/code/modules/client/preferences/languages.dm
@@ -129,6 +129,7 @@
 	var/static/list/bonus_languages
 
 /datum/language_picker/New(datum/preferences/prefs)
+	ASSERT(istype(prefs))
 	owner_prefs = prefs
 
 /datum/language_picker/Destroy()


### PR DESCRIPTION
Slipped by me replacing `usr` with `user`.