### PR TITLE
Adds in admin spawn variants of the AI Shell, which come with power cells.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5634,6 +5634,7 @@
 #include "maplestation_modules\code\modules\mob\living\carbon\human\species_types\skrell.dm"
 #include "maplestation_modules\code\modules\mob\living\carbon\human\species_types\species.dm"
 #include "maplestation_modules\code\modules\mob\living\carbon\human\species_types\synths.dm"
+#include "maplestation_modules\code\modules\mob\living\silicon\robot\robot_defines.dm"
 #include "maplestation_modules\code\modules\mob\living\simple_animal\corpse.dm"
 #include "maplestation_modules\code\modules\mod\mod_control.dm"
 #include "maplestation_modules\code\modules\mod\modules\modules_general.dm"

--- a/maplestation_modules/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/maplestation_modules/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -1,0 +1,7 @@
+///A version of the AI shell for admin spawning that comes with a pre-installed energy cell
+/mob/living/silicon/robot/shell/admin_spawn
+	cell = /obj/item/stock_parts/cell/high
+
+///Comes with a pre-installed bluespace cell for later-game use or less optimal stations
+/mob/living/silicon/robot/shell/admin_spawn/bluespace
+	cell = /obj/item/stock_parts/cell/bluespace


### PR DESCRIPTION
Yeah this PR just adds admin spawn variants of the AI Shell, where they come with a power cell instead of being set to null.

/mob/living/silicon/robot/shell/admin_spawn
Comes with a high-capacity power cell.

/mob/living/silicon/robot/shell/admin_spawn/bluespace
Comes with a bluespace power cell.

I don't really see any reason for these types to exist outside of admin spawning and maybe a malf AI ability though, since we'd still want the crew to assemble any "Shell Ready-2-Eat" kits if they're obtainable anywhere other than robotics.