### PR TITLE
Changes default Keybind to pixelshift without Ctrl

### DIFF
--- a/maplestation_modules/code/modules/pixel_shift/code/pixel_shift_keybind.dm
+++ b/maplestation_modules/code/modules/pixel_shift/code/pixel_shift_keybind.dm
@@ -1,5 +1,5 @@
 /datum/keybinding/mob/living/pixel_shift
-	hotkey_keys = list("CtrlB")
+	hotkey_keys = list("V")
 	name = "pixel_shift"
 	full_name = "Pixel Shift"
 	description = "Shift your characters offset."


### PR DESCRIPTION
The default bind of Ctrl + B prevents characters from unpixelshifting. This changes it to V so new players won't have this problem.