### PR TITLE
Small puppy tweaks

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1873,13 +1873,13 @@
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agh" = (
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "agi" = (
@@ -5367,17 +5367,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/command/bridge)
 "arC" = (
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/transit_tube/station/reverse/flipped{
+/obj/structure/cable,
+/obj/structure/transit_tube/station/dispenser/reverse/flipped{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/command/bridge)
 "arD" = (
@@ -22280,10 +22277,7 @@
 /turf/open/floor/iron/smooth_half,
 /area/station/hallway/secondary/entry)
 "bAL" = (
-/obj/structure/transit_tube/station/reverse/flipped,
-/obj/structure/transit_tube_pod{
-	dir = 8
-	},
+/obj/structure/transit_tube/station/dispenser/reverse/flipped,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
 "bAM" = (
@@ -25530,7 +25524,7 @@
 /turf/closed/wall,
 /area/station/service/chapel/dock)
 "bNx" = (
-/obj/structure/transit_tube/station/reverse{
+/obj/structure/transit_tube/station/dispenser/reverse{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
@@ -39604,6 +39598,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -46246,14 +46243,14 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/drone_bay)
 "ndt" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 4
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)


### PR DESCRIPTION
Swaps the transit tube stations to be dispensers instead of simple stations

Adds a cargo request console outside cargo so you can actually order things