### PR TITLE
Fixes anesthesia locker access, adds shock blankets to generic medical lockers

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5416,6 +5416,7 @@
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\crates.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\asset_protection.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\bridge_officer.dm"
+#include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\medical.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\quartermaster.dm"
 #include "maplestation_modules\code\modules\admin\admin_vv.dm"
 #include "maplestation_modules\code\modules\admin\smites\pain_smite.dm"

--- a/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/medical.dm
+++ b/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/medical.dm
@@ -1,0 +1,9 @@
+// Adds shock blankets to general med lockers
+/obj/structure/closet/secure_closet/medical1/PopulateContents()
+	. = ..()
+	new /obj/item/shock_blanket(src)
+
+// Adds robotics access to anesthesiology lockers
+/obj/structure/closet/secure_closet/medical2
+	req_access = null
+	req_one_access = list(ACCESS_SURGERY, ACCESS_ROBOTICS)


### PR DESCRIPTION
- Roboticists now have access to Aneshetia lockers. 
- Medical lockers (those containing a pile of generic medical equipment) now spawn with shock blankets, since I was in the area. 