### PR TITLE
Adds liver and lung autosurgeons to cargo

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5683,6 +5683,7 @@
 #include "maplestation_modules\code\modules\research\techweb\_research.dm"
 #include "maplestation_modules\code\modules\research\techweb\all_nodes.dm"
 #include "maplestation_modules\code\modules\surgery\organs\augments_arms.dm"
+#include "maplestation_modules\code\modules\surgery\organs\autosurgeon.dm"
 #include "maplestation_modules\code\modules\surgery\organs\ears.dm"
 #include "maplestation_modules\code\modules\surgery\organs\eyes.dm"
 #include "maplestation_modules\code\modules\surgery\organs\tongue.dm"

--- a/maplestation_modules/code/modules/cargo/packs.dm
+++ b/maplestation_modules/code/modules/cargo/packs.dm
@@ -15,7 +15,7 @@
 /datum/supply_pack/medical/luciferium_bottles
 	name = "Luciferium Shipment"
 	desc = "Contains three bottles - sixty units - of Luciferium, an extremely dangerous drug that can cure the most absolute of medicinal issues, but cause permanent addiction. Requires CMO access to open."
-	cost = CARGO_CRATE_VALUE * 30
+	cost = PAYCHECK_COMMAND * 60
 	access = ACCESS_CMO
 	contraband = TRUE
 	crate_name = "luciferium Shipment"
@@ -38,7 +38,7 @@
 /datum/supply_pack/medical/go_juice_bottles
 	name = "Go-Juice Shipment"
 	desc = "Contains three bottles - sixty units - of Go-Juice, a potent but addictive combat stimulant and pain suppressant. Requires armory access to open."
-	cost = CARGO_CRATE_VALUE * 10
+	cost = PAYCHECK_COMMAND * 20
 	contraband = TRUE
 	access = ACCESS_ARMORY
 	crate_name = "go-juice Shipment"
@@ -51,7 +51,7 @@
 /datum/supply_pack/medical/psychoids
 	name = "Psychoid Variety Shipment"
 	desc = "Contains three randomly selected containers of drugs made from the psychoid leaf - Yayo, Flake, or Psychite Tea - often used to reduce pain and raise moods. Requires medical access to open."
-	cost = CARGO_CRATE_VALUE * 8
+	cost = PAYCHECK_COMMAND * 16
 	access = ACCESS_MEDICAL
 	crate_name = "psychoid shipment"
 	contains = list(
@@ -176,7 +176,7 @@
 /datum/supply_pack/medical/painkiller_syringes
 	name = "Painkiller Syringe Shipment"
 	desc = "Contains six syringes of general medicinal painkillers - Ibuprofen, Paracetamol, and Aspirin."
-	cost = CARGO_CRATE_VALUE * 7.5
+	cost = PAYCHECK_COMMAND * 15
 	crate_name = "syringe shipment"
 	contains = list(
 		/obj/item/reagent_containers/syringe/ibuprofen,
@@ -190,15 +190,34 @@
 /datum/supply_pack/medical/painkiller_pens
 	name = "Painkiller Medipen Shipment"
 	desc = "Contains three emergency painkiller medipens."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = PAYCHECK_COMMAND * 8
 	crate_name = "medipen shipment"
 	contains = list(
 		/obj/item/reagent_containers/hypospray/medipen/emergency_painkiller,
 		/obj/item/reagent_containers/hypospray/medipen/emergency_painkiller,
 		/obj/item/reagent_containers/hypospray/medipen/emergency_painkiller,
 	)
+
 /datum/supply_pack/goody/crew_plasma_sword_pack // this is, in effect, now a placeholder/current thing only. there are plans to rework this to instead require upgrades to get this to be good.
 	name = "Plasma Blade Case"
 	desc = "A premium (standard) case containing a highly advanced (dangerously volatile) NT Plasma Sword. Requires permit for open carry and use, but not for purchase."
 	cost = PAYCHECK_CREW * 30 // this should equal roughly 1500 credits on average.
 	contains = list(/obj/item/melee/maple_plasma_blade)
+
+/datum/supply_pack/medical/liver_autodoc
+	name = "Liver Replacement Autosurgeon"
+	desc = "Contains an emergency autosurgeon capable of quickly replacing a patient's damaged liver. \
+		Liver not included. Requires surgery access to open."
+	cost = PAYCHECK_COMMAND * 20
+	access = ACCESS_SURGERY
+	contains = list(/obj/item/autosurgeon/only_on_damaged_organs/liver)
+	crate_name = "autosurgeon crate"
+
+/datum/supply_pack/medical/lung_autodoc
+	name = "Lung Replacement Autosurgeon"
+	desc = "Contains an emergency autosurgeon capable of quickly replacing a patient's damaged lungs. \
+		Lungs not included. Requires surgery access to open."
+	cost = PAYCHECK_COMMAND * 20
+	access = ACCESS_SURGERY
+	contains = list(/obj/item/autosurgeon/only_on_damaged_organs/lungs)
+	crate_name = "autosurgeon crate"

--- a/maplestation_modules/code/modules/surgery/organs/autosurgeon.dm
+++ b/maplestation_modules/code/modules/surgery/organs/autosurgeon.dm
@@ -1,0 +1,36 @@
+/// Subtype of autosurgeons that only function if used on missing or heavily damaged organs.
+/obj/item/autosurgeon/only_on_damaged_organs
+	surgery_speed = 1.25
+	/// What organ slot do we check for damage?
+	var/slot_to_check
+
+/obj/item/autosurgeon/only_on_damaged_organs/attack_self(mob/user)
+	return // cringe but this shouldn't be instant-use
+
+/obj/item/autosurgeon/only_on_damaged_organs/load_organ(obj/item/organ/loaded_organ, mob/living/user)
+	if(loaded_organ.slot == slot_to_check)
+		return ..()
+
+	to_chat(user, span_alert("[src] is not compatible with [loaded_organ]."))
+	return FALSE
+
+/obj/item/autosurgeon/only_on_damaged_organs/use_autosurgeon(mob/living/target, mob/living/user, implant_time)
+	var/obj/item/organ/organ_to_check = target.get_organ_slot(slot_to_check)
+	if(isnull(organ_to_check) || organ_to_check.damage >= organ_to_check.high_threshold)
+		return ..()
+
+	audible_message(span_warning("[src] buzzes: [target]'s [organ_to_check] is not damaged enough to warrant replacement."))
+	playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+	return FALSE
+
+/obj/item/autosurgeon/only_on_damaged_organs/lungs
+	name = "lung emergency autosurgeon"
+	desc = "A device that automatically implants a new set of lungs. \
+		Only works on patients with heavily damaged or missing lungs."
+	slot_to_check = ORGAN_SLOT_LUNGS
+
+/obj/item/autosurgeon/only_on_damaged_organs/liver
+	name = "liver emergency autosurgeon"
+	desc = "A device that automatically implants a new liver. \
+		Only works on patients with heavily damaged or missing livers."
+	slot_to_check = ORGAN_SLOT_LIVER


### PR DESCRIPTION
- Adds Liver and *LUNG Emergency Autosurgeons to cargo.
   - These cost 2000 credits, but of course can be freely ordered with departmental orders. 
   - Requires surgery access. 
   - Cannot be self-used instantly, like other auto-surgeons. 
      - (They CAN be self-used, just not instantly. It requires a do_after as if used on another person.)
   - The only accept their corresponding organ types. 
   - These autosurgeons only work on mobs with very damaged or otherwise missing organs. 

Replacing the livers and lungs of people who repeatedly drink themselves is fun and all for the medical staff, but after the nth patient on the same round it maybe gets a little old. 

So, if an MD is starting to get impatient, they can pop in an order for one of these to make their life going forward easier. 
Someone comes in with a failing liver, just pop a new cybernetic liver in the autosurgeon and let it do the work. 