### PR TITLE
Adds `R_BAN`, `R_DEBUG`, or `R_SERVER` requirement to seeing ahelp ticket popups / tab

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -115,6 +115,8 @@ SUBSYSTEM_DEF(statpanels)
 	target.stat_panel.send_message("update_mc", list("mc_data" = mc_data, "coord_entry" = coord_entry))
 
 /datum/controller/subsystem/statpanels/proc/set_tickets_tab(client/target)
+	if(!check_rights_for(target, R_BAN|R_DEBUG|R_SERVER)) // NON-MODULE CHANGE
+		return
 	var/list/ahelp_tickets = GLOB.ahelp_tickets.stat_entry()
 	target.stat_panel.send_message("update_tickets", ahelp_tickets)
 	var/datum/interview_manager/m = GLOB.interviews

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -410,6 +410,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	//send this msg to all admins
 	for(var/client/X in GLOB.admins)
+		if(!check_rights_for(X, R_BAN|R_DEBUG|R_SERVER)) // NON-MODULE CHANGE
+			continue
 		if(X.prefs.toggles & SOUND_ADMINHELP)
 			SEND_SOUND(X, sound('sound/effects/adminhelp.ogg'))
 		window_flash(X, ignorepref = TRUE)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -555,6 +555,8 @@
 		else
 			log_admin_private("PM: [our_name]->External: [sanitize_text(trim(raw_message))]")
 		for(var/client/lad in GLOB.admins)
+			if(!check_rights_for(lad, R_BAN|R_DEBUG|R_SERVER)) // NON-MODULE CHANGE
+				continue
 			to_chat(lad,
 				type = MESSAGE_TYPE_ADMINPM,
 				html = span_notice("<B>PM: [our_linked_ckey]-&gt;External:</B> [keyword_parsed_msg]"),
@@ -583,6 +585,8 @@
 	//we don't use message_admins here because the sender/receiver might get it too
 	for(var/client/lad in GLOB.admins)
 		if(lad.key == key || lad.key == recipient_key) //check to make sure client/lad isn't the sender or recipient
+			continue
+		if(!check_rights_for(lad, R_BAN|R_DEBUG|R_SERVER)) // NON-MODULE CHANGE
 			continue
 		to_chat(lad,
 			type = MESSAGE_TYPE_ADMINPM,


### PR DESCRIPTION
By request: Admins require one of `R_BAN` (banning permissions) `R_DEBUG` (debug permissions) or `R_SERVER` (server restart permissions) to see ahelps. 

Also: This is very much not foolproof, as long as someone knows how VV works they you can unwrap the ahelp tracker pretty easily. However it should serve for our purposes (and is very easily caught). 

Also also: This also half affects interviews because the panels are intertwined, but I couldn't bring myself to care about it since we don't do in game interviews. In fact I imagine they're disabled.

Also also also: this is difficult to test, so should be test-merged on a pre-round or something.

