### PR TITLE
Makes Lima Cargo Vertical 

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -2125,7 +2125,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aQn" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Quartermaster's Office"
@@ -11810,9 +11809,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"epu" = (
-/turf/open/space/basic,
-/area/station/maintenance/port/lower)
 "epw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -30688,7 +30684,6 @@
 "kMh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49837,9 +49832,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/barricade,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "qUf" = (
@@ -94481,18 +94473,18 @@ aDd
 jkB
 aDd
 fLP
-epu
-epu
-epu
-epu
-epu
-epu
-epu
-epu
-epu
-epu
-epu
-epu
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
+ymg
 cQP
 mSr
 moF

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -194,12 +194,24 @@
 /turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
 "afD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
+/obj/structure/industrial_lift/public,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/storage)
+"afV" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/button/elevator/directional/north{
+	id = "cargolift"
+	},
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "cargolift"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "agd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -512,34 +524,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/surgery)
 "alQ" = (
-/obj/structure/table,
-/obj/item/stack/wrapping_paper{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/stack/package_wrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/camera{
 	c_tag = "Cargo - Delivery Office";
-	dir = 10;
+	dir = 9;
 	network = list("ss13","qm")
 	},
-/obj/item/hand_labeler{
-	pixel_y = 8
-	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	name = "Cargo Bay RC";
-	pixel_x = -30
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/turf/open/floor/iron,
 /area/station/cargo/sorting)
 "amq" = (
 /obj/effect/turf_decal/bot/right,
@@ -927,16 +919,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"arK" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "arM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -1490,6 +1472,12 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/security/detectives_office/bridge_officer_office)
+"aDa" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "aDd" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
@@ -1509,6 +1497,10 @@
 "aDn" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
+"aDw" = (
+/obj/vehicle/sealed/mecha/working/ripley/cargo,
+/turf/open/floor/iron/recharge_floor,
+/area/space)
 "aDx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1810,7 +1802,8 @@
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "packageSort2";
-	pixel_y = 20
+	pixel_y = 17;
+	pixel_x = 8
 	},
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron,
@@ -2023,6 +2016,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/service/bar)
+"aOk" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/cargo/warehouse)
 "aOu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2101,10 +2100,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aQn" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Quartermaster's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/floor/iron/textured,
+/area/space)
 "aQq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -2188,11 +2193,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aRR" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "aRY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3126,6 +3130,9 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"bhY" = (
+/turf/open/space/openspace,
+/area/station/cargo/storage)
 "biB" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
@@ -3223,11 +3230,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bkc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "bkm" = (
@@ -3449,8 +3452,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "bnt" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -3993,6 +3996,7 @@
 	sortType = 3
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bzc" = (
@@ -4077,10 +4081,11 @@
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "bzK" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/station/cargo/storage)
 "bzN" = (
 /obj/machinery/door/firedoor/heavy,
@@ -4135,11 +4140,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/fore)
-"bAH" = (
-/obj/effect/decal/cleanable/plastic,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "bAM" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -4270,6 +4270,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/warning/docking/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "bCx" = (
@@ -4628,9 +4629,8 @@
 /area/station/hallway/primary/upper)
 "bJy" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "bJI" = (
@@ -4726,6 +4726,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"bLD" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bLJ" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/telecomms,
@@ -4801,13 +4805,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/cargo/office)
-"bNG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bNH" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5104,12 +5101,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "bSi" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/space)
 "bSE" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -5142,6 +5141,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"bTd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/space)
 "bTh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -5179,6 +5182,18 @@
 	dir = 4
 	},
 /area/station/cargo/miningdock)
+"bUJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargodelivery";
+	pixel_x = -8;
+	pixel_y = 17
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bUO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -5210,11 +5225,8 @@
 /area/station/hallway/secondary/service)
 "bVu" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/turf/open/floor/carpet/orange,
+/area/space)
 "bVz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -5363,19 +5375,6 @@
 	},
 /turf/open/space/openspace,
 /area/space)
-"bZg" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	name = "Cargo Bay RC";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bZk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -5433,6 +5432,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
+"cad" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cae" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -5441,6 +5450,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/hallway/secondary/service)
+"cav" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood/large,
+/area/space)
 "caw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shieldgen,
@@ -5464,6 +5477,9 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"caL" = (
+/turf/open/floor/engine/hull,
+/area/space)
 "caT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5491,14 +5507,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/industrial/loader,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light_switch/directional/west{
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/airalarm/directional/west,
+/turf/closed/wall,
+/area/space)
 "ccb" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -5578,17 +5589,12 @@
 /turf/closed/wall,
 /area/station/service/library/abandoned)
 "cdw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/turf/open/floor/wood/large,
+/area/space)
+"cdK" = (
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/station/maintenance/port/lower)
 "cdP" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/camera{
@@ -5991,12 +5997,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
-"cof" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "cop" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -6168,12 +6168,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"crW" = (
-/obj/machinery/door/poddoor{
-	id = "dont_let_people_open_this"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "csa" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -6377,11 +6371,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
-"ctT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "cud" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7153,14 +7142,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"cGM" = (
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/start/quartermaster,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "cGS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8315,14 +8296,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "ddc" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "ddg" = (
@@ -8699,12 +8676,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/cargo/office)
-"djF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/trash/grime,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "djN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8963,11 +8934,6 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
-"dpf" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "dpy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/spawner/directional/south,
@@ -9439,17 +9405,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"dyk" = (
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "dys" = (
 /obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
@@ -9786,6 +9741,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central)
+"dEe" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/folder/yellow,
+/obj/item/stamp/head/qm,
+/turf/open/floor/carpet/orange,
+/area/space)
 "dEK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -10196,6 +10158,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"dML" = (
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/space)
 "dMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10863,13 +10830,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"ebR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "ebZ" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/misc/dirt{
@@ -10906,13 +10866,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"ecU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "ede" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -10970,6 +10923,9 @@
 "eei" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/cargo)
+"eep" = (
+/turf/open/floor/iron,
+/area/space)
 "eeq" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -11493,14 +11449,6 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
-"eoW" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/vehicle/sealed/mecha/working/ripley/cargo,
-/turf/open/floor/iron/recharge_floor,
-/area/station/cargo/storage)
 "epe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12308,6 +12256,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"eDl" = (
+/obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "eDp" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -12690,13 +12643,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
-"eJJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "eKe" = (
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -12943,6 +12889,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"eNy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/button/elevator/directional/south{
+	id = "cargolift"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "cargolift"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "eNB" = (
 /obj/structure/cable,
 /turf/open/floor/wood/large,
@@ -13454,10 +13416,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"eXc" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/engine/atmos)
 "eXd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -13749,19 +13707,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "fcf" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
-"fcg" = (
-/obj/structure/ladder,
-/obj/structure/sign/departments/maint/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "fci" = (
 /turf/closed/wall,
 /area/station/maintenance/port)
@@ -13789,16 +13739,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
-"fcC" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fcD" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -13901,15 +13841,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
-"feg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fei" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14160,6 +14091,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"fjk" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood/large,
+/area/space)
 "fjv" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -14422,20 +14357,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/experiment_room)
 "fnd" = (
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/machinery/camera{
-	c_tag = "Cargo - Bay";
-	dir = 5;
-	network = list("ss13","qm")
-	},
-/obj/machinery/status_display/supply{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
 /area/station/cargo/storage)
 "fnr" = (
 /obj/structure/cable,
@@ -14799,6 +14723,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
+"ftE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "ftP" = (
 /obj/machinery/component_printer{
 	pixel_y = 4
@@ -14825,6 +14758,12 @@
 	dir = 4
 	},
 /turf/open/space/openspace,
+/area/space)
+"fub" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron,
 /area/space)
 "ful" = (
 /turf/open/floor/iron/sepia,
@@ -14930,6 +14869,16 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science)
+"fxn" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "fxK" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14948,6 +14897,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"fxW" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/space)
 "fyd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15007,6 +14961,9 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
+"fzK" = (
+/turf/open/floor/plating,
+/area/space)
 "fzS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -15390,6 +15347,15 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"fGj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fGS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -15580,6 +15546,11 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/barber)
+"fKf" = (
+/obj/structure/table,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "fKl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15629,10 +15600,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "fKP" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/gloves/color/fyellow,
-/turf/open/floor/plating,
+/obj/structure/stairs/west{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/station/maintenance/port/lower)
 "fKT" = (
 /obj/machinery/light/directional/north,
@@ -15665,6 +15636,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos)
+"fLP" = (
+/obj/machinery/door/poddoor{
+	id = "dont_let_people_open_this"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "fLZ" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -16168,13 +16145,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
-"fVu" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fVL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -16868,6 +16838,12 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"gkN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "gla" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17449,6 +17425,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
+"gvK" = (
+/obj/machinery/photocopier,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood/large,
+/area/space)
 "gwd" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/yellow{
@@ -18763,10 +18744,12 @@
 /area/station/engineering/atmos)
 "gSr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/light_switch/directional/west{
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "gSs" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/co2,
@@ -19646,10 +19629,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"hjh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "hjo" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -19747,13 +19726,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"hlk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hlm" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -20532,11 +20504,12 @@
 /turf/open/floor/carpet/orange,
 /area/station/service/lawoffice)
 "hzX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/space)
 "hAb" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -20609,13 +20582,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBC" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/flora/grass/jungle,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "hBI" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -20897,6 +20865,9 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"hGZ" = (
+/turf/closed/wall,
+/area/space)
 "hHf" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -21288,6 +21259,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"hMb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "hMg" = (
 /obj/structure/flora/grass/green,
 /obj/machinery/light/directional/north,
@@ -21432,6 +21407,10 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/lower)
+"hPv" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/cargo/storage)
 "hPE" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
@@ -21898,13 +21877,6 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"hYg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hYr" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
@@ -22127,15 +22099,6 @@
 /obj/structure/stairs/west,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"idj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "idn" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/showroomfloor,
@@ -22157,21 +22120,6 @@
 /mob/living/basic/lizard/wags_his_tail,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
-"idE" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table,
-/obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = -3
-	},
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "idP" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -22321,11 +22269,6 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"igQ" = (
-/obj/effect/spawner/random/decoration/glowstick,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "igZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -22421,6 +22364,14 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/textured_half,
 /area/station/engineering/gravity_generator)
+"iii" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "iij" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -22614,6 +22565,14 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ilF" = (
+/obj/structure/table,
+/obj/machinery/fax/deluxe,
+/obj/machinery/status_display/supply{
+	pixel_y = -32
+	},
+/turf/open/floor/wood/large,
+/area/space)
 "ilN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22641,18 +22600,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/checkpoint/arrivals)
-"ini" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/conveyor_switch/oneway{
-	id = "cargodelivery";
-	pixel_x = -8;
-	pixel_y = 17
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "inI" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/grimy,
@@ -22992,22 +22939,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"isX" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = -3
-	},
-/obj/machinery/light/directional/west,
-/obj/item/dest_tagger,
-/obj/item/crowbar,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/sorting)
 "ite" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23277,12 +23208,6 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/arrivals)
-"iyT" = (
-/obj/machinery/door/poddoor{
-	id = "dont_let_people_open_this"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "izf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23875,6 +23800,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"iJA" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet/orange,
+/area/space)
 "iJL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24067,6 +24001,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"iMY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/openspace,
+/area/space)
 "iNm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -24687,16 +24628,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/cryo)
-"iYo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "iYq" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -24881,6 +24812,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"jdy" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "jdI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -24900,9 +24838,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jec" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -25456,15 +25396,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"jqZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "QM #3"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/storage)
 "jrb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing"
@@ -25551,10 +25482,30 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "jsy" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "QMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = -24;
+	pixel_y = 8;
+	req_access = list("cargo")
+	},
+/obj/machinery/button/door{
+	id = "QMLoaddoor";
+	layer = 4;
+	name = "Loading Doors 2";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access = list("cargo")
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "jsE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -26072,6 +26023,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jBb" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/cargo/sorting)
 "jBc" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -26323,11 +26278,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
-"jFt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "jFu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -26434,6 +26384,13 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"jIA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command/glass{
+	name = "Quartermaster's Office"
+	},
+/turf/open/floor/iron/textured,
+/area/space)
 "jIN" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
@@ -26721,6 +26678,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/docking/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "jMO" = (
@@ -26841,6 +26799,19 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"jPG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/space)
 "jPO" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -27027,6 +26998,17 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
+"jTc" = (
+/mob/living/simple_animal/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "QM #2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/cargo)
 "jTh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27177,14 +27159,13 @@
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "jVx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/openspace,
+/area/space)
 "jVy" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wrench,
@@ -27529,6 +27510,13 @@
 /obj/effect/landmark/start/ordnance_tech,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"kax" = (
+/obj/machinery/keycard_auth/directional/north,
+/obj/machinery/computer/security/qm{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/cargo/warehouse)
 "kaB" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -27618,8 +27606,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kbn" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -27789,7 +27777,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "kdW" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -27827,6 +27814,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"kez" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "keD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28606,13 +28600,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/medical/break_room)
-"ksy" = (
-/obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "ksF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29749,6 +29736,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"kMq" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/textured,
+/area/space)
 "kMs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -29841,11 +29833,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"kOk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "kOp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29913,12 +29900,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Quartermaster's Office"
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Bay"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "kPI" = (
@@ -30316,6 +30300,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
+"kWg" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/space)
 "kWm" = (
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
@@ -30657,7 +30647,6 @@
 /turf/open/floor/iron/airless,
 /area/station/tcommsat/oldaisat/stationside)
 "lco" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "lcp" = (
@@ -30851,6 +30840,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"leJ" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "leN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/medbay/alt/directional/west,
@@ -31568,6 +31561,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"lpw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "lpE" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -31625,15 +31626,6 @@
 /obj/effect/spawner/random/food_or_drink/snack/lizard,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"lqh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "lqm" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 4
@@ -31799,6 +31791,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ltP" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "ltV" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/suit/white_on_white,
@@ -31878,6 +31876,14 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"lvw" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/wood/large,
+/area/space)
 "lvy" = (
 /obj/effect/landmark/start/xenobiologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32427,11 +32433,13 @@
 /turf/open/floor/plating/airless,
 /area/station/tcommsat/oldaisat/stationside)
 "lER" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/openspace,
+/area/space)
 "lET" = (
 /obj/structure/sign/poster/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32955,6 +32963,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"lNg" = (
+/obj/structure/table,
+/obj/item/stack/package_wrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "lNh" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33759,8 +33782,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/structure/table,
-/obj/machinery/fax/deluxe,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "mcm" = (
@@ -34287,6 +34308,10 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"mkP" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/orange,
+/area/space)
 "mli" = (
 /obj/machinery/light/cold/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -34733,11 +34758,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage)
 "mtx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/floor/plating,
+/area/space)
 "mtD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -35035,6 +35061,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"myV" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "mzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35159,19 +35189,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"mBo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/textured,
-/area/station/cargo/storage)
 "mBp" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/firealarm/directional/east,
@@ -35582,35 +35599,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
-"mKY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor2";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = 8;
-	req_access = list("cargo")
-	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor";
-	layer = 4;
-	name = "Loading Doors 2";
-	pixel_x = -24;
-	pixel_y = -8;
-	req_access = list("cargo")
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "mLj" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -35951,8 +35939,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "mPI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "mPQ" = (
@@ -36059,12 +36046,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "mRa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Quartermaster Maintenance"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "mRo" = (
@@ -36584,15 +36569,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "mZX" = (
-/obj/machinery/computer/security/qm{
-	dir = 4;
-	network = list("mine","auxbase","vault","qm")
-	},
-/obj/machinery/camera{
-	c_tag = "Command - Quartermaster's Office";
-	dir = 10;
-	network = list("ss13","qm")
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
@@ -37489,6 +37465,18 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"npt" = (
+/obj/machinery/camera{
+	c_tag = "Cargo - Bay";
+	dir = 5;
+	network = list("ss13","qm")
+	},
+/obj/machinery/status_display/supply{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/space)
 "npJ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/sepia,
@@ -37994,6 +37982,17 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"nyj" = (
+/obj/machinery/button/door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -1;
+	pixel_y = -24;
+	req_access = list("cargo")
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nyw" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/iron/dark/telecomms,
@@ -38660,17 +38659,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "nHW" = (
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "QM #2"
-	},
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
 /area/station/cargo/storage)
 "nIg" = (
 /obj/structure/window/spawner/directional/west,
@@ -38841,8 +38833,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nKD" = (
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "nKE" = (
 /obj/machinery/door/firedoor,
@@ -39206,12 +39197,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
 "nSK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/effect/landmark/start/quartermaster,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/space)
 "nSN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -39999,6 +39991,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"ohA" = (
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/space)
 "ohL" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
@@ -40024,6 +40025,9 @@
 "oig" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
+"oio" = (
+/turf/open/floor/carpet/orange,
+/area/space)
 "oit" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40477,6 +40481,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
+"opv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "opD" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -40821,6 +40832,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
+"ovc" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ovg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -41475,14 +41495,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/ordnance/testlab)
 "oHi" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/large,
+/area/space)
 "oHw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41913,10 +41928,14 @@
 	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
-"oQp" = (
-/obj/effect/turf_decal/bot,
+"oQI" = (
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -6
+	},
+/obj/structure/table,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/space)
 "oQK" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -43492,14 +43511,15 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "prB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Command - Quartermaster's Office";
+	dir = 10;
+	network = list("ss13","qm")
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/obj/machinery/pdapainter/supply,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/wood/large,
+/area/space)
 "prF" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -43690,10 +43710,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "puo" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/obj/effect/landmark/lift_id{
+	specific_lift_id = "cargolift"
+	},
+/obj/structure/industrial_lift/public,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/storage)
 "pus" = (
 /obj/machinery/camera{
 	c_tag = "Aft Hallway - Custodial Closet";
@@ -44275,7 +44300,6 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "pEc" = (
-/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/disposaloutlet{
@@ -44303,6 +44327,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
+"pEy" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 4;
+	height = 7;
+	shuttle_id = "cargo_home";
+	name = "Cargo Bay";
+	width = 10
+	},
+/turf/open/space/basic,
+/area/space)
 "pET" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/line,
@@ -44402,6 +44437,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"pGC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/space)
 "pGI" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -44639,9 +44680,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
 "pKm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -44943,24 +44981,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/station/ai_monitored/command/nuke_storage)
-"pRj" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 30
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Cargo - Mech Pad";
-	dir = 9;
-	network = list("ss13","qm")
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pRk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45310,6 +45330,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"pWO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
+"pWS" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood/large,
+/area/space)
 "pWZ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -45355,12 +45386,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/airless,
 /area/station/tcommsat/oldaisat/stationside)
-"pXU" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "pXV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -45626,14 +45651,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"qci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "qcl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -45825,11 +45842,6 @@
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"qgk" = (
-/obj/structure/sign/warning/docking/directional/south,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "qgp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
@@ -46194,18 +46206,17 @@
 /turf/open/floor/iron,
 /area/station/medical/surgery)
 "qli" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/keycard_auth/directional/east{
-	pixel_y = 8
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 24;
-	pixel_y = -5
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/machinery/pdapainter/supply,
+/obj/structure/table,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = -3
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qlv" = (
@@ -46759,6 +46770,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qtv" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/conveyor{
+	id = "cargodelivery";
+	name = "Cargo Belt"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "qtw" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/wood,
@@ -46985,18 +47004,8 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/library)
 "qwW" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/folder/yellow,
-/obj/item/stamp/head/qm,
-/obj/machinery/requests_console{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC";
-	pixel_y = -30
-	},
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qwY" = (
@@ -47071,6 +47080,13 @@
 	},
 /turf/open/floor/glass,
 /area/station/science/xenobiology)
+"qxI" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/space)
 "qxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47143,6 +47159,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"qyx" = (
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "qyy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/electrified_grille,
@@ -47555,9 +47576,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qHd" = (
-/obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
-/obj/structure/window/spawner/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -47826,6 +47845,14 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"qMT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "qNf" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood,
@@ -47983,6 +48010,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/bar)
+"qQa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "qQd" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -48203,6 +48236,12 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"qTw" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "qTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -48846,8 +48885,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/modular_computer/console/preset/id{
-	dir = 8
+/obj/structure/table,
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates{
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -48890,11 +48931,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rfh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/openspace,
+/area/space)
 "rfv" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room"
@@ -49452,18 +49490,12 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"rpu" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance"
+"rpw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/wood/large,
+/area/space)
 "rpL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -49509,6 +49541,19 @@
 "rqp" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"rqt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rqM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49874,6 +49919,12 @@
 	dir = 1
 	},
 /area/station/security/execution/education)
+"rvX" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "rwb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -49909,6 +49960,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"rxw" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "rxA" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 1
@@ -50285,14 +50342,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rDP" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron/dark,
+/obj/machinery/rnd/bepis,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "rEe" = (
 /obj/structure/cable,
@@ -50662,6 +50715,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"rJp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner,
+/turf/open/openspace,
+/area/space)
 "rJr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50675,9 +50734,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
 "rJt" = (
-/obj/structure/sign/warning/docking{
-	pixel_y = 31
-	},
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -50973,6 +51029,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"rOj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "rOl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -51587,6 +51649,12 @@
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
+"rXB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "rXI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/airalarm/directional/east,
@@ -52119,6 +52187,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lower)
+"sgr" = (
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "sgz" = (
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/bar)
@@ -52450,6 +52521,25 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"snr" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/folder/yellow,
+/obj/item/dest_tagger,
+/obj/item/crowbar{
+	pixel_x = 13
+	},
+/obj/item/pen{
+	pixel_x = -3
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	name = "Cargo Bay RC";
+	pixel_y = 32
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "sns" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/plating,
@@ -52737,6 +52827,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"ssl" = (
+/obj/structure/stairs/west{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "ssv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53171,12 +53267,15 @@
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
 "szZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "sAa" = (
 /obj/effect/turf_decal/tile/purple,
@@ -53692,11 +53791,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"sHS" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "sIg" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
 /obj/effect/spawner/random/maintenance/two,
@@ -53782,14 +53876,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
-"sIW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "sIZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -54054,6 +54140,12 @@
 /obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"sNy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "sNF" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -54074,10 +54166,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos)
 "sNT" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Mail Delivery";
-	req_access = list("shipping")
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -54349,13 +54437,6 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/station/science/server)
-"sRn" = (
-/obj/machinery/light/small/red/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "sRI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54755,6 +54836,19 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
+"sZH" = (
+/obj/machinery/requests_console{
+	department = "Quartermaster's Desk";
+	name = "Quartermaster RC";
+	pixel_y = -30
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/cargo/warehouse)
 "tak" = (
 /obj/machinery/computer/exodrone_control_console{
 	dir = 1
@@ -55340,6 +55434,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"tkQ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "tli" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -56050,6 +56157,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
+"txB" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "txC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56166,6 +56279,11 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"tAa" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/space)
 "tAw" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/delivery,
@@ -56641,6 +56759,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tKq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/space)
 "tKs" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -56965,10 +57089,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"tQk" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "tQu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -57148,10 +57268,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/main)
-"tTI" = (
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "tTW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -57434,6 +57550,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"tZu" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "tZv" = (
 /obj/machinery/camera{
 	c_tag = "Service - Library Quiet Room";
@@ -58186,12 +58311,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "unl" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/flora/bush/leavy/style_random,
-/turf/open/floor/grass,
+/obj/machinery/suit_storage_unit/industrial/loader,
+/turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "unr" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -58369,6 +58490,18 @@
 /obj/structure/grille/broken,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lower)
+"upH" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "upJ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/robotics/mechbay)
@@ -58680,6 +58813,10 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/service)
+"uuK" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/cargo)
 "uuL" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleportershutters";
@@ -59000,13 +59137,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"uCI" = (
-/obj/effect/landmark/start/quartermaster,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "uCW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59055,6 +59185,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
+"uDr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/open/openspace,
+/area/space)
 "uDD" = (
 /obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/trimline/red/filled/end{
@@ -59411,11 +59546,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/abandoned_gambling_den)
 "uKw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "uKx" = (
@@ -59634,6 +59769,18 @@
 /obj/item/paper/fake_report/water,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/lower)
+"uNK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uNV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60849,6 +60996,16 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"vle" = (
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	name = "Cargo Bay RC";
+	pixel_x = 32
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/turf/open/floor/iron,
+/area/space)
 "vlk" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 5"
@@ -60863,6 +61020,13 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"vls" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/space)
 "vlu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -61257,6 +61421,13 @@
 /obj/machinery/gravity_generator/main,
 /turf/open/floor/iron/smooth_half,
 /area/station/engineering/gravity_generator)
+"vsn" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "QM #4"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "vsr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -61790,11 +61961,14 @@
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/aft)
 "vDN" = (
-/obj/machinery/conveyor{
-	id = "cargodelivery";
-	name = "Cargo Belt"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "QM #3"
 	},
-/obj/machinery/firealarm/directional/north,
+/mob/living/simple_animal/bot/mulebot{
+	home_destination = "QM #3";
+	suffix = "#3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "vDW" = (
@@ -61812,19 +61986,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"vEr" = (
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/directional/south,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "QM #1"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/storage)
+"vEn" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/space)
 "vEt" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape{
@@ -61913,10 +62078,6 @@
 	dir = 4
 	},
 /area/station/science/lab)
-"vFK" = (
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "vFM" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -61963,6 +62124,10 @@
 	name = "Quartermaster's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/effect/landmark/navigate_destination,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/textured,
 /area/station/command/heads_quarters/qm)
 "vGM" = (
@@ -62185,6 +62350,10 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"vMq" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "vMu" = (
 /obj/machinery/atmospherics/components/tank/air{
 	initialize_directions = 4;
@@ -62369,6 +62538,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vPg" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "vPp" = (
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
@@ -62688,12 +62861,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"vWh" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "vWm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63119,10 +63286,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
-"wfh" = (
-/obj/machinery/rnd/bepis,
-/turf/open/floor/iron/dark,
-/area/station/cargo/storage)
 "wfu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63352,9 +63515,12 @@
 /turf/closed/wall,
 /area/station/maintenance/department/science)
 "wke" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/space)
 "wki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -63530,8 +63696,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/hydroponics/park)
 "wmw" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/station/cargo/storage)
 "wmy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
@@ -64950,15 +65115,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/station/engineering/gravity_generator)
-"wOF" = (
-/obj/structure/cable,
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "wOO" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line,
@@ -65049,6 +65205,15 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"wQI" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "QM #1"
+	},
+/obj/machinery/newscaster/directional/west,
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/cargo)
 "wQK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65411,6 +65576,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"wXS" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/space)
 "wYf" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -65449,15 +65620,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"wYF" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "wYH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -65995,6 +66157,13 @@
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
+"xhz" = (
+/obj/structure/industrial_lift/public,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/storage)
 "xhH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -66114,6 +66283,12 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"xjB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "xjF" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -66392,6 +66567,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"xpn" = (
+/turf/open/floor/engine/hull,
+/area/station/cargo/storage)
 "xpq" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/directional/west,
@@ -66539,21 +66717,11 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "xrn" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -1;
-	pixel_y = -24;
-	req_access = list("cargo")
-	},
-/obj/item/clothing/shoes/wheelys/rollerskates,
-/obj/item/clothing/shoes/wheelys/rollerskates{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/space)
 "xrV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66729,6 +66897,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"xuP" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "xuW" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair,
@@ -67256,7 +67429,7 @@
 /area/station/hallway/primary/fore)
 "xFk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/closed/wall,
 /area/station/cargo/sorting)
@@ -67357,6 +67530,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"xHu" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/space)
 "xHB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -67622,6 +67799,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"xLZ" = (
+/turf/open/floor/iron,
+/area/space/nearstation)
 "xMg" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
@@ -67665,6 +67845,10 @@
 	dir = 4
 	},
 /area/station/security/courtroom)
+"xMK" = (
+/obj/effect/turf_decal/arrows/red,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "xMQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -67720,13 +67904,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xNR" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "xNZ" = (
 /turf/closed/wall,
 /area/station/medical/medbay/central)
@@ -67742,11 +67919,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"xOx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "xOE" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -68665,9 +68837,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/filingcabinet,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "yew" = (
@@ -92167,7 +92336,7 @@ sag
 cjW
 vjV
 owa
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -92424,7 +92593,7 @@ sag
 sag
 shr
 owa
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -92681,7 +92850,7 @@ yci
 uLo
 sag
 iPl
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -92938,7 +93107,7 @@ aDd
 aDd
 sag
 nHh
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -93195,7 +93364,7 @@ dDJ
 aDd
 tDy
 vjV
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -93452,7 +93621,7 @@ dDJ
 oxz
 sag
 vjV
-cQP
+fLP
 ymg
 ymg
 ymg
@@ -93709,14 +93878,14 @@ aDd
 blm
 sag
 nHh
-cQP
+fLP
 ymg
 ymg
 ymg
 ymg
 ymg
 ymg
-ymg
+pEy
 ymg
 ymg
 ymg
@@ -93966,16 +94135,16 @@ sag
 sag
 sag
 owa
-cQP
+fLP
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+xoF
+vOw
+vrt
+nnR
+vrt
+iRs
+xoF
 ymg
 ymg
 ymg
@@ -94223,16 +94392,16 @@ hkb
 sag
 wAn
 owa
-cQP
+fLP
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+xoF
+coF
+ipg
+xoF
+ipg
+aGb
+xoF
 ymg
 ymg
 ymg
@@ -94479,22 +94648,22 @@ aDd
 dDJ
 sag
 sag
-hYg
+aDd
 bfg
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
-cQP
+xoF
+xoF
+xPT
+vOw
+sxI
+xPT
+sxI
+iRs
+xPT
+sfW
+ivt
+ivt
 bfg
-wAL
+aDd
 aDd
 sag
 ymg
@@ -94736,23 +94905,23 @@ aDd
 sag
 sag
 deJ
-igQ
+aDd
 sag
-yiL
-yiL
-aDd
-aDd
-aDd
+qtv
+rnp
+vDe
+dKS
+lKl
 jsy
-auY
-fra
-jdh
-mSr
-bAH
-auY
-auY
-auY
-wAn
+dfF
+aiQ
+wuZ
+mZz
+vEP
+vEP
+sag
+sag
+sag
 sag
 ymg
 ymg
@@ -94992,22 +95161,22 @@ sag
 iDO
 sag
 aDd
-jkB
-owa
-sag
-sag
-sag
-jyd
-jkB
 dDJ
-auY
-dDJ
-cjW
-qii
-dDJ
-jrJ
 aDd
-dDJ
+iii
+uNK
+uNK
+rqt
+opv
+bUJ
+amr
+gdw
+vYk
+pWO
+xCr
+tkQ
+fxn
+upH
 gSr
 sag
 sag
@@ -95248,24 +95417,24 @@ sag
 ofn
 aDd
 hna
-dDJ
-crf
-vjV
 aDd
+aDd
+aDd
+sag
 puo
-sag
-aDd
-jFt
-hna
-ymh
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
+xhz
+ovc
+sgr
+sgr
+eKN
+vBr
+gkN
+bLD
+pdF
+rxw
+rXB
+ftE
+dbf
 sag
 xsG
 xsG
@@ -95503,27 +95672,27 @@ auY
 auY
 ahI
 auY
-rbW
-fIx
-ptl
-ptl
 sIV
-rbW
-fIx
-afD
-fIx
-sIV
-fIx
-tKD
+owa
+aDd
+aDd
+aDd
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+afD
+afD
+fGj
+sgr
+sgr
+pep
+sgr
+sgr
+nyj
+sfW
+cvd
+oSp
+lMT
+gDa
+hGZ
 ymg
 xsG
 xsG
@@ -95760,27 +95929,27 @@ rhb
 aDd
 sag
 dDJ
+kez
 aDd
 aDd
-ldO
-xOx
-rhb
-ctT
+aDd
 aDd
 sag
-aDd
-rhb
-dDJ
-fIx
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+sag
+afV
+xMK
+eDl
+qQa
+qyx
+ltP
+npt
+sfW
+xGo
+xom
+sjB
+wkA
+hGZ
 ymg
 ymg
 wNX
@@ -96020,24 +96189,24 @@ sag
 sag
 sag
 sag
+aDd
+aDd
 sag
-sag
-sag
-sag
-sag
-sag
-sag
-dDJ
-fIx
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+leJ
+hMb
+sNy
+hna
+myV
+xjB
+hna
+eep
+fub
+sfW
+bsK
+mPR
+orL
+bfY
+hGZ
 ymg
 ymg
 wNX
@@ -96276,25 +96445,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
-jkB
+hGZ
+fzK
+fzK
+hGZ
+kMq
+bTd
+aDa
+xMK
+cdK
 aRR
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+cdK
+ltP
+xHu
+sfW
+sLc
+lTH
+osO
+cjl
+hGZ
 ymg
 ymg
 wNX
@@ -96533,25 +96702,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
-aDd
-fIx
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+hGZ
+fzK
+fzK
+hGZ
+aDw
+bTd
+wXS
+rOj
+qTw
+tZu
+qTw
+pGC
+kWg
+hGZ
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 ymg
 wNX
@@ -96790,25 +96959,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
+hGZ
+fzK
+fzK
+hGZ
+hGZ
+hGZ
+tAa
+hMb
 fKP
-fIx
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+ssl
+ssl
+bTd
+fxW
+hGZ
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 ymg
 wNX
@@ -97047,25 +97216,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+hGZ
+fzK
+fzK
+hGZ
+eep
+hGZ
+oQI
+fKf
 sag
 sag
-eJJ
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-xsG
+vle
+qxI
+hGZ
+eep
+eep
+eep
+xLZ
+pAf
 xsG
 wNX
 wNX
@@ -97304,25 +97473,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+hGZ
+fzK
+fzK
+hGZ
+eep
+hGZ
+hGZ
 sag
-aDd
-fIx
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+hna
+sag
+hGZ
+hGZ
+hGZ
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 wNX
 ymg
@@ -97561,25 +97730,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
-aDd
-rbW
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+hGZ
+fzK
+fzK
+hGZ
+eep
+eep
+eep
+hna
+hna
+hna
+hna
+eep
+eep
+eep
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 wNX
 ymg
@@ -97818,25 +97987,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
-aBN
-hlk
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+hGZ
+fzK
+fzK
+hGZ
+eep
+eep
+eep
+hna
+hna
+hna
+hna
+eep
+eep
+eep
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 xsG
 ymg
@@ -98075,25 +98244,25 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
-jkB
-fIx
-sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
+hGZ
+fzK
+fzK
+hGZ
+eep
+eep
+eep
+hna
+hna
+hna
+hna
+eep
+eep
+eep
+eep
+eep
+eep
+xLZ
+hGZ
 ymg
 xsG
 ymg
@@ -98332,16 +98501,16 @@ ymg
 ymg
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+hGZ
+fzK
+fzK
+hGZ
+hGZ
+hGZ
+hGZ
 sag
-kOk
-sRn
+sag
+sag
 sag
 sag
 sag
@@ -98588,15 +98757,15 @@ sag
 sag
 sag
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
+hGZ
+hGZ
+fzK
+fzK
+fzK
+fzK
+fzK
+fzK
+aDd
 foi
 ptl
 owa
@@ -98847,13 +99016,13 @@ dxp
 sag
 ymg
 ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-sag
+fzK
+fzK
+fzK
+fzK
+fzK
+fzK
+aDd
 fVj
 fra
 nHh
@@ -99102,9 +99271,9 @@ sag
 jXg
 sag
 sag
-ymg
-ymg
-ymg
+hGZ
+hGZ
+hGZ
 jLf
 jLf
 xKy
@@ -99619,7 +99788,7 @@ dBF
 ymg
 ymg
 ymg
-xKy
+jLf
 doP
 qQx
 jFN
@@ -99876,7 +100045,7 @@ dBF
 dBF
 dBF
 ymg
-xKy
+jLf
 fwu
 jFN
 xym
@@ -100133,7 +100302,7 @@ gne
 exy
 dBF
 ymg
-xKy
+jLf
 bll
 jFN
 arM
@@ -157442,11 +157611,11 @@ jGV
 gqp
 gjw
 pyO
-dpf
+pwP
 yaO
 wAr
 bCu
-eXc
+aJm
 xzv
 xzv
 xzv
@@ -157459,7 +157628,7 @@ xzv
 xzv
 xzv
 xzv
-eXc
+aJm
 jMC
 rOE
 gDI
@@ -157703,7 +157872,7 @@ juB
 dbW
 wAr
 sum
-crW
+xzv
 xzK
 xzK
 xzK
@@ -157960,7 +158129,7 @@ csx
 wAr
 wAr
 sum
-crW
+xzv
 xzK
 xzK
 xzK
@@ -158217,7 +158386,7 @@ xgM
 gXd
 utz
 ctI
-crW
+xzv
 xzK
 xzK
 xzK
@@ -158474,7 +158643,7 @@ eyG
 slw
 ejm
 jUM
-iyT
+nJz
 xzK
 xzK
 xzK
@@ -158731,7 +158900,7 @@ vkV
 slw
 ejm
 bdD
-iyT
+nJz
 xzK
 xzK
 xzK
@@ -158988,7 +159157,7 @@ ezo
 slw
 ejm
 bdD
-iyT
+nJz
 xzK
 xzK
 xzK
@@ -159245,7 +159414,7 @@ sdO
 slw
 ejm
 ejm
-iyT
+nJz
 xzK
 xzK
 xzK
@@ -159505,13 +159674,13 @@ bdD
 nJz
 xzK
 xzK
-xoF
-vOw
-vrt
-nnR
-vrt
-iRs
-xoF
+xpn
+xpn
+xpn
+xpn
+xpn
+xpn
+xpn
 xzK
 xzK
 xzK
@@ -159760,18 +159929,18 @@ slw
 bdD
 ejm
 nJz
-xzK
-xzK
+caL
+caL
+xPT
 xoF
-coF
-ipg
 xoF
-ipg
-aGb
 xoF
-xzK
-xzK
-xzK
+xoF
+xoF
+xPT
+caL
+caL
+caL
 nJz
 quB
 ejm
@@ -160014,19 +160183,19 @@ nKE
 sGK
 nKE
 slw
-mBA
-qgk
+txB
+slw
 slw
 xoF
 xoF
 xPT
-vOw
-sxI
+hPv
+hPv
+hPv
+hPv
+hPv
 xPT
-sxI
-iRs
-xPT
-sfW
+ivt
 ivt
 ivt
 slw
@@ -160271,24 +160440,24 @@ iKd
 uBV
 iKd
 slw
-ejm
-ejm
-slw
+uuK
+wQI
+jTc
 vDN
-rnp
-vDe
-dKS
-lKl
-mKY
-dfF
-aiQ
-wuZ
-mZz
-vEP
-vEP
+vsn
+xPT
+bhY
+bhY
+bhY
+bhY
+bhY
+xPT
+kax
+aOk
+sZH
 slw
 slw
-slw
+ejm
 lHx
 xqh
 slw
@@ -160528,25 +160697,25 @@ iKd
 uBV
 iKd
 slw
-ejm
-ejm
+jdy
+rvX
 szZ
-pXU
+jPG
+jPG
 bSi
-bSi
-bSi
-ini
-vYk
-gdw
-vYk
-fVu
-xCr
+vls
+vls
+vls
+vls
+vls
+hGZ
+pWS
 cdw
 oHi
 prB
 cca
-slw
 cRp
+ejm
 qgM
 slw
 fNC
@@ -160784,25 +160953,25 @@ muC
 iKd
 uBV
 iKd
-slw
-fcg
+vPg
 nKD
-slw
-pRj
-iYo
+nKD
+lpw
+rfh
+rfh
 mtx
-ecU
+jVx
 lER
-pep
-vBr
+uDr
+rJp
 jVx
 aQn
-pdF
-ebR
+vEn
+bVu
 nSK
 bVu
-dbf
-rpu
+jIA
+kcs
 byQ
 sGL
 nKr
@@ -161041,24 +161210,24 @@ muC
 okU
 uBV
 kdW
-ifT
-ifT
-ifT
-ifT
-arK
-mBo
-eoW
-bNG
-wke
+lVu
+vMq
+gRQ
+qMT
+rfh
+rfh
+hGZ
+rfh
+iMY
 hzX
 wke
 rfh
 xrn
-sfW
-cvd
-oSp
-lMT
-gDa
+cav
+mkP
+dEe
+mkP
+hGZ
 slw
 llI
 pyX
@@ -161297,25 +161466,25 @@ jMa
 muC
 xST
 uBV
-qTX
+xuP
 ifT
 alQ
-isX
-ifT
-ifT
+gRQ
+eNy
+jBb
 xFk
 ifT
-bZg
-vFK
-eKN
-tTI
+wmw
+wmw
+wmw
+wmw
 wmw
 fnd
-sfW
-xGo
-xom
-sjB
-wkA
+cdw
+oio
+oio
+iJA
+ohA
 slw
 ecO
 sdl
@@ -161555,24 +161724,24 @@ muC
 iKd
 uBV
 qTX
-lVu
-gRQ
+ifT
+snr
 yik
 qHd
 pEc
 jqt
 ifT
-dyk
-sHS
-djF
-oQp
-tQk
-vEr
-sfW
-bsK
-mPR
-orL
-bfY
+wmw
+wmw
+wmw
+wmw
+wmw
+fnd
+cdw
+oio
+oio
+tKq
+gvK
 slw
 eoB
 bvU
@@ -161813,23 +161982,23 @@ xIc
 uBV
 qTX
 lVu
-gRQ
+lNg
 qRN
 sNT
 dpy
 mog
 ifT
-xNR
-oQp
-amr
-oQp
-tQk
+wmw
+wmw
+wmw
+wmw
+wmw
 nHW
-sfW
-sLc
-lTH
-osO
-cjl
+fjk
+lvw
+dML
+rpw
+ilF
 slw
 llI
 ejm
@@ -162076,12 +162245,12 @@ xfv
 fXv
 mog
 ifT
-ksy
-oQp
-cof
-oQp
-tQk
-jqZ
+wmw
+wmw
+wmw
+wmw
+wmw
+xPT
 sdD
 sdD
 sdD
@@ -162333,12 +162502,12 @@ hsu
 aJo
 mog
 ifT
-wOF
-sIW
-uCI
-hjh
-idj
-idE
+wmw
+wmw
+wmw
+wmw
+wmw
+suT
 unl
 fcf
 mZX
@@ -162590,12 +162759,12 @@ mDv
 ryX
 kpk
 ifT
-wfh
+bzK
 kbn
-feg
+sgr
 bnt
 bzK
-fcC
+suT
 hBC
 pKm
 lco
@@ -162854,8 +163023,8 @@ iul
 suT
 suT
 sdD
-wYF
-vWh
+pKm
+lco
 bkc
 mcl
 slw
@@ -163111,7 +163280,7 @@ kiU
 biT
 nRn
 kPA
-lqh
+pKm
 lco
 rDP
 slw
@@ -163368,8 +163537,8 @@ wSc
 kLW
 xdf
 mPI
-qci
-cGM
+pKm
+lco
 qwW
 slw
 ovY
@@ -168260,7 +168429,7 @@ lFt
 soY
 dIP
 dIP
-bov
+cad
 cKQ
 cHn
 eld

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -124,6 +124,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
+"adB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "adT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -197,17 +204,14 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/machinery/button/elevator/directional/north{
-	id = "cargolift"
-	},
-/obj/machinery/lift_indicator/directional/north{
-	linked_elevator_id = "cargolift"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/button/elevator/directional/north{
+	id = "cargolift"
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "agd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/garbage,
@@ -840,7 +844,7 @@
 /area/station/commons/lounge)
 "aqN" = (
 /turf/open/floor/iron/dark,
-/area/space/nearstation)
+/area/station/cargo/miningdock)
 "arc" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center"
@@ -1471,7 +1475,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "aDd" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
@@ -1494,7 +1498,7 @@
 "aDw" = (
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
 /turf/open/floor/iron/recharge_floor,
-/area/space)
+/area/station/cargo/storage)
 "aDx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1932,6 +1936,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aMI" = (
@@ -2015,7 +2022,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/station/command/heads_quarters/qm)
 "aOu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2102,8 +2109,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
 /obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
 /turf/open/floor/iron/textured,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "aQq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3118,9 +3129,6 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
-"bhY" = (
-/turf/open/space/openspace,
-/area/station/cargo/storage)
 "biB" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
@@ -3481,8 +3489,8 @@
 	pixel_x = -6;
 	pixel_y = 2
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "bob" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -3713,7 +3721,6 @@
 	dir = 9;
 	network = list("ss13","qm")
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -3733,6 +3740,11 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"btd" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "btg" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
@@ -4989,6 +5001,18 @@
 	},
 /turf/open/space/openspace,
 /area/space)
+"bPO" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "bPS" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
@@ -5120,8 +5144,13 @@
 	dir = 5
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/sorting)
 "bSE" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -5156,8 +5185,11 @@
 /area/station/service/library)
 "bTd" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/storage)
 "bTh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -5240,7 +5272,7 @@
 "bVu" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "bVz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -5468,7 +5500,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "caw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shieldgen,
@@ -5494,7 +5526,7 @@
 /area/station/maintenance/port)
 "caL" = (
 /turf/open/floor/engine/hull,
-/area/space)
+/area/space/nearstation)
 "caT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5524,7 +5556,7 @@
 "cca" = (
 /obj/machinery/airalarm/directional/west,
 /turf/closed/wall,
-/area/space)
+/area/station/maintenance/department/cargo)
 "ccb" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -5605,11 +5637,11 @@
 /area/station/service/library/abandoned)
 "cdw" = (
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "cdK" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "cdP" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/camera{
@@ -5984,7 +6016,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "cnt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -7195,7 +7227,7 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "cHI" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
@@ -7436,6 +7468,10 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"cNp" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "cNq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7861,6 +7897,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cVt" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/cargo/storage)
 "cVw" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -8169,6 +8212,7 @@
 /area/station/maintenance/fore)
 "dbf" = (
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dbi" = (
@@ -8828,6 +8872,13 @@
 /obj/effect/spawner/costume/maid,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"dnq" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/command/heads_quarters/qm)
 "dnw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -9757,7 +9808,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
+"dEz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "dEK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -10162,7 +10220,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "dMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10611,7 +10669,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "dVy" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -10679,6 +10737,13 @@
 "dWZ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/genetics)
+"dXh" = (
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "dXi" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningdock)
@@ -10937,8 +11002,9 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/cargo)
 "eep" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "eeq" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -11463,8 +11529,9 @@
 	},
 /area/station/service/bar)
 "epa" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "epe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12279,7 +12346,7 @@
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "eDp" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -12910,15 +12977,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /obj/machinery/button/elevator/directional/south{
 	id = "cargolift"
 	},
 /obj/machinery/lift_indicator/directional/south{
 	linked_elevator_id = "cargolift"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -14110,7 +14177,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "fjv" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -14119,6 +14186,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab/firing_range)
+"fjA" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/cargo/storage)
 "fjC" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/broken_floor,
@@ -14375,8 +14449,11 @@
 "fnd" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/station/cargo/storage)
+/area/station/command/heads_quarters/qm)
 "fnr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14764,10 +14841,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fub" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "ful" = (
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
@@ -14804,7 +14881,7 @@
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "fvb" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -14907,8 +14984,9 @@
 "fxW" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/storage)
 "fyd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14969,8 +15047,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
 "fzK" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
-/area/space)
+/area/station/maintenance/port/lower)
 "fzS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -15054,8 +15133,9 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "fBK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -15576,8 +15656,9 @@
 /obj/item/clothing/gloves/cargo_gauntlet{
 	pixel_y = -3
 	},
+/obj/structure/railing,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "fKl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15913,8 +15994,8 @@
 	pixel_y = 6;
 	pixel_x = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "fQT" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -15993,8 +16074,10 @@
 /obj/structure/frame/computer{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/obj/machinery/light/small/directional/west,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "fSl" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
@@ -16489,6 +16572,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/barber)
+"gdc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/cargo/storage)
 "gdt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -17472,7 +17559,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "gwd" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/siding/yellow{
@@ -18840,8 +18927,10 @@
 /obj/machinery/computer/security/mining{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "gTa" = (
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
@@ -19616,7 +19705,7 @@
 "hhk" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "hhv" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Pure Chamber";
@@ -19868,12 +19957,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"hmI" = (
-/obj/machinery/light/small/red/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hmT" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -20161,8 +20244,12 @@
 /area/station/science/robotics/lab)
 "hsR" = (
 /obj/machinery/rnd/bepis,
+/obj/effect/turf_decal/trimline/brown/corner,
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "hsV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -20562,7 +20649,7 @@
 	dir = 4
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "hAb" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -20639,6 +20726,7 @@
 /obj/machinery/coffeemaker{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "hBI" = (
@@ -20780,6 +20868,10 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"hEk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/cargo/sorting)
 "hEq" = (
 /obj/machinery/atmospherics/pipe/color_adapter{
 	dir = 8
@@ -20939,9 +21031,6 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"hGZ" = (
-/turf/closed/wall,
-/area/space)
 "hHf" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -21335,8 +21424,9 @@
 /area/station/maintenance/fore)
 "hMb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/railing,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "hMg" = (
 /obj/structure/flora/grass/green,
 /obj/machinery/light/directional/north,
@@ -21389,7 +21479,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "hNq" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
@@ -21483,6 +21572,10 @@
 /area/station/maintenance/starboard/lower)
 "hPv" = (
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/grass,
 /area/station/cargo/storage)
 "hPE" = (
@@ -21804,10 +21897,6 @@
 "hVB" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
-"hVD" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/space)
 "hVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -22663,12 +22752,15 @@
 	pixel_y = -32
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "ilN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/experiment_room)
+"imb" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/port/lower)
 "imK" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -22734,8 +22826,9 @@
 "iop" = (
 /obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "iov" = (
 /obj/item/target,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -23095,11 +23188,9 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
 "iul" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/airlock/mining/glass,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "iuB" = (
@@ -23895,7 +23986,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "iJL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24094,7 +24185,7 @@
 	dir = 5
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "iNm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -24898,7 +24989,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "jdI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -25339,10 +25430,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
-"jos" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/space)
 "joE" = (
 /obj/structure/bookcase,
 /obj/effect/mapping_helpers/broken_floor,
@@ -25419,10 +25506,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"jqm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
 "jqq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -26471,12 +26554,22 @@
 	name = "Quartermaster Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/turf/open/floor/iron/textured,
-/area/space)
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "jIF" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/corner,
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "jIN" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
@@ -26695,6 +26788,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w,
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
+"jLs" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "jLB" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/spawner/random/vending/snackvend,
@@ -26897,7 +26999,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/sorting)
 "jPO" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -27096,8 +27198,9 @@
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "jTh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27254,7 +27357,7 @@
 	dir = 4
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "jVy" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wrench,
@@ -27605,7 +27708,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/station/command/heads_quarters/qm)
 "kaB" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -28925,7 +29028,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "kwg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -29159,7 +29262,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "kyW" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -29453,9 +29556,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "kFK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -29809,9 +29909,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kLW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -29854,7 +29951,7 @@
 /obj/machinery/mech_bay_recharge_port,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/textured,
-/area/space)
+/area/station/cargo/storage)
 "kMs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -30018,6 +30115,7 @@
 	name = "Cargo Bay"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "kPI" = (
@@ -30067,9 +30165,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"kQj" = (
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "kQo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30411,9 +30506,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "kWm" = (
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/table,
@@ -30578,7 +30672,7 @@
 /obj/structure/closet/crate/trashcart/filled,
 /obj/item/relic,
 /turf/open/floor/plating,
-/area/station/cargo/miningdock)
+/area/station/maintenance/department/cargo)
 "kZq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -30955,8 +31049,9 @@
 /area/station/engineering/storage)
 "leJ" = (
 /obj/machinery/computer/mech_bay_power_console,
+/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "leN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/medbay/alt/directional/west,
@@ -31495,10 +31590,11 @@
 "lmV" = (
 /obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/station/cargo/miningdock)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31681,14 +31777,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"lpw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
 "lpE" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -31916,7 +32004,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "ltV" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/suit/white_on_white,
@@ -32001,7 +32089,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "lvy" = (
 /obj/effect/landmark/start/xenobiologist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32557,7 +32645,7 @@
 	dir = 4
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "lET" = (
 /obj/structure/sign/poster/random/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33490,8 +33578,9 @@
 /area/station/service/kitchen/coldroom)
 "lUE" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "lUK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/janitor_supplies,
@@ -33897,7 +33986,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/command/heads_quarters/qm)
 "mcm" = (
 /obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/east,
@@ -34246,8 +34335,13 @@
 /area/station/medical/treatment_center)
 "mia" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "min" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34422,8 +34516,12 @@
 /area/station/medical/pharmacy)
 "mkP" = (
 /obj/structure/table/wood,
+/obj/machinery/light/directional/south,
+/obj/item/storage/wallet{
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "mli" = (
 /obj/machinery/light/cold/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -34869,7 +34967,7 @@
 "mtu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "mtv" = (
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage)
@@ -34879,7 +34977,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/station/cargo/sorting)
 "mtD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -35040,6 +35138,14 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
+"mwH" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/grass,
+/area/station/cargo/storage)
 "mwI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -35180,7 +35286,7 @@
 "myV" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "mzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35256,6 +35362,14 @@
 /obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"mAs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "mAy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -35673,6 +35787,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"mJO" = (
+/obj/structure/industrial_lift/public,
+/obj/machinery/elevator_control_panel/directional/east{
+	linked_elevator_id = "cargolift";
+	preset_destination_names = list("2" = "Cargo Bay", "3" = "Delivery Office");
+	pixel_y = 10
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/storage)
 "mJW" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/iron/dark/telecomms,
@@ -35948,7 +36071,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
 "mOA" = (
-/obj/machinery/light/directional/east,
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
@@ -36159,7 +36281,7 @@
 	name = "Cargo Bay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "mRo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36490,8 +36612,8 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "mWL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36734,6 +36856,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"naU" = (
+/turf/open/openspace,
+/area/station/cargo/sorting)
 "naV" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/flora/bush/jungle/c/style_random,
@@ -37118,6 +37243,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"nhz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "nhE" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating,
@@ -37602,8 +37737,9 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "npJ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/sepia,
@@ -38786,8 +38922,12 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/leafy,
+/obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
-/area/station/cargo/storage)
+/area/station/command/heads_quarters/qm)
 "nIg" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/south,
@@ -38955,9 +39095,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nKD" = (
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
 "nKE" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -39328,7 +39465,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "nSN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -40133,7 +40270,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "ohL" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
@@ -40161,7 +40298,7 @@
 /area/station/security/prison/rec)
 "oio" = (
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "oit" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40223,7 +40360,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/command/heads_quarters/qm)
 "ojA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -40516,6 +40653,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"onL" = (
+/obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "onN" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -40729,7 +40872,6 @@
 /area/station/security/prison/workout)
 "orE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
@@ -41616,7 +41758,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "oHw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41996,7 +42138,6 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "oPC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
@@ -42047,13 +42188,16 @@
 	pixel_x = -6
 	},
 /obj/structure/table,
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/clothing/shoes/wheelys/rollerskates{
 	pixel_y = 5
 	},
 /obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/machinery/status_display/evac/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = 5
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "oQK" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -42355,8 +42499,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "oVj" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -43252,8 +43397,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "pky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43619,6 +43764,13 @@
 /obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"pqK" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/reed/style_random,
+/turf/open/floor/grass,
+/area/station/cargo/storage)
 "pqZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/glass,
@@ -43635,8 +43787,13 @@
 /area/station/service/library/abandoned)
 "prx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "prB" = (
 /obj/machinery/camera{
 	c_tag = "Command - Quartermaster's Office";
@@ -43646,7 +43803,7 @@
 /obj/machinery/pdapainter/supply,
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "prF" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -43733,12 +43890,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
-"ptl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "ptq" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/item/toy/plush/moth{
@@ -44461,7 +44612,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "pEy" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -44579,8 +44730,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "pGI" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -45330,7 +45484,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
-/area/space/nearstation)
+/area/station/cargo/warehouse)
 "pUE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45434,7 +45588,7 @@
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "pWp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45493,7 +45647,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "pWZ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -46362,6 +46516,10 @@
 /obj/machinery/recharge_station,
 /obj/machinery/status_display/evac/directional/south,
 /obj/structure/sign/poster/official/random/directional/east,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "qlv" = (
@@ -47233,8 +47391,10 @@
 	pixel_y = 4;
 	pixel_x = -4
 	},
+/obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "qxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47311,7 +47471,7 @@
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "qyy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/electrified_grille,
@@ -47458,8 +47618,8 @@
 /obj/machinery/cell_charger{
 	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/space)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "qBC" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -47547,6 +47707,7 @@
 /area/station/science/ordnance)
 "qDb" = (
 /obj/machinery/door/airlock/mining,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qDt" = (
@@ -47666,8 +47827,13 @@
 /area/station/hallway/primary/port)
 "qFr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "qFy" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -48080,8 +48246,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "qOk" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -48401,7 +48573,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "qTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -48685,7 +48857,7 @@
 	name = "Mining Maintenance"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/station/maintenance/port/lower)
 "qYZ" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -49050,6 +49222,10 @@
 "reD" = (
 /obj/machinery/suit_storage_unit/industrial/loader,
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "reF" = (
@@ -49090,9 +49266,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"rfh" = (
-/turf/open/openspace,
-/area/space)
 "rfv" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room"
@@ -49660,7 +49833,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "rpL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -50091,7 +50264,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "rwb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -50518,6 +50691,7 @@
 "rDP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "rEe" = (
@@ -50718,7 +50892,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "rHE" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room B"
@@ -50901,7 +51075,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/corner,
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "rJr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50963,7 +51137,7 @@
 "rKu" = (
 /obj/item/banner/cargo/mundane,
 /turf/open/floor/plating,
-/area/station/cargo/miningdock)
+/area/station/maintenance/department/cargo)
 "rKw" = (
 /obj/item/tank/internals/oxygen/empty,
 /obj/item/wrench,
@@ -51214,8 +51388,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "rOl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -51405,7 +51580,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "rRq" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office"
@@ -52730,6 +52905,7 @@
 	pixel_y = 32
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sns" = (
@@ -53022,7 +53198,7 @@
 "ssl" = (
 /obj/structure/stairs/east,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "ssv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53050,6 +53226,9 @@
 "sti" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "stj" = (
@@ -53402,17 +53581,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"syT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "syU" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/comfy/brown,
@@ -53466,7 +53634,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "sAa" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -54326,7 +54494,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "sNF" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -54686,7 +54854,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "sTe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55035,7 +55203,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/station/command/heads_quarters/qm)
 "tak" = (
 /obj/machinery/computer/exodrone_control_console{
 	dir = 1
@@ -55368,8 +55536,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/warehouse)
 "tfn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -55632,6 +55801,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tli" = (
@@ -56475,8 +56645,9 @@
 "tAa" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/storage)
 "tAw" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/delivery,
@@ -56945,7 +57116,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "tKs" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -57086,7 +57257,7 @@
 /obj/item/computer_disk/quartermaster,
 /obj/item/computer_disk/quartermaster,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "tMI" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -57756,8 +57927,9 @@
 /area/station/service/library)
 "tZw" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "tZE" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/machinery/camera{
@@ -57970,6 +58142,7 @@
 /area/station/service/bar/backroom)
 "ucu" = (
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ucy" = (
@@ -58510,6 +58683,7 @@
 /obj/machinery/microwave{
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "unr" = (
@@ -58783,7 +58957,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "uro" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cloth/five,
@@ -59012,7 +59186,7 @@
 "uuK" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "uuL" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleportershutters";
@@ -59061,8 +59235,14 @@
 /area/station/command/corporate_showroom)
 "uvX" = (
 /obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/machinery/status_display/supply{
+	pixel_y = -30
+	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "uwg" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -59396,7 +59576,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment,
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "uDD" = (
 /obj/machinery/telecomms/server/presets/security,
 /obj/effect/turf_decal/trimline/red/filled/end{
@@ -60025,11 +60205,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"uOX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "uPj" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60203,7 +60378,7 @@
 "uRy" = (
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "uRz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60966,6 +61141,7 @@
 /area/station/medical/medbay/lobby)
 "vgZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "vhn" = (
@@ -61211,8 +61387,11 @@
 	pixel_x = 32
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "vlk" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 5"
@@ -61233,7 +61412,7 @@
 	dir = 8
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "vlu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -61637,7 +61816,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/cargo/storage)
+/area/station/cargo/sorting)
 "vsr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -62002,6 +62181,10 @@
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
+"vAG" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "vAL" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -62113,8 +62296,11 @@
 /area/station/maintenance/starboard/fore)
 "vCI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/station/cargo/miningdock)
 "vCP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/black,
@@ -62146,6 +62332,7 @@
 	name = "Cargo Belt"
 	},
 /obj/structure/sign/warning/docking/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "vDm" = (
@@ -62187,7 +62374,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/cargo/storage)
+/area/station/cargo/sorting)
 "vDW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62206,7 +62393,7 @@
 "vEn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "vEt" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape{
@@ -62748,10 +62935,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"vPg" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "vPp" = (
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/plating,
@@ -62767,6 +62950,13 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/station/service/hydroponics/park)
+"vPN" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
 "vPQ" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63728,7 +63918,7 @@
 	dir = 6
 	},
 /turf/open/openspace,
-/area/space)
+/area/station/cargo/storage)
 "wki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -64249,6 +64439,21 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"wsF" = (
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_y = -5
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "wtd" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plating,
@@ -64348,6 +64553,7 @@
 	name = "Cargo Belt"
 	},
 /obj/structure/sign/warning/docking/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "wvb" = (
@@ -65282,8 +65488,9 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/miningdock)
 "wMV" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
@@ -65445,7 +65652,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/sorting)
 "wQK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65535,10 +65742,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"wSc" = (
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "wSP" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
@@ -65558,7 +65761,7 @@
 /area/station/maintenance/department/science)
 "wTf" = (
 /turf/open/floor/iron/dark/side,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "wTw" = (
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -65816,7 +66019,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/station/cargo/storage)
 "wYf" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -66519,7 +66722,7 @@
 "xjB" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "xjF" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -66683,6 +66886,10 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
+"xnF" = (
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/openspace,
+/area/station/cargo/miningdock)
 "xod" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/flora/bush/jungle/b/style_random,
@@ -66950,8 +67157,10 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/bush/style_random,
+/obj/structure/flora/bush/leafy,
 /turf/open/floor/grass,
-/area/space)
+/area/station/command/heads_quarters/qm)
 "xrV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -67767,10 +67976,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
-"xHu" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron,
-/area/space)
 "xHB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -68040,7 +68245,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/space/nearstation)
+/area/station/cargo/warehouse)
 "xMg" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
@@ -68087,7 +68292,7 @@
 "xMK" = (
 /obj/effect/turf_decal/arrows/red,
 /turf/open/floor/iron,
-/area/station/maintenance/port/lower)
+/area/station/cargo/storage)
 "xMQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -68471,8 +68676,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "xUz" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/port/lower)
+/area/station/cargo/miningdock)
 "xUE" = (
 /obj/structure/window/reinforced/spawner/directional/west{
 	layer = 2.9
@@ -68588,6 +68796,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"xVR" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "xWb" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -69071,7 +69283,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/area/station/command/heads_quarters/qm)
 "yew" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/south,
@@ -92565,18 +92777,18 @@ cjW
 vjV
 owa
 fLP
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+epu
+epu
+epu
+epu
+epu
+epu
+epu
+epu
+epu
+epu
+epu
+epu
 cQP
 mSr
 moF
@@ -95147,7 +95359,7 @@ wuZ
 mZz
 vEP
 vEP
-sag
+sfW
 rxH
 sag
 sag
@@ -95407,7 +95619,7 @@ fxn
 upH
 gSr
 sag
-epu
+ymg
 ymg
 ymg
 wNX
@@ -95663,7 +95875,7 @@ rxw
 sjB
 ftE
 dbf
-sag
+sfW
 xsG
 xsG
 wNX
@@ -95907,7 +96119,7 @@ aDd
 aDd
 sag
 afD
-afD
+mJO
 fGj
 sgr
 sgr
@@ -95920,7 +96132,7 @@ cvd
 oSp
 lMT
 gDa
-hGZ
+sfW
 ymg
 xsG
 xsG
@@ -96163,8 +96375,8 @@ aDd
 aDd
 aDd
 sag
-sag
-sag
+xPT
+xPT
 afV
 xMK
 eDl
@@ -96177,7 +96389,7 @@ xGo
 xom
 sjB
 wkA
-jqm
+ivt
 ymg
 ymg
 wNX
@@ -96421,20 +96633,20 @@ aDd
 aDd
 sag
 leJ
-hMb
+gdc
 sNy
-hna
+sgr
 myV
 xjB
-hna
-eep
+sgr
+sgr
 fub
 sfW
 bsK
 mPR
 lMT
 bfY
-hGZ
+sfW
 ymg
 ymg
 wNX
@@ -96673,25 +96885,25 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
+sag
+aDd
+aDd
+sag
 kMq
-bTd
+gdc
 aDa
 fuX
 cdK
 cdK
 cdK
 ltP
-xHu
+bLD
 qDb
 sLc
 lTH
 sjB
 cjl
-hGZ
+sfW
 ymg
 ymg
 wNX
@@ -96930,12 +97142,12 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
+sag
+aDd
+aDd
+sag
 aDw
-bTd
+gdc
 wXS
 rOj
 qTw
@@ -96943,12 +97155,12 @@ qTw
 qTw
 pGC
 kWg
-hGZ
+sfW
 tfm
 pWj
-eep
+lMT
 xLZ
-jqm
+ivt
 ymg
 ymg
 wNX
@@ -97187,12 +97399,12 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
-hGZ
-hGZ
+sag
+aDd
+aDd
+sag
+xPT
+xPT
 tAa
 hMb
 ssl
@@ -97200,12 +97412,12 @@ ssl
 ssl
 bTd
 fxW
-hGZ
+sfW
 pEx
 cHu
 eep
 pUD
-hGZ
+sfW
 ymg
 ymg
 wNX
@@ -97444,25 +97656,25 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
-fzK
-hGZ
+sag
+aDd
+aDd
+sag
+aDd
+xPT
 oQI
 fKf
-sag
-sag
-sag
+xPT
+xPT
+xPT
 vle
 qxI
-hGZ
+sfW
 rRo
-eep
+lMT
 oUS
-pAf
-pAf
+sfW
+sfW
 xsG
 wNX
 wNX
@@ -97701,24 +97913,24 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
-hGZ
-hGZ
-hGZ
+sag
+aDd
+aDd
 sag
 sag
+xPT
+xPT
+xPT
+gAG
 hsR
-sag
-hGZ
-hGZ
-hGZ
-hGZ
+xPT
+xPT
+xPT
+gAG
+gAG
 lmV
-hGZ
-pAf
+gAG
+gAG
 ymg
 ymg
 wNX
@@ -97958,24 +98170,24 @@ ymg
 ymg
 ymg
 ymg
-hGZ
+sag
+aDd
+aDd
+sag
 fzK
-fzK
-hGZ
-fzK
-fzK
-hGZ
+aDd
+sag
 fQQ
 prx
-xUz
+dXh
 fSi
 qBi
-hGZ
+gAG
 kyN
 mia
 vCI
 uvX
-pAf
+gAG
 ymg
 ymg
 wNX
@@ -98215,27 +98427,27 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-fzK
-fzK
-fzK
-hGZ
+sag
+aDd
+aDd
+xVR
+aDd
+aDd
+sag
 wMS
-xUz
+bPO
 jIF
-xUz
-epa
+jLs
+wsF
 iop
-epa
-vCI
-epa
-uvX
-pAf
-hGZ
-hGZ
-pAf
+aqN
+dEz
+aqN
+onL
+gAG
+sag
+sag
+sag
 ymg
 ymg
 ymg
@@ -98472,27 +98684,27 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
-hVD
-jos
-hGZ
+sag
+aDd
+aDd
+sag
+faa
+fVj
+sag
 bnW
 qFr
-xUz
+dXh
 tZw
-hGZ
-hGZ
+gAG
+gAG
 rHf
-vCI
-epa
+dEz
+aqN
 epa
 aqN
 qYR
-fzK
-pAf
+aDd
+sag
 ymg
 ymg
 ymg
@@ -98729,13 +98941,13 @@ ymg
 ymg
 ymg
 ymg
-hGZ
-fzK
-fzK
-hGZ
-hGZ
-hGZ
-hGZ
+sag
+aDd
+aDd
+sag
+sag
+sag
+sag
 sag
 sag
 ujF
@@ -98751,7 +98963,7 @@ sag
 aDd
 sag
 sag
-pAf
+sag
 xsG
 xsG
 wNX
@@ -98985,24 +99197,24 @@ sag
 sag
 sag
 sag
-hGZ
-hGZ
-fzK
-fzK
-fzK
-fzK
-fzK
-fzK
+sag
+sag
+aDd
+aDd
+aDd
 aDd
 dDJ
-ptl
 aDd
+dDJ
+dDJ
+hna
+vAG
 sag
 hhk
 wTf
 xUz
 url
-xUz
+epa
 gSZ
 sag
 aDd
@@ -99242,24 +99454,24 @@ kyH
 wPR
 dxp
 sag
-ymg
-ymg
-fzK
-fzK
-fzK
-fzK
-fzK
-fzK
 aDd
 aDd
-ptl
+aDd
+aDd
+aDd
+dDJ
+aDd
+dDJ
+aDd
+aDd
+jkB
 dDJ
 sag
-sag
+gAG
 fBF
-lUE
+mAs
 qOj
-lUE
+nhz
 pkb
 sag
 aDd
@@ -99499,9 +99711,9 @@ sag
 jXg
 sag
 sag
-hGZ
-hGZ
-hGZ
+sag
+sag
+sag
 jLf
 jLf
 xKy
@@ -99509,16 +99721,16 @@ xKy
 xKy
 sag
 sag
-rbW
+dDJ
 hna
 bfg
-sag
-sag
-cQP
+dXi
+dXi
+nKx
 dVw
-cQP
-sag
-sag
+nKx
+dXi
+imb
 bfg
 dDJ
 oIQ
@@ -99766,7 +99978,7 @@ rol
 rol
 apH
 sag
-rbW
+dDJ
 dDJ
 fLP
 ymg
@@ -100023,7 +100235,7 @@ jFN
 aBV
 gps
 sag
-hmI
+deJ
 aDd
 fLP
 ymg
@@ -101815,7 +102027,7 @@ hcs
 hcs
 dIM
 tlP
-hcs
+adB
 toc
 hcs
 iRv
@@ -160414,18 +160626,18 @@ slw
 txB
 slw
 slw
-xoF
-xoF
+hEk
+hEk
 xPT
-hPv
-hPv
-hPv
-hPv
+mwH
+fjA
+cVt
+pqK
 hPv
 xPT
-uOX
-uOX
-uOX
+ttf
+ttf
+ttf
 slw
 rJt
 pyX
@@ -160667,19 +160879,19 @@ dAs
 iKd
 uBV
 iKd
-slw
+ifT
 uuK
 wQI
 jTc
 vDN
 vsn
-xPT
-bhY
-bhY
-bhY
-bhY
-bhY
-xPT
+ifT
+wmw
+wmw
+wmw
+wmw
+wmw
+sdD
 kax
 aOk
 sZH
@@ -160924,7 +161136,7 @@ muC
 iKd
 uBV
 kdW
-slw
+ifT
 jdy
 rvX
 szZ
@@ -160936,7 +161148,7 @@ vls
 vls
 vls
 vls
-hGZ
+sdD
 pWS
 uRy
 oHi
@@ -161181,12 +161393,12 @@ muC
 iKd
 uBV
 qTX
-vPg
-nKD
-nKD
-lpw
-rfh
-rfh
+lVu
+gRQ
+gRQ
+qMT
+naU
+naU
 mtx
 jVx
 lER
@@ -161442,20 +161654,20 @@ lVu
 vMq
 gRQ
 qMT
-rfh
-rfh
-hGZ
-rfh
+naU
+naU
+ifT
+wmw
 iMY
 hzX
 wke
-rfh
+wmw
 xrn
 cav
-mkP
+vPN
 dEe
 mkP
-hGZ
+slw
 slw
 llI
 pyX
@@ -161961,10 +162173,10 @@ jqt
 ifT
 wmw
 wmw
+naU
 wmw
 wmw
-wmw
-fnd
+dnq
 tME
 mtu
 sSW
@@ -162483,7 +162695,7 @@ sdD
 uyw
 ttf
 vGI
-slw
+sdD
 slw
 xqd
 slw
@@ -163245,7 +163457,7 @@ lVu
 ifT
 ifT
 suT
-syT
+iul
 suT
 iul
 suT
@@ -163761,7 +163973,7 @@ rKx
 mOA
 kFK
 ucu
-wSc
+rKx
 kLW
 xdf
 mPI
@@ -164013,7 +164225,7 @@ jwr
 uTG
 mSQ
 ava
-uhc
+ujJ
 jBP
 gAG
 gAG
@@ -164275,13 +164487,13 @@ gAG
 gAG
 wqD
 hNq
-dyi
+cNp
 wFR
 ckh
 ckh
-gAG
-gAG
-gAG
+slw
+slw
+slw
 slw
 gVI
 gEm
@@ -164535,10 +164747,10 @@ dyi
 nbo
 xVP
 ckh
-ckh
-gAG
-kQj
-kQj
+xnF
+slw
+ejm
+ejm
 wqb
 ejm
 iiq
@@ -164793,7 +165005,7 @@ vyd
 qrC
 oKM
 gAc
-gAG
+slw
 rKu
 kZf
 slw
@@ -165038,7 +165250,7 @@ rAj
 qTX
 kEQ
 xyF
-uTG
+btd
 oPC
 pMl
 uhc
@@ -165050,9 +165262,9 @@ oqU
 dXi
 nKx
 nKx
-dXi
-dXi
-dXi
+eei
+eei
+eei
 eei
 eei
 jKf

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -124,13 +124,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
-"adB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "adT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -156,6 +149,9 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/service)
+"aes" = (
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "aeF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -281,6 +277,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "ahZ" = (
@@ -469,7 +468,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "akI" = (
-/obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
@@ -536,6 +534,10 @@
 	c_tag = "Cargo - Delivery Office";
 	network = list("ss13","qm")
 	},
+/obj/item/stack/sheet/cardboard{
+	amount = 4
+	},
+/obj/item/storage/box/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "amq" = (
@@ -796,6 +798,7 @@
 /area/station/command/teleporter)
 "apX" = (
 /obj/structure/cable/multilayer/multiz,
+/obj/machinery/light/small/red/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "aqh" = (
@@ -915,7 +918,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "arM" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden/abandoned)
 "arO" = (
@@ -1094,9 +1096,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1124,6 +1123,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office/bridge_officer_office)
+"avO" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/crate,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "avX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1153,6 +1157,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "awv" = (
@@ -1314,6 +1321,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"aAw" = (
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/wood/large,
+/area/station/maintenance/old_rec)
 "aAB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -1419,7 +1430,7 @@
 "aCB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -1589,6 +1600,11 @@
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
+"aFj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "aFp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/meter,
@@ -1614,6 +1630,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"aFV" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/old_rec)
 "aGb" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -2084,6 +2104,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"aPs" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lower)
 "aPI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
@@ -2204,6 +2228,9 @@
 /obj/effect/spawner/random/structure/barricade,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "aSw" = (
@@ -2469,6 +2496,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aXA" = (
@@ -2573,6 +2603,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"aYx" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "aYA" = (
 /obj/machinery/light/small/directional/north,
 /mob/living/carbon/human/species/monkey,
@@ -2600,6 +2636,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "aYY" = (
@@ -2734,6 +2773,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "bbR" = (
@@ -2741,8 +2783,8 @@
 /area/station/medical/cryo)
 "bbT" = (
 /obj/structure/table,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/spawner/random/food_or_drink/snack,
+/obj/effect/spawner/costume/mafia/white,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "bcd" = (
@@ -3193,7 +3235,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "bjs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3248,8 +3290,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "bkI" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/departments/botany/directional/east,
@@ -3271,6 +3314,10 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"bkV" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "blb" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -3701,6 +3748,7 @@
 "bry" = (
 /obj/machinery/light/small/red/directional/north,
 /obj/effect/spawner/random/structure/crate,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "bsh" = (
@@ -3755,6 +3803,9 @@
 "btd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "btg" = (
@@ -4087,7 +4138,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "bzz" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -4189,6 +4240,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bBg" = (
@@ -4311,6 +4365,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/docking/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "bCx" = (
@@ -4372,6 +4427,14 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"bDU" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lower)
 "bDY" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -4593,6 +4656,10 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"bIi" = (
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "bIu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -4612,9 +4679,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -4849,10 +4913,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"bNB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron/showroomfloor,
-/area/station/cargo/office)
 "bNH" = (
 /obj/effect/spawner/random/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4869,6 +4929,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bNU" = (
@@ -4926,6 +4987,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "bOx" = (
@@ -5161,9 +5225,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "bSi" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -5173,6 +5234,9 @@
 	},
 /obj/effect/turf_decal/siding/brown,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Delivery Office"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bSE" = (
@@ -5201,6 +5265,10 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
+"bSS" = (
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "bSZ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -5212,6 +5280,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "bTh" = (
@@ -5221,6 +5292,10 @@
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 40
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bTn" = (
@@ -5380,6 +5455,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"bXJ" = (
+/obj/structure/cable,
+/obj/structure/grille/broken,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "bXR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -5653,15 +5733,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/experiment_room)
-"cdu" = (
-/turf/closed/wall,
-/area/station/service/library/abandoned)
 "cdw" = (
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "cdK" = (
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "cdP" = (
 /obj/effect/landmark/start/assistant,
@@ -5926,10 +6003,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "cjl" = (
-/obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/closet/crate/preopen,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cjJ" = (
@@ -6017,6 +6094,11 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
+"cmi" = (
+/obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/old_rec)
 "cmx" = (
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
@@ -6025,6 +6107,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/science)
 "cmQ" = (
@@ -6421,6 +6506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "ctL" = (
@@ -6531,6 +6617,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cvn" = (
@@ -6574,6 +6663,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "cvJ" = (
@@ -6612,6 +6704,8 @@
 	name = "Cargo Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "cwo" = (
@@ -6784,6 +6878,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"cyI" = (
+/obj/machinery/door/airlock{
+	name = "Commissary Backroom"
+	},
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "cyJ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -7243,8 +7343,6 @@
 /area/station/maintenance/department/medical)
 "cHu" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -7296,6 +7394,9 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "cIR" = (
@@ -7312,6 +7413,11 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/carpet/blue,
 /area/station/service/library)
+"cIY" = (
+/obj/machinery/light/small/red/directional/south,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "cJd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -7369,7 +7475,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "cKF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -7461,6 +7567,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"cMO" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "cMQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -7504,9 +7614,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "cNp" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Mining";
+	name = "Mining RC";
+	pixel_x = -30
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -7554,6 +7668,9 @@
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 7
+	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "cOD" = (
@@ -7784,6 +7901,7 @@
 "cTa" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "cTc" = (
@@ -7815,6 +7933,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cTQ" = (
@@ -7893,10 +8014,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"cUz" = (
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "cUI" = (
 /obj/structure/sign/warning/directional/south,
 /turf/open/floor/plating,
@@ -7981,7 +8098,7 @@
 	},
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "cVV" = (
 /turf/open/floor/vault,
 /area/station/ai_monitored/command/nuke_storage)
@@ -8146,8 +8263,8 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "cYS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cZa" = (
@@ -8199,6 +8316,9 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
+"cZV" = (
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "daa" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -8255,6 +8375,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dbi" = (
@@ -8768,7 +8889,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/large,
 /area/station/cargo/office)
 "djN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -9035,6 +9156,13 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
+"dpi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "dpy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/spawner/directional/south,
@@ -9044,6 +9172,7 @@
 /area/station/cargo/sorting)
 "dpA" = (
 /obj/effect/spawner/random/trash/hobo_squat,
+/obj/structure/sign/departments/maint/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "dpC" = (
@@ -9059,6 +9188,13 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"dpU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "dpY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -9418,13 +9554,6 @@
 "dxn" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/oldaisat/stationside)
-"dxp" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "dxq" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -9603,6 +9732,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "dzJ" = (
@@ -9629,6 +9759,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "dAg" = (
@@ -9734,7 +9867,7 @@
 "dCe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "dCh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -9784,7 +9917,7 @@
 "dDn" = (
 /obj/machinery/shower/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "dDp" = (
 /obj/effect/spawner/random/structure/furniture_parts,
 /obj/structure/closet/crate/wooden,
@@ -10069,11 +10202,18 @@
 "dIP" = (
 /turf/open/openspace,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dIV" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/large,
+/area/station/maintenance/old_rec)
 "dIY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/barricade,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dJb" = (
@@ -10174,7 +10314,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "dLh" = (
 /obj/structure/lattice/catwalk,
@@ -10318,7 +10458,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "dNh" = (
 /obj/structure/closet/secure_closet/brig{
@@ -10370,6 +10510,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dNN" = (
@@ -10536,6 +10679,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"dRu" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "dRy" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -10554,6 +10704,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dRF" = (
@@ -10753,9 +10906,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 13
-	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "dVD" = (
@@ -10772,6 +10922,15 @@
 /obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
+"dVN" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lower)
 "dWi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
@@ -10833,10 +10992,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "dXI" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/item/kirbyplants/random,
 /obj/machinery/door/firedoor,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "dXK" = (
@@ -10923,6 +11081,9 @@
 "dZK" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "eaw" = (
@@ -11081,6 +11242,10 @@
 /area/station/maintenance/department/cargo)
 "eep" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/brown/filled/shrink_ccw,
+/obj/effect/turf_decal/trimline/brown/filled/shrink_cw{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "eeq" = (
@@ -11346,6 +11511,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ejP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "ejQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -11901,8 +12071,9 @@
 "ets" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/mess,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "ett" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/spawner/directional/west,
@@ -11913,6 +12084,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /obj/item/wirecutters,
+/obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "euc" = (
@@ -12015,6 +12187,7 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/item/stack/rods/ten,
 /obj/item/stack/cable_coil/five,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "evK" = (
@@ -12052,6 +12225,12 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/lower)
+"ewF" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "ewO" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -12141,6 +12320,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eym" = (
@@ -12212,7 +12392,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "eyY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12250,7 +12430,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "ezF" = (
@@ -12456,7 +12635,7 @@
 "eDl" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "eDp" = (
 /turf/closed/wall/r_wall,
@@ -12761,6 +12940,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -13451,7 +13633,7 @@
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "eUr" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Lab"
@@ -13591,6 +13773,7 @@
 	dir = 1;
 	name = "plush sofa"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "eWB" = (
@@ -13856,8 +14039,6 @@
 /turf/open/floor/carpet/black,
 /area/station/security/prison/workout)
 "faF" = (
-/obj/structure/sign/poster/random/directional/south,
-/obj/machinery/light/small/red/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
@@ -13868,9 +14049,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "faT" = (
-/obj/item/wheelchair,
-/obj/effect/spawner/random/trash/janitor_supplies,
 /obj/structure/closet/crate,
+/obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "fba" = (
@@ -13932,6 +14112,13 @@
 "fci" = (
 /turf/closed/wall,
 /area/station/maintenance/port)
+"fcq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "fcs" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -14288,6 +14475,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fio" = (
@@ -14663,6 +14851,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"foq" = (
+/obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "for" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /obj/machinery/meter,
@@ -15157,6 +15353,9 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "fyd" = (
@@ -15199,6 +15398,7 @@
 	dir = 8;
 	network = list("ss13","qm")
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "fzC" = (
@@ -15218,9 +15418,20 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
+"fzH" = (
+/obj/structure/closet,
+/obj/item/clothing/under/color/jumpskirt/blue,
+/obj/item/clothing/under/color/blue,
+/obj/item/clothing/under/color/blue,
+/obj/item/clothing/under/color/blue,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "fzK" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/closet_empty,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "fzS" = (
@@ -15364,6 +15575,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
+"fCC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "fCE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/directional/north,
@@ -15623,6 +15838,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -16080,6 +16298,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"fPf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "fPr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -16610,6 +16835,18 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/circuit,
 /area/station/engineering/storage)
+"fYI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "fYP" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
@@ -16738,6 +16975,9 @@
 /area/station/service/barber)
 "gdc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "gdt" = (
@@ -17149,6 +17389,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/structure/sign/warning/directional/south,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "glb" = (
@@ -17264,6 +17507,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"gmp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "gmy" = (
 /turf/open/openspace,
 /area/station/hallway/primary/fore)
@@ -17271,7 +17520,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "gmG" = (
 /obj/structure/table/wood,
@@ -17558,9 +17807,14 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/carpet,
 /area/station/hallway/primary/central)
-"gsO" = (
+"gsJ" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/girder,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
+"gsO" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "gsV" = (
@@ -17776,6 +18030,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/service/hydroponics/park)
 "gwN" = (
@@ -17835,6 +18092,9 @@
 	name = "Abandoned Medical"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "gxK" = (
@@ -17854,6 +18114,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gxV" = (
@@ -18079,6 +18342,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "gBI" = (
@@ -18257,6 +18523,19 @@
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"gDR" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
+"gDV" = (
+/obj/item/target,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "gEd" = (
 /obj/structure/chair{
 	dir = 4
@@ -18334,6 +18613,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/hallway/secondary/service)
+"gGk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "gGC" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -18404,6 +18692,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"gHr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "gHs" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/light/built/directional/north,
@@ -18556,6 +18852,13 @@
 "gKr" = (
 /turf/closed/wall,
 /area/station/security/prison/garden)
+"gKH" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "gKN" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -18790,11 +19093,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gNX" = (
-/obj/machinery/status_display/supply{
-	pixel_y = -30
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -18873,6 +19177,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/brig)
+"gPD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "gPI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19206,6 +19515,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "gUY" = (
@@ -19331,6 +19643,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "gWu" = (
@@ -19393,6 +19708,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "gXg" = (
@@ -19485,7 +19802,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "gYz" = (
 /obj/effect/spawner/random/structure/table_or_rack,
@@ -19734,6 +20051,13 @@
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/wall/r_wall,
 /area/station/science/server)
+"heI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "heN" = (
 /obj/structure/toilet{
 	dir = 8
@@ -19788,6 +20112,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"hfU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/old_rec)
 "hfW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19854,6 +20182,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
 "hgF" = (
@@ -19876,6 +20208,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"hgV" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "hgZ" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
@@ -19934,8 +20272,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "hid" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room"
@@ -20286,6 +20625,9 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "hoC" = (
@@ -20305,6 +20647,11 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hpw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "hpF" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
@@ -20725,8 +21072,9 @@
 "hxU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "hxY" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing"
@@ -20783,6 +21131,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "hyS" = (
@@ -20838,6 +21189,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "hzO" = (
@@ -20871,6 +21225,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "hAu" = (
@@ -20893,7 +21250,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "hAN" = (
 /obj/machinery/telecomms/server/presets/supply,
@@ -21084,7 +21441,7 @@
 "hEf" = (
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "hEk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21203,6 +21560,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"hGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "hGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -21261,6 +21623,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
+"hHm" = (
+/obj/structure/closet/crate/preopen,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "hHn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -21349,7 +21716,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "hIs" = (
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/large,
 /area/station/cargo/office)
 "hIE" = (
 /obj/structure/cable,
@@ -21361,7 +21728,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "hIG" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden/abandoned)
@@ -21646,6 +22012,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/railing,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "hMg" = (
@@ -21690,6 +22059,7 @@
 "hNg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "hNi" = (
@@ -21710,6 +22080,7 @@
 	dir = 10;
 	network = list("ss13","qm")
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hNu" = (
@@ -22047,6 +22418,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hTK" = (
@@ -22206,7 +22578,7 @@
 /area/station/maintenance/starboard/aft)
 "hWG" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "hWJ" = (
 /obj/effect/turf_decal/stripes,
@@ -22621,6 +22993,11 @@
 	dir = 4
 	},
 /area/station/engineering/main)
+"ifk" = (
+/obj/structure/sign/departments/maint/directional/south,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "ifD" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -22789,7 +23166,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22938,7 +23314,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "ikE" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -23015,6 +23391,12 @@
 "imb" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/lower)
+"imi" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "imK" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -23078,17 +23460,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "iop" = (
-/obj/machinery/door/airlock/mining{
-	name = "Computer Den"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/brown,
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
+/obj/machinery/door/airlock/mining{
+	name = "Computer Den"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningdock)
 "iov" = (
@@ -23250,6 +23629,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"irl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "irt" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/multiz/yellow/visible{
@@ -23460,7 +23849,10 @@
 "iul" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/machinery/door/airlock/mining/glass,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "iuB" = (
@@ -23585,6 +23977,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "ixQ" = (
@@ -23871,6 +24266,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
+"iCW" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "iCY" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -23920,7 +24319,8 @@
 "iDD" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "iDH" = (
 /obj/machinery/camera{
@@ -24049,6 +24449,13 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/sepia,
 /area/station/hallway/secondary/service)
+"iGj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "iGx" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plating,
@@ -24410,6 +24817,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"iMd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "iMe" = (
 /obj/machinery/vending/security,
 /obj/effect/turf_decal/bot,
@@ -24695,6 +25109,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"iQG" = (
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "iQX" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/stripes/line{
@@ -24771,11 +25192,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
-"iSa" = (
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "iSg" = (
 /obj/structure/chair{
 	dir = 8
@@ -25151,7 +25567,8 @@
 /area/station/solars/starboard/aft)
 "iZN" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "iZQ" = (
@@ -25169,6 +25586,12 @@
 	dir = 1
 	},
 /area/station/command/bridge)
+"jaY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "jba" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -25333,12 +25756,6 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"jfn" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/cargo/office)
 "jfs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -25355,11 +25772,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"jgo" = (
-/obj/structure/sign/poster/random/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "jgx" = (
 /obj/structure/railing{
 	dir = 8
@@ -25700,6 +26112,7 @@
 "joE" = (
 /obj/structure/bookcase,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "joI" = (
@@ -25902,6 +26315,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"jsr" = (
+/obj/structure/closet/crate/cardboard,
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "jst" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -25942,6 +26359,7 @@
 	pixel_y = -8;
 	req_access = list("cargo")
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "jsE" = (
@@ -26101,6 +26519,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
+"jvy" = (
+/obj/structure/closet,
+/obj/item/clothing/under/color/jumpskirt/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/obj/structure/sign/clock/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "jvD" = (
 /obj/machinery/power/solar{
 	id = "foreportsolar";
@@ -26846,6 +27273,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "jIN" = (
@@ -26981,12 +27409,13 @@
 "jKw" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Abandoned Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "jKx" = (
@@ -27057,11 +27486,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
-"jLf" = (
-/turf/closed/wall,
-/area/station/service/hydroponics/garden/abandoned)
 "jLm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w,
 /turf/open/floor/circuit/telecomms,
@@ -27207,8 +27633,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "jNE" = (
+/obj/effect/spawner/random/structure/grille,
 /obj/structure/girder,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "jOC" = (
@@ -27216,11 +27642,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
-"jOI" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "jOL" = (
@@ -27241,6 +27662,8 @@
 "jON" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jOQ" = (
@@ -27459,7 +27882,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jSV" = (
@@ -27960,6 +28382,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/lower)
 "kaq" = (
@@ -28756,6 +29181,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/mail_sorting/engineering/atmospherics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "kmz" = (
@@ -28865,8 +29291,9 @@
 	pixel_y = -9;
 	pixel_x = -5
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "koR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -28975,6 +29402,11 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"kqT" = (
+/obj/machinery/light/small/red/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "kre" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -29280,6 +29712,12 @@
 /obj/effect/landmark/navigate_destination/kitchen,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"kvr" = (
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "kvQ" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -29292,6 +29730,7 @@
 /obj/machinery/light/small/red/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "kvT" = (
@@ -29346,6 +29785,9 @@
 "kwt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "kwv" = (
@@ -29844,10 +30286,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "kFK" = (
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kFL" = (
@@ -29898,6 +30340,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "kGA" = (
@@ -30043,6 +30488,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"kIO" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "kIQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -30095,15 +30544,18 @@
 "kJT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "kKd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "kKh" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "kKs" = (
@@ -30199,10 +30651,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"kLN" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/openspace,
-/area/station/cargo/storage)
 "kLO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30244,6 +30692,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "kMk" = (
@@ -30266,6 +30715,7 @@
 "kMq" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "kMs" = (
@@ -30318,9 +30768,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -30343,8 +30790,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random/directional/south,
+/obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "kNG" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -30434,11 +30883,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Break Room"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
 "kPI" = (
@@ -30472,7 +30922,6 @@
 	dir = 0
 	},
 /obj/effect/landmark/blobstart,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "kQi" = (
@@ -30757,7 +31206,7 @@
 "kUQ" = (
 /obj/structure/hoop,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "kVm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30881,6 +31330,13 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"kXK" = (
+/obj/item/gavelblock,
+/obj/item/gavelhammer{
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "kXO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -31096,15 +31552,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/bar)
-"laI" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance{
-	name = "Abandoned Diner"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/service/kitchen/abandoned)
 "laL" = (
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/broken_floor,
@@ -31117,7 +31564,7 @@
 /obj/machinery/shower/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "lbr" = (
 /obj/machinery/light/small/red/directional/east,
 /obj/effect/spawner/random/structure/crate,
@@ -31146,20 +31593,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar/lower)
-"lce" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/abandoned)
 "lcm" = (
 /obj/effect/spawner/random/trash/soap,
 /obj/effect/spawner/random/trash/mopbucket,
@@ -31293,6 +31726,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "ldK" = (
@@ -31305,10 +31741,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
-"ldO" = (
-/obj/machinery/light/small/red/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "ldP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31377,6 +31809,7 @@
 "leJ" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "leN" = (
@@ -31474,7 +31907,6 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/landmark/blobstart,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/abandoned)
 "lgZ" = (
@@ -31927,12 +32359,8 @@
 /obj/machinery/door/airlock/mining{
 	name = "Warehouse"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32483,6 +32911,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lwl" = (
@@ -32513,6 +32944,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lwA" = (
@@ -32754,12 +33189,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
-"lAj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "lAp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -32956,8 +33385,9 @@
 /area/station/medical/storage)
 "lDu" = (
 /obj/structure/chair/stool/directional/south,
+/obj/effect/spawner/costume/mafia,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "lEn" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -32986,9 +33416,11 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "lEs" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/service/library/abandoned)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "lEB" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating/airless,
@@ -33102,6 +33534,15 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"lGi" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
+"lGj" = (
+/obj/structure/sign/departments/maint/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lGt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -33110,10 +33551,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
 "lGv" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/moisture_trap,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "lGz" = (
 /obj/structure/cable,
@@ -33386,6 +33826,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
+"lLc" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lower)
 "lLj" = (
 /obj/structure/railing{
 	dir = 8
@@ -33411,6 +33859,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
+"lLw" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/ammo_casing/spent,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "lLz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
@@ -33506,6 +33960,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lMT" = (
+/obj/effect/turf_decal/trimline/brown/filled/shrink_cw,
+/obj/effect/turf_decal/trimline/brown/filled/shrink_ccw{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lMU" = (
@@ -33710,6 +34168,9 @@
 	name = "Storage Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "lPZ" = (
@@ -33751,8 +34212,9 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "lQW" = (
-/turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "lQY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -34078,6 +34540,14 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"lWZ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/lower)
 "lXm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -34230,8 +34700,9 @@
 	},
 /obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/grey_tide/directional/east,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "maC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
@@ -34419,7 +34890,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "mdl" = (
 /obj/machinery/duct,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -34608,6 +35079,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "mfX" = (
@@ -35493,6 +35967,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "mvC" = (
@@ -35645,6 +36120,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mye" = (
@@ -35941,6 +36417,9 @@
 "mDv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "mDS" = (
@@ -36047,6 +36526,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"mGa" = (
+/turf/closed/wall,
+/area/station/maintenance/old_rec)
 "mGg" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -36094,7 +36576,7 @@
 "mGX" = (
 /obj/effect/turf_decal/trimline/dark_red/line,
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "mHh" = (
 /obj/structure/guillotine,
 /turf/open/floor/iron/dark,
@@ -36381,6 +36863,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "mNv" = (
@@ -36478,12 +36963,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/hydroponics)
 "mOA" = (
-/obj/machinery/status_display/supply{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "mOB" = (
@@ -36685,6 +37168,9 @@
 /area/station/hallway/secondary/entry)
 "mQT" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "mRa" = (
@@ -36693,6 +37179,7 @@
 	name = "Cargo Bay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "mRo" = (
@@ -36735,6 +37222,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "mRB" = (
@@ -36773,6 +37263,11 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/treatment_center)
+"mRY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/target/syndicate,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "mSc" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -36806,7 +37301,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Commissary Backroom"
+	name = "Commissary Storage"
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -36829,7 +37324,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "mSZ" = (
@@ -36994,6 +37488,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "mVX" = (
@@ -37037,12 +37534,14 @@
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 2
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "mWU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "mWX" = (
@@ -37181,11 +37680,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/tcommsat/computer)
 "mZq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/bookbinder,
 /turf/open/floor/plating,
-/area/station/service/library/abandoned)
+/area/station/maintenance/port/lower)
 "mZv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -37219,6 +37716,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"mZM" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "mZR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -37388,7 +37889,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/large,
 /area/station/cargo/office)
 "ndz" = (
 /turf/closed/indestructible{
@@ -37423,6 +37924,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "nek" = (
@@ -37701,13 +38203,13 @@
 "nia" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "nie" = (
 /obj/effect/decal/cleanable/shreds,
@@ -37872,6 +38374,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "nlk" = (
@@ -38022,7 +38527,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "nnF" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron,
@@ -38121,6 +38626,9 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
+"noX" = (
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/old_rec)
 "npa" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/carpet/black,
@@ -38231,7 +38739,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "nre" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38277,6 +38785,15 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/command/bridge)
+"nrL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nrX" = (
 /obj/structure/closet/crate/cardboard,
 /turf/open/floor/plating,
@@ -38429,10 +38946,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "nuD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "nuJ" = (
@@ -38665,6 +39185,9 @@
 	req_access = list("cargo")
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nyw" = (
@@ -38755,6 +39278,11 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"nAb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "nAc" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/sign/poster/random/directional/north,
@@ -39085,7 +39613,7 @@
 /obj/item/clothing/mask/whistle,
 /obj/effect/spawner/costume/referee,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "nEP" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -39321,6 +39849,11 @@
 "nHz" = (
 /turf/closed/wall/r_wall,
 /area/station/security/detectives_office/bridge_officer_office)
+"nHF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "nHP" = (
 /obj/structure/chair{
 	dir = 1
@@ -39407,6 +39940,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "nJe" = (
@@ -39547,7 +40083,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Abandoned Kitchen"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/plating,
@@ -39713,11 +40248,20 @@
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "nNV" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"nOw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"nOH" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "nOJ" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/carpet/red,
@@ -39767,6 +40311,10 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"nPz" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "nPF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -39860,6 +40408,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"nRN" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "nSd" = (
 /obj/structure/sign/picture_frame/showroom/three{
 	pixel_x = -11;
@@ -39960,6 +40513,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/tcommsat/computer)
+"nTQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "nTR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -40207,11 +40765,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"nZr" = (
-/obj/effect/spawner/costume/mafia,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "nZJ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -40336,6 +40889,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "obP" = (
@@ -40520,11 +41076,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"ofn" = (
-/obj/machinery/light/small/red/directional/north,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "ofq" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 4;
@@ -40799,6 +41350,7 @@
 "ojv" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
 "ojA" = (
@@ -40869,6 +41421,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "okD" = (
 /obj/machinery/light/small/red/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "okM" = (
@@ -41310,6 +41863,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "orD" = (
@@ -41321,7 +41877,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -41541,6 +42096,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution/red{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ovg" = (
@@ -41619,6 +42177,8 @@
 /area/station/security/prison)
 "oxz" = (
 /obj/effect/decal/cleanable/plastic,
+/obj/structure/closet/crate/preopen,
+/obj/item/wheelchair,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "oxH" = (
@@ -41646,6 +42206,9 @@
 	name = "Tool Storage Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "oyb" = (
@@ -41685,6 +42248,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
+"oyp" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/service/kitchen/abandoned)
 "oyr" = (
 /obj/machinery/light/small/red/directional/north,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -41896,6 +42463,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
+"oAX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "oAY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -42031,6 +42604,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "oEr" = (
@@ -42222,7 +42798,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "oHL" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42241,6 +42817,7 @@
 "oIQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
+/obj/machinery/light/small/red/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "oJj" = (
@@ -42600,9 +43177,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oPL" = (
@@ -42632,8 +43207,9 @@
 	dir = 8
 	},
 /obj/structure/chair/stool/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "oQi" = (
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
@@ -42961,7 +43537,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -42971,6 +43547,9 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "oVj" = (
@@ -43055,6 +43634,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"oVZ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "oWm" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -43245,7 +43830,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pai" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -43310,7 +43895,7 @@
 "pbi" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/closed/wall,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pbo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -43431,7 +44016,6 @@
 /area/station/maintenance/department/medical)
 "pdb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
@@ -43454,16 +44038,16 @@
 /turf/open/floor/iron,
 /area/station/science/server)
 "pdF" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/floor/iron/textured,
@@ -43579,7 +44163,7 @@
 /obj/machinery/shower/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pfh" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Bathroom"
@@ -43667,7 +44251,7 @@
 "pgQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/large,
 /area/station/cargo/office)
 "pgT" = (
 /obj/machinery/button/door{
@@ -43691,8 +44275,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "phh" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/airalarm/directional/east,
@@ -43776,6 +44361,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "piL" = (
@@ -43866,7 +44452,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "pjO" = (
 /obj/structure/disposalpipe/segment,
@@ -44000,6 +44586,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "pnv" = (
@@ -44028,6 +44617,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"poj" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "poo" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -44479,7 +45077,7 @@
 	pixel_x = 9
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pum" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -44823,6 +45421,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "pAf" = (
@@ -44832,8 +45433,12 @@
 /obj/structure/chair/stool/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/bacteria,
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
+	},
+/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pAs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -45072,8 +45677,9 @@
 /obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/sign/poster/contraband/andromeda_bitters/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "pDO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -45490,6 +46096,16 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
+"pKu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
+"pKA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood/large,
+/area/station/maintenance/old_rec)
 "pKF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45577,9 +46193,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45753,9 +46366,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/east,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/abandoned)
+"pQq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "pQC" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -45944,6 +46561,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "pUj" = (
@@ -46004,6 +46624,8 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "pUE" = (
@@ -46104,6 +46726,11 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"pVK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate_empty,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "pWj" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/cardboard,
@@ -46160,13 +46787,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "pWO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pWS" = (
@@ -46271,11 +46898,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"pYX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/service/kitchen/abandoned)
 "pZh" = (
 /obj/machinery/button/door{
 	id = "xenobio6";
@@ -46392,6 +47014,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qaG" = (
@@ -46484,6 +47109,16 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"qbv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "qcl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -47439,6 +48074,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qrt" = (
+/obj/structure/sign/poster/random/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "qrz" = (
@@ -47648,6 +48285,8 @@
 /area/station/maintenance/department/science)
 "quB" = (
 /obj/structure/cable/multilayer/multiz,
+/obj/structure/sign/departments/maint/directional/north,
+/obj/machinery/light/small/red/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "quD" = (
@@ -48002,7 +48641,7 @@
 "qyx" = (
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "qyy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48243,6 +48882,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qDt" = (
@@ -48262,6 +48902,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"qDF" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "qDS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -48353,6 +48997,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"qFf" = (
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "qFq" = (
 /obj/structure/chair{
 	dir = 4
@@ -48379,6 +49027,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"qFB" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "qFE" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/recharge_floor,
@@ -48721,6 +49373,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/red,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qNf" = (
@@ -48747,6 +49400,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
+"qNA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/target,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "qNM" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -48801,6 +49459,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qOn" = (
@@ -48889,6 +49550,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/bar)
+"qPW" = (
+/obj/structure/closet/crate/preopen,
+/turf/open/floor/iron,
+/area/station/commons/vacant_room/commissary)
 "qQd" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -49172,6 +49837,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/barricade,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "qUf" = (
@@ -49297,6 +49965,18 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"qWC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "qWF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -49385,6 +50065,9 @@
 "qYj" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "qYq" = (
@@ -49509,11 +50192,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"rao" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/service/kitchen/abandoned)
 "raG" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -49780,6 +50458,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"reA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "reD" = (
 /obj/machinery/suit_storage_unit/industrial/loader,
 /obj/machinery/newscaster/directional/east,
@@ -50115,6 +50799,7 @@
 /area/station/service/library)
 "rkg" = (
 /obj/effect/decal/cleanable/generic,
+/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "rki" = (
@@ -50149,8 +50834,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"rkS" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "rla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -50385,6 +51075,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "rpt" = (
@@ -50477,6 +51168,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "rqW" = (
@@ -50878,6 +51572,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "rxA" = (
@@ -50972,10 +51669,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ryX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rzc" = (
@@ -51143,6 +51842,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "rBA" = (
@@ -51215,6 +51915,9 @@
 	name = "Delivery Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rCK" = (
@@ -51229,7 +51932,7 @@
 /area/station/security/checkpoint/arrivals)
 "rDr" = (
 /turf/open/floor/wood/large,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "rDu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -51642,9 +52345,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -51693,7 +52393,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "rJO" = (
 /obj/machinery/smartfridge,
@@ -51956,6 +52656,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "rOd" = (
@@ -52036,6 +52739,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"rPa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "rPj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -52169,8 +52877,8 @@
 	amount = 8
 	},
 /obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -52262,6 +52970,7 @@
 	name = "Old Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "rTi" = (
@@ -52317,6 +53026,9 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -52688,6 +53400,10 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"rYK" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "rYP" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/security_officer,
@@ -53180,6 +53896,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "shM" = (
@@ -53208,6 +53927,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "siC" = (
@@ -53264,6 +53984,10 @@
 /area/station/service/bar)
 "sjB" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "sjT" = (
@@ -53370,8 +54094,8 @@
 	c_tag = "Aft Hallway - Intersection";
 	dir = 5
 	},
-/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "slJ" = (
@@ -53472,9 +54196,15 @@
 /area/station/commons/toilet/restrooms)
 "snr" = (
 /obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_y = 4;
+	pixel_x = -6
+	},
 /obj/item/paper_bin,
-/obj/item/folder/yellow,
-/obj/item/dest_tagger,
+/obj/item/dest_tagger{
+	pixel_x = 13;
+	pixel_y = 6
+	},
 /obj/item/crowbar{
 	pixel_x = 13
 	},
@@ -53561,6 +54291,14 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"spf" = (
+/obj/item/ammo_casing/spent{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/ammo_casing/spent,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "spq" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -53803,6 +54541,11 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
+"ssU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "stf" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/directional/east,
@@ -53813,6 +54556,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -53861,6 +54607,7 @@
 "stN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "stQ" = (
@@ -53908,6 +54655,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "suo" = (
@@ -53985,7 +54733,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "swn" = (
 /obj/structure/sign/poster/random/directional/south,
 /obj/structure/table,
@@ -54084,7 +54832,7 @@
 	},
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "sya" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54616,13 +55364,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "sFI" = (
-/obj/structure/closet,
-/obj/item/clothing/under/color/jumpskirt/red,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/under/color/red,
+/obj/item/rack_parts,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "sFJ" = (
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark/smooth_half,
@@ -54851,6 +55596,10 @@
 /area/station/engineering/atmos)
 "sJq" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "sJw" = (
@@ -55267,6 +56016,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "sQa" = (
@@ -55748,7 +56498,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "sYT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/three,
@@ -55995,7 +56745,7 @@
 "tcF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/large,
 /area/station/cargo/office)
 "tcI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -56308,6 +57058,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "tjp" = (
@@ -56405,9 +57158,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
@@ -56415,6 +57165,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tli" = (
@@ -56851,8 +57604,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/sepia,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "trT" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/plastic,
@@ -56863,6 +57617,11 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"tsb" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "tsp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -56929,6 +57688,9 @@
 /obj/machinery/camera{
 	c_tag = "Service - Lower Bar Lounge";
 	dir = 9
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 7
 	},
 /turf/open/floor/wood,
 /area/station/service/bar/lower)
@@ -57091,6 +57853,9 @@
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/carpet/green,
 /area/station/service/bar/lower)
+"twH" = (
+/turf/open/floor/plating,
+/area/station/service/hydroponics/garden/abandoned)
 "twQ" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/line,
@@ -57270,6 +58035,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "tAw" = (
@@ -57557,6 +58325,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"tFW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "tGi" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small/red/directional/west,
@@ -57616,10 +58391,6 @@
 /obj/effect/landmark/start/asset_protection,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/bridge)
-"tHt" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/commons/vacant_room/commissary)
 "tHV" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
@@ -57736,11 +58507,22 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tKp" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "tKs" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
+"tKv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/wood/large,
+/area/station/maintenance/old_rec)
 "tKD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -57858,6 +58640,8 @@
 /area/station/service/hydroponics/garden)
 "tMw" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "tMD" = (
@@ -58027,6 +58811,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "tOP" = (
@@ -58927,17 +59712,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
-"ueX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/abandoned)
 "ueZ" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/sepia,
@@ -59058,6 +59832,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "uhf" = (
@@ -59168,6 +59943,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ujP" = (
@@ -59193,15 +59969,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/lower)
-"ukl" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/item/kirbyplants,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/openspace,
-/area/station/cargo/storage)
 "uko" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications"
@@ -59231,6 +59998,9 @@
 	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 5
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -59318,7 +60088,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "umA" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -59402,8 +60172,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "uoo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59477,6 +60248,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "uoK" = (
@@ -59727,7 +60499,7 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "uta" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -59775,6 +60547,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "utC" = (
@@ -60296,6 +61069,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"uEi" = (
+/obj/effect/spawner/random/engineering/tank,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "uEs" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster/directional/west,
@@ -60308,6 +61086,15 @@
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/station/tcommsat/server)
+"uEz" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "uEG" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -60315,6 +61102,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"uEL" = (
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "uEN" = (
 /obj/machinery/rnd/bepis,
 /turf/open/space/basic,
@@ -60724,6 +61515,22 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"uLy" = (
+/obj/structure/closet/crate/cardboard,
+/obj/item/storage/pill_bottle/lsd{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/storage/pill_bottle/happy,
+/obj/item/storage/pill_bottle/happy{
+	pixel_y = 2;
+	pixel_x = 6
+	},
+/obj/item/storage/pill_bottle/zoom{
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "uLz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -60900,6 +61707,9 @@
 "uPv" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uPw" = (
@@ -60931,7 +61741,7 @@
 /area/station/medical/storage)
 "uPP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "uPQ" = (
@@ -61379,6 +62189,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "uWZ" = (
@@ -61426,6 +62239,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"uYk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "uYo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -61484,6 +62302,11 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"uZI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "uZM" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -61815,6 +62638,9 @@
 "vgZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "vhn" = (
@@ -61853,7 +62679,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/spawner/random/trash/food_packaging,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
@@ -61977,7 +62802,7 @@
 "vjz" = (
 /obj/machinery/piratepad/civilian,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "vjC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -62125,11 +62950,15 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "vmm" = (
-/obj/structure/closet,
-/obj/item/clothing/under/color/jumpskirt/blue,
-/obj/item/clothing/under/color/blue,
-/obj/item/clothing/under/color/blue,
-/obj/item/clothing/under/color/blue,
+/obj/structure/rack,
+/obj/item/toy/basketball,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
+"vmr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "vmA" = (
@@ -62537,6 +63366,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vtb" = (
@@ -62570,7 +63402,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "vtr" = (
 /obj/effect/decal/cleanable/glass,
@@ -62578,6 +63410,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "vtN" = (
@@ -62711,12 +63546,15 @@
 "vwe" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "vwf" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "vwL" = (
 /obj/structure/chair{
 	dir = 8
@@ -62876,6 +63714,7 @@
 /area/station/medical/cryo)
 "vAG" = (
 /obj/structure/sign/poster/contraband/random/directional/south,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "vAL" = (
@@ -62896,6 +63735,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/spawner/random/structure/grille,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "vAU" = (
@@ -62913,6 +63755,11 @@
 /obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
+"vBe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "vBl" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -63380,7 +64227,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "vKP" = (
 /obj/structure/disposalpipe/segment{
@@ -63700,6 +64547,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "vQp" = (
@@ -63910,7 +64760,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "vUE" = (
 /obj/structure/flora/bush/grassy/style_random,
@@ -63996,7 +64846,9 @@
 /area/station/engineering/atmos)
 "vWx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "vWL" = (
@@ -64259,6 +65111,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "wcb" = (
@@ -64549,6 +65402,15 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wic" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "wie" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1
@@ -64804,6 +65666,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wmv" = (
@@ -64897,7 +65760,7 @@
 "wnE" = (
 /obj/machinery/shower/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "wnK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/glass/reinforced,
@@ -65037,6 +65900,9 @@
 "wqb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "wqf" = (
@@ -65064,7 +65930,6 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
 "wqD" = (
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -65117,6 +65982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/structure/steam_vent,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wrK" = (
@@ -65367,6 +66233,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
 /area/station/tcommsat/oldaisat/stationside)
+"wwB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wwD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65413,6 +66284,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"wxf" = (
+/obj/effect/spawner/random/engineering/material_cheap,
+/obj/structure/closet/crate/preopen,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wxq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/wood,
@@ -65827,6 +66703,7 @@
 /obj/item/chair{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/abandoned)
 "wEY" = (
@@ -65883,15 +66760,11 @@
 /area/station/medical/virology)
 "wFR" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/requests_console{
-	department = "Mining";
-	name = "Mining RC";
-	pixel_x = -30
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wFS" = (
@@ -66250,6 +67123,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"wNg" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "wNK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/white,
@@ -66302,7 +67183,7 @@
 "wOV" = (
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "wOX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -66488,6 +67369,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"wSl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/bucket,
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wSP" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
@@ -66527,9 +67415,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "wTP" = (
-/obj/structure/closet/crate,
-/obj/item/storage/crayons,
 /obj/machinery/light/small/red/directional/north,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "wTV" = (
@@ -66686,6 +67574,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
+"wVV" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wWd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -66995,6 +67889,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xbW" = (
@@ -67064,13 +67959,11 @@
 /area/station/science/lab)
 "xdf" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/machinery/status_display/supply{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "xdx" = (
@@ -67167,9 +68060,6 @@
 "xeM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -10
-	},
 /turf/open/floor/wood,
 /area/station/service/bar/lower)
 "xeN" = (
@@ -67193,7 +68083,6 @@
 "xfo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "xfv" = (
@@ -67284,6 +68173,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xgQ" = (
@@ -67361,6 +68251,9 @@
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/cargo/storage)
+"xhG" = (
+/turf/open/floor/plating,
+/area/station/commons/vacant_room/commissary)
 "xhH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -67823,6 +68716,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xqh" = (
@@ -68077,6 +68973,7 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/spawner/random/entertainment/wallet_storage,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
 "xuy" = (
@@ -68132,6 +69029,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/eva)
 "xvF" = (
@@ -68215,6 +69115,9 @@
 "xxu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "xxD" = (
@@ -68249,7 +69152,6 @@
 /area/station/ai_monitored/turret_protected/ai)
 "xym" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
@@ -68454,19 +69356,20 @@
 /area/station/engineering/main)
 "xCr" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
 /turf/open/floor/iron/textured,
 /area/station/cargo/warehouse)
 "xCs" = (
@@ -68575,7 +69478,7 @@
 /obj/machinery/shower/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "xDR" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -68836,7 +69739,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "xIQ" = (
 /turf/open/floor/iron/grimy,
@@ -68930,10 +69833,6 @@
 	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
-"xKy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/hydroponics/garden/abandoned)
 "xKD" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot{
@@ -68987,6 +69886,13 @@
 "xLk" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/storage)
+"xLr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "xLt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 8
@@ -69245,6 +70151,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
 "xRf" = (
@@ -69556,8 +70465,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/structure/grille,
 /obj/structure/sign/warning/directional/south,
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "xVP" = (
@@ -69576,8 +70485,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/lower)
+/area/station/maintenance/old_rec)
 "xWb" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -69814,6 +70725,12 @@
 "xZx" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
+"xZB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "xZC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -70081,6 +70998,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/red/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/abandoned)
 "yeG" = (
@@ -70167,6 +71085,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/library)
+"yfS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood/large,
+/area/station/maintenance/old_rec)
 "yge" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/stripes/line{
@@ -70183,6 +71106,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"ygi" = (
+/obj/effect/decal/cleanable/insectguts,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "ygm" = (
 /obj/effect/spawner/random/decoration/glowstick,
 /obj/effect/spawner/random/trash/moisture_trap,
@@ -70255,6 +71182,10 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"yhg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/old_rec)
 "yhO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -86608,7 +87539,7 @@ xsG
 rMW
 qzm
 qQh
-ley
+gmp
 hCY
 rMW
 rMW
@@ -92007,7 +92938,7 @@ sag
 deJ
 qii
 sag
-aDd
+qof
 wlt
 sag
 xsG
@@ -92780,17 +93711,17 @@ auY
 mSr
 mSr
 mSr
-aDd
-aDd
-jkB
-dDJ
-aDd
-aDd
-jkB
-dDJ
-dDJ
-aDd
-hna
+xQy
+xGv
+hGa
+nOw
+lyd
+xQy
+hGa
+vfw
+vBe
+xGv
+hVj
 jkB
 auY
 dDJ
@@ -93030,14 +93961,14 @@ xsG
 ymg
 ymg
 sag
-sag
+blm
 sYK
 aDd
 rhb
 aDd
 aDd
 jSw
-xQy
+aDd
 dDJ
 dDJ
 dDJ
@@ -93287,7 +94218,7 @@ xsG
 ymg
 ymg
 sag
-blm
+hHm
 aDd
 aDd
 jkB
@@ -93778,7 +94709,7 @@ wNX
 ymg
 sag
 sag
-sKG
+qbv
 xhh
 cMi
 cMi
@@ -93803,7 +94734,7 @@ ymg
 sag
 lVv
 faT
-iSa
+aDd
 dDJ
 aDd
 fLP
@@ -94315,8 +95246,8 @@ xsG
 ymg
 ymg
 sag
-aDd
-aDd
+gDV
+wxf
 sag
 aDd
 dDJ
@@ -94572,8 +95503,8 @@ xsG
 ymg
 ymg
 cQP
-ctw
-aDd
+lLw
+bkV
 hNg
 aDd
 jkB
@@ -94592,7 +95523,7 @@ ymg
 ymg
 cQP
 xdF
-dDJ
+wwB
 sag
 ymg
 wNX
@@ -94830,7 +95761,7 @@ ymg
 ymg
 cQP
 aDd
-aDd
+hna
 hNg
 aDd
 jkB
@@ -95065,7 +95996,7 @@ sag
 jyd
 mLJ
 sag
-cOL
+oyp
 cOL
 cOL
 cOL
@@ -95087,9 +96018,9 @@ ymg
 ymg
 sag
 aDd
-aDd
+jkB
 sag
-aDd
+bSS
 hVJ
 fLP
 ymg
@@ -95333,7 +96264,7 @@ lgU
 kck
 yeC
 sag
-cUz
+aDd
 dDJ
 sag
 sag
@@ -95343,7 +96274,7 @@ xsG
 ymg
 sag
 sag
-aDd
+hna
 aDd
 sag
 vjS
@@ -95601,7 +96532,7 @@ xsG
 sag
 wAn
 dDJ
-aDd
+spf
 sag
 kzt
 tOz
@@ -95620,7 +96551,7 @@ ymg
 ymg
 imb
 apX
-aDd
+lGj
 sag
 ymg
 ymg
@@ -95846,7 +96777,7 @@ lcG
 rZS
 qhW
 vWx
-sag
+cks
 yal
 jyd
 fRw
@@ -95856,9 +96787,9 @@ ymg
 ymg
 ymg
 cQP
-dDJ
-aDd
-dDJ
+qNA
+dRu
+mRY
 sag
 oaU
 sag
@@ -96096,12 +97027,12 @@ sag
 cTu
 bbT
 mWU
-rao
+qSS
 nKU
-pYX
+rxG
 pQl
-lce
-ueX
+kck
+lcG
 lcG
 sag
 ohL
@@ -96114,11 +97045,11 @@ ymg
 ymg
 cQP
 lcm
-aDd
-aDd
+mSr
+hna
 sag
 mqU
-aDd
+cIY
 sag
 qtv
 rnp
@@ -96358,11 +97289,11 @@ cOL
 cOL
 cOL
 cOL
-laI
+cOL
 cOL
 sag
 sag
-lAj
+qQf
 sag
 sag
 cQP
@@ -96371,10 +97302,10 @@ cQP
 cQP
 sag
 sag
-hNg
-hNg
+poj
+raV
 sag
-cSn
+dpi
 dRW
 iii
 uNK
@@ -96613,26 +97544,26 @@ uqD
 rkg
 wBF
 cTa
-cdu
+sag
 mZq
-lEs
-aDd
-sag
-wAn
-jyd
-aDd
 dDJ
+bIi
+aDd
+aDd
 jyd
 aDd
+sag
+jyd
+dDJ
 aDd
 aDd
 sag
-ofn
-sYS
-hna
-aDd
+deJ
+mSr
+jaY
+dDJ
 evK
-aDd
+wWl
 sag
 puo
 xhz
@@ -96642,7 +97573,7 @@ sgr
 eKN
 vBr
 gkN
-bLD
+tKp
 pdF
 rxw
 dCb
@@ -96872,24 +97803,24 @@ cEA
 kly
 xRe
 lEs
-aDd
-sag
-sag
-aDd
-jkB
 dDJ
-jkB
+aDd
 jkB
 aDd
+uZI
+dDJ
+gKH
+jkB
+aDd
+ejP
 auY
-auY
-ahI
+irl
 auY
 sIV
 jcK
 mSr
-evK
-aDd
+iGj
+ifk
 sag
 afD
 mJO
@@ -97127,26 +98058,26 @@ pru
 ppL
 taU
 faF
+cks
+dDJ
 sag
-aDd
-sag
-sag
+dDJ
 gsO
-aDd
-ldO
-jgo
-hna
+sag
+sag
+sag
+sag
+cjW
 dDJ
 dDJ
-rhb
-aDd
+cjW
 sag
 sag
 sag
 sag
 sag
-evK
-aDd
+gHr
+nAb
 sag
 xPT
 xPT
@@ -97385,25 +98316,25 @@ usy
 bgY
 qrt
 sag
+avO
 sag
-sag
-xGv
+xQy
 jNE
-aDd
 sag
-sag
+fzH
+jvy
 sag
 sag
 kkw
 dno
-nZr
+sag
 sag
 sFI
 nEG
 vmm
 sag
-evK
-aDd
+xLr
+xGv
 sag
 leJ
 gdc
@@ -97417,7 +98348,7 @@ fub
 sfW
 bsK
 mPR
-lMT
+kvr
 bfY
 sfW
 ymg
@@ -97640,27 +98571,27 @@ sag
 sag
 sag
 sag
+qDF
 sag
+boV
 sag
-sag
-dDJ
 lGv
-xGv
+qof
 sag
-sag
-dDJ
+rPa
+yhg
 nnE
 sag
 sag
 sag
 sag
-sag
+mZM
 nuy
-aDd
+nRN
 nuy
 sag
-evK
-aDd
+fPf
+bkS
 sag
 kMq
 gdc
@@ -97674,7 +98605,7 @@ bLD
 qDb
 sLc
 lTH
-sjB
+iQG
 cjl
 sfW
 ymg
@@ -97893,21 +98824,21 @@ fIx
 fIx
 aDd
 cIo
+hna
 aDd
+xgG
 aDd
-sag
-deJ
 aDd
 aDd
 jyd
-aDd
-aDd
+sag
+sag
 sag
 sag
 lQW
 sYS
 kNy
-sag
+mGa
 cVU
 pAf
 pah
@@ -97917,7 +98848,7 @@ usY
 cVU
 sag
 evK
-aDd
+pVK
 sag
 aDw
 gdc
@@ -97931,7 +98862,7 @@ kWg
 sfW
 tfm
 pWj
-lMT
+fcq
 xLZ
 ivt
 ymg
@@ -98145,36 +99076,36 @@ dDJ
 cjW
 aDd
 fIx
+jkB
+jkB
 dDJ
-dDJ
-dDJ
-aDd
+hna
 aDd
 dDJ
 jyd
-xgG
-dDJ
+sag
+aFj
 jkB
 abc
 dDJ
-aDd
 sag
-sag
+cmi
+cmi
 vwf
-aDd
+yhg
 ets
 bzy
 pbi
-rDr
-rDr
-dDJ
+pKA
+dIV
+yhg
 hxU
-aDd
-rDr
-dDJ
+cZV
+aAw
+yhg
 sag
 evK
-aDd
+hna
 sag
 xPT
 xPT
@@ -98415,25 +99346,25 @@ sag
 jkB
 kda
 sag
-sag
-lQW
-vwf
-lQW
-jcK
-mSr
+noX
+aFV
+hfU
+noX
+gPD
+fCC
 cKq
-mSr
-mSr
+pQq
+fCC
 eyS
-mSr
+fCC
 hhT
-aDd
+cZV
 bjq
 sag
-evK
+heI
 aDd
 sag
-aDd
+uLy
 xPT
 oQI
 fKf
@@ -98673,22 +99604,22 @@ dDJ
 dDJ
 sag
 laV
-vwf
+hfU
 wnE
-sag
+mGa
 bko
-sag
-sag
+mGa
+mGa
 kUQ
-dDJ
+yhg
 mGX
-mSr
-dDJ
+nTQ
+yhg
 dCe
 svY
 sag
-evK
-aDd
+qTN
+ieW
 sag
 sag
 xPT
@@ -98930,22 +99861,22 @@ aDd
 ctw
 sag
 hEf
-dDJ
+yhg
 wOV
-sag
-auY
+mGa
+hpw
 lDu
-cks
+nPz
 oHJ
-aDd
-dDJ
+iCW
+yhg
 kKd
 mdj
-aDd
+ygi
 pul
 sag
-evK
-aDd
+heI
+dDJ
 sag
 fzK
 aDd
@@ -99184,28 +100115,28 @@ sag
 sag
 sag
 sag
-qQf
+uDU
 sag
 xDQ
 umy
 wOV
-sag
-pcr
+mGa
+dpU
 eUg
-cks
+nPz
 rDr
-aDd
-aDd
-hxU
-aDd
-dCe
+cZV
+qFf
+tKv
+cZV
+yfS
 rDr
 sag
 evK
-aDd
+jkB
 xVR
 dDJ
-dDJ
+jkB
 sag
 wMS
 bPO
@@ -99441,15 +100372,15 @@ ajv
 rac
 tNw
 sag
-aDd
+uEL
 sag
 dDn
-vwf
+hfU
 peV
-sag
+mGa
 koP
-lDu
-cks
+qFB
+nPz
 oQe
 pDN
 xVS
@@ -99458,8 +100389,8 @@ pgY
 maA
 sxY
 sag
-evK
-aDd
+iGj
+tsb
 sag
 iDD
 fVj
@@ -99698,7 +100629,7 @@ qse
 nWu
 rRi
 sag
-uDU
+qQf
 sag
 sag
 sag
@@ -99715,8 +100646,8 @@ sag
 sag
 sag
 sag
-evK
-aDd
+fYI
+sag
 sag
 sag
 sag
@@ -99959,27 +100890,27 @@ dDJ
 aDd
 sag
 aDd
+uEi
+nOw
+rkS
+vym
 aDd
-aDd
-aDd
-aDd
-aDd
-aDd
-aDd
+uYk
+nOH
+kqT
+dRW
 okD
-mqU
-okD
-aDd
-aDd
+dDJ
+jkB
 aDd
 evK
+ssU
 aDd
-aDd
-aDd
-dDJ
-aDd
-dDJ
-dDJ
+rYK
+iMd
+xQy
+pKu
+wSl
 hna
 vAG
 sag
@@ -99992,7 +100923,7 @@ gSZ
 sag
 aDd
 crf
-qfc
+wVV
 sag
 ymg
 ymg
@@ -100213,27 +101144,27 @@ jkB
 sag
 jbD
 owa
-wPR
+gsJ
 enY
-wPR
+oVZ
 vGZ
+bXJ
+wPR
+sIZ
+wPR
+gsJ
 owa
-wPR
-owa
-wPR
-wPR
-jOI
 wPR
 hAE
-dxp
+pMc
+ihe
 pMc
 pMc
-pMc
-evK
+qTN
 fIx
-fIx
+tKD
 rbW
-fIx
+tKD
 rbW
 fIx
 fIx
@@ -100487,14 +101418,14 @@ sag
 sag
 sag
 sag
-jLf
-jLf
-xKy
-xKy
-xKy
 sag
 sag
-rbW
+cQP
+cQP
+cQP
+sag
+sag
+vmr
 hna
 bfg
 dXi
@@ -100726,7 +101657,7 @@ gkM
 dDJ
 sag
 lwR
-wPR
+gsJ
 wWl
 sag
 ttK
@@ -100739,12 +101670,12 @@ mKa
 svG
 nXy
 oZB
-tHt
+xhG
+cyI
+xhG
+aes
+aes
 dBF
-ymg
-ymg
-ymg
-jLf
 mgk
 rol
 rol
@@ -100998,13 +101929,13 @@ wut
 hGT
 xuo
 dBF
-ymg
-ymg
-ymg
-jLf
+qPW
+jsr
+cMO
+dBF
 doP
 qQx
-jFN
+twH
 aBV
 gps
 sag
@@ -101241,7 +102172,7 @@ dDJ
 sag
 aDd
 kzi
-aDd
+hna
 sag
 xeM
 spu
@@ -101257,8 +102188,8 @@ dBF
 dBF
 dBF
 dBF
-ymg
-jLf
+dBF
+dBF
 fwu
 jFN
 xym
@@ -101514,8 +102445,8 @@ niG
 gne
 exy
 dBF
-ymg
-jLf
+kXK
+dBF
 bll
 jFN
 arM
@@ -101770,7 +102701,7 @@ cAk
 efq
 xKD
 sWk
-sag
+dBF
 sag
 sag
 nxG
@@ -102284,18 +103215,18 @@ dni
 bMv
 eDd
 dBF
-sag
+dBF
 huu
 qsx
 uaw
 uaw
 wBl
-wBl
+oAX
 jxv
-jxv
+reA
 kVL
 uaw
-hNg
+aDd
 aDd
 dDJ
 aDd
@@ -102541,7 +103472,7 @@ dEc
 jDr
 dEc
 qqq
-sag
+jRZ
 sag
 sag
 gTP
@@ -102800,7 +103731,7 @@ hcs
 hcs
 dIM
 tlP
-adB
+hcs
 toc
 hcs
 iRv
@@ -105598,7 +106529,7 @@ gXm
 gXm
 vca
 wWd
-ljk
+lWZ
 jBZ
 uOo
 kSK
@@ -110213,7 +111144,7 @@ xsG
 gXm
 vca
 jBZ
-ljk
+lWZ
 cJo
 vAn
 gXm
@@ -110233,7 +111164,7 @@ gXm
 gXm
 gXm
 gXm
-oEd
+dVN
 gXm
 gXm
 gXm
@@ -111496,7 +112427,7 @@ gXm
 gXm
 gXm
 gXm
-ljk
+lLc
 gXm
 gXm
 pWB
@@ -115376,7 +116307,7 @@ icT
 icT
 qYG
 qYG
-qWT
+aPs
 xVK
 qYG
 nWO
@@ -118206,7 +119137,7 @@ hiD
 twb
 trT
 wWd
-dZK
+bDU
 vca
 vca
 nFE
@@ -156732,7 +157663,7 @@ liC
 vLq
 pMY
 myq
-qYj
+ewF
 cSk
 qoU
 cSk
@@ -162944,7 +163875,7 @@ qHd
 pEc
 jqt
 ifT
-kLN
+wmw
 wmw
 wmw
 wmw
@@ -163972,7 +164903,7 @@ mDv
 ryX
 kpk
 ifT
-ukl
+bzK
 kbn
 odA
 bnt
@@ -164230,7 +165161,7 @@ lVu
 ifT
 ifT
 suT
-iul
+wic
 suT
 iul
 suT
@@ -164482,7 +165413,7 @@ jty
 kEQ
 rvi
 vgZ
-lvV
+qWC
 lvV
 rTD
 oUJ
@@ -164666,7 +165597,7 @@ cYB
 cYB
 jWP
 jWP
-uPv
+imi
 upL
 upL
 upL
@@ -164676,7 +165607,7 @@ upL
 acN
 ggR
 ggR
-uPv
+wNg
 ggR
 ggR
 ggR
@@ -164935,7 +165866,7 @@ upL
 upL
 orJ
 upL
-uPv
+imi
 upL
 ilA
 tru
@@ -164995,7 +165926,7 @@ rIA
 wZl
 kEQ
 jwr
-uTG
+tFW
 mSQ
 ava
 ujJ
@@ -165252,7 +166183,7 @@ aeF
 arm
 kEQ
 dok
-uTG
+tFW
 jSR
 kMQ
 dzG
@@ -165512,7 +166443,7 @@ rbo
 pnm
 jSR
 kMQ
-ujJ
+foq
 gTh
 nuD
 ibE
@@ -165766,12 +166697,12 @@ rAj
 qTX
 kEQ
 sPw
-uTG
+gDR
 jSR
 rJl
 uoE
 hTJ
-qAD
+nrL
 qAD
 ddC
 vyd
@@ -165785,7 +166716,7 @@ slw
 htk
 dtQ
 sCk
-jGt
+lGi
 slw
 jCC
 egw
@@ -166028,7 +166959,7 @@ oPC
 pMl
 uhc
 gTh
-dyi
+xZB
 tcl
 ldq
 oqU
@@ -166281,7 +167212,7 @@ qTX
 kEQ
 udc
 vQb
-pnb
+gGk
 eIb
 gNX
 gAG
@@ -166479,7 +167410,7 @@ aae
 upL
 ggR
 ggR
-uPv
+wNg
 ggR
 ggR
 ggR
@@ -166795,7 +167726,7 @@ hZB
 kEQ
 xIJ
 gYt
-jfn
+pnb
 nia
 nrd
 gTh
@@ -166813,7 +167744,7 @@ xzK
 xzK
 nJz
 ghd
-ejm
+gqr
 slw
 gHX
 bmL
@@ -167054,7 +167985,7 @@ dLc
 hIs
 pgQ
 djz
-bNB
+uTG
 gTh
 aRJ
 fKl
@@ -167562,8 +168493,8 @@ auA
 owR
 iKd
 rAj
-qTX
-sJq
+kIO
+aYx
 gmF
 hIs
 pgQ
@@ -167584,7 +168515,7 @@ nJz
 nJz
 jKf
 oSq
-gqr
+ejm
 slw
 qCk
 eKq
@@ -167841,7 +168772,7 @@ ejm
 ejm
 bdD
 oSq
-bdD
+nHF
 slw
 pfl
 vas
@@ -168336,7 +169267,7 @@ sTo
 bZU
 nAR
 dlq
-jXY
+hgV
 aCB
 wld
 jXY
@@ -180113,7 +181044,7 @@ aqh
 qRV
 qRV
 xxu
-bAM
+uEz
 dJc
 hXx
 wfI

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -201,14 +201,14 @@
 /area/station/cargo/storage)
 "afV" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/button/elevator/directional/north{
 	id = "cargolift"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -473,6 +473,9 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "akP" = (
@@ -525,12 +528,14 @@
 /area/station/medical/surgery)
 "alQ" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/camera{
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/north{
 	c_tag = "Cargo - Delivery Office";
-	dir = 9;
 	network = list("ss13","qm")
 	},
-/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "amq" = (
@@ -696,15 +701,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"aoq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "aoE" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/firealarm/directional/east,
@@ -846,9 +842,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/lounge)
-"aqN" = (
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "arc" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center"
@@ -2551,10 +2544,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
-"aYp" = (
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "aYr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -3199,6 +3188,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"bjq" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "bjs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3245,6 +3240,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"bko" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "bkI" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/departments/botany/directional/east,
@@ -3899,6 +3904,9 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bvU" = (
@@ -4074,6 +4082,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/medical/virology)
+"bzy" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "bzz" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -5228,11 +5242,11 @@
 "bUg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
 /obj/structure/chair,
 /obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -5564,10 +5578,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"cca" = (
-/obj/machinery/airalarm/directional/west,
-/turf/closed/wall,
-/area/station/maintenance/department/cargo)
 "ccb" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -5721,7 +5731,6 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "cfw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/crate/wooden,
 /obj/item/storage/crayons,
@@ -6027,7 +6036,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "cnt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -7352,6 +7361,15 @@
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
+"cKq" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "cKF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -7487,6 +7505,9 @@
 /area/station/tcommsat/server)
 "cNp" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "cNq" = (
@@ -7954,6 +7975,13 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar/backroom)
+"cVU" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "cVV" = (
 /turf/open/floor/vault,
 /area/station/ai_monitored/command/nuke_storage)
@@ -9011,11 +9039,13 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/large,
 /area/station/cargo/sorting)
+"dpA" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "dpC" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -9390,6 +9420,9 @@
 /area/station/tcommsat/oldaisat/stationside)
 "dxp" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "dxq" = (
@@ -9698,6 +9731,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"dCe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "dCh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -9744,6 +9781,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"dDn" = (
+/obj/machinery/shower/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "dDp" = (
 /obj/effect/spawner/random/structure/furniture_parts,
 /obj/structure/closet/crate/wooden,
@@ -9833,7 +9874,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/cargo/miningdock)
 "dEK" = (
 /obj/structure/chair/comfy/brown{
@@ -9976,6 +10017,14 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/service)
+"dIq" = (
+/obj/machinery/camera{
+	c_tag = "Cargo - Upper Bay";
+	dir = 1;
+	network = list("ss13","qm")
+	},
+/turf/open/openspace,
+/area/station/cargo/storage)
 "dIr" = (
 /obj/item/paint/anycolor,
 /obj/item/radio/intercom/prison/directional/east,
@@ -10794,6 +10843,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dXY" = (
@@ -11236,6 +11288,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/transit_tube)
+"eiK" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/cargo/miningdock)
 "eiQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -11276,6 +11334,9 @@
 	name = "Abandoned Gambling Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "ejK" = (
@@ -11516,6 +11577,7 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "eol" = (
@@ -11560,8 +11622,10 @@
 	},
 /area/station/service/bar)
 "epa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/cargo/miningdock)
 "epe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -11834,6 +11898,11 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
+"ets" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "ett" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/spawner/directional/west,
@@ -12138,6 +12207,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"eyS" = (
+/obj/item/toy/basketball,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "eyY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12589,10 +12664,15 @@
 /turf/open/floor/iron/white/textured,
 /area/station/command/heads_quarters/captain/private)
 "eGZ" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock_note_placer{
+	name = "under construction";
+	note_info = "Nanotrasen-approved labor crews are very hard at work constructing this room! For your safety, please do not open this door until construction has been completed.";
+	note_name = "construction notice"
+	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "eHb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13367,6 +13447,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"eUg" = (
+/obj/structure/chair/stool/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "eUr" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Ordnance Lab"
@@ -13953,7 +14038,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/station/cargo/miningdock)
 "fdF" = (
 /obj/effect/turf_decal/siding/purple{
@@ -15222,6 +15307,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "fBK" = (
@@ -15750,11 +15838,11 @@
 "fKl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/effect/landmark/start/shaft_miner,
 /obj/structure/chair,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -16367,15 +16455,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
-"fVL" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_half,
-/area/station/cargo/miningdock)
 "fVX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -17482,7 +17561,6 @@
 "gsO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "gsV" = (
@@ -17914,6 +17992,12 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -19034,6 +19118,7 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "gTa" = (
@@ -19092,6 +19177,9 @@
 /obj/machinery/duct,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "gTQ" = (
@@ -19555,6 +19643,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"hcA" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "hcL" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -19832,6 +19929,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"hhT" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "hid" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room"
@@ -20351,7 +20455,7 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "hsV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -20618,6 +20722,11 @@
 "hxM" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
+"hxU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "hxY" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing"
@@ -20744,6 +20853,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/chair/stool/directional/east,
 /turf/open/openspace,
 /area/station/cargo/storage)
 "hAb" = (
@@ -20776,6 +20886,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"hAE" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "hAN" = (
@@ -20964,6 +21081,10 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"hEf" = (
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "hEk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21084,7 +21205,7 @@
 /area/station/service/bar)
 "hGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side{
@@ -21256,6 +21377,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "hIQ" = (
@@ -21578,6 +21702,14 @@
 "hNq" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo - Mining Office";
+	dir = 10;
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hNu" = (
@@ -22082,9 +22214,6 @@
 /area/station/engineering/supermatter)
 "hWK" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningdock)
 "hWN" = (
@@ -22132,6 +22261,11 @@
 	},
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Cargo - Break Room";
+	dir = 6;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
@@ -22798,6 +22932,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
+"ikD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "ikE" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -22937,12 +23078,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "iop" = (
-/obj/machinery/door/airlock/mining,
+/obj/machinery/door/airlock/mining{
+	name = "Computer Den"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningdock)
 "iov" = (
 /obj/item/target,
@@ -25011,17 +25158,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"jab" = (
-/obj/effect/mapping_helpers/airlock_note_placer{
-	name = "under construction";
-	note_info = "Nanotrasen-approved labor crews are very hard at work constructing this room! For your safety, please do not open this door until construction has been completed.";
-	note_name = "construction notice"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/maintenance/external,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "jaP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -25085,6 +25221,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"jcK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "jda" = (
 /obj/machinery/door/airlock/security{
 	name = "Perma Brig"
@@ -25103,6 +25244,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "jdI" = (
@@ -25115,6 +25259,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "jdT" = (
@@ -25124,11 +25271,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jec" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
@@ -25208,6 +25355,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/crematorium,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"jgo" = (
+/obj/structure/sign/poster/random/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "jgx" = (
 /obj/structure/railing{
 	dir = 8
@@ -25275,10 +25427,7 @@
 /turf/open/floor/iron/airless,
 /area/station/tcommsat/oldaisat/stationside)
 "jhE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/side{
@@ -25960,6 +26109,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
+"jvH" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/miningdock)
 "jvJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -26181,6 +26336,13 @@
 /obj/effect/spawner/random/entertainment/deck,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
+"jzi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "jzl" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -26684,7 +26846,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "jIN" = (
 /obj/machinery/light/directional/north,
@@ -28120,13 +28282,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"kez" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "keD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28486,6 +28641,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/science/lab)
+"kkw" = (
+/obj/effect/spawner/costume/elpresidente,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "kkD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -28700,6 +28860,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"koP" = (
+/obj/item/wallframe/newscaster{
+	pixel_y = -9;
+	pixel_x = -5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "koR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -29365,12 +29532,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/safe)
-"kyH" = (
-/obj/structure/cable,
-/obj/machinery/light/small/red/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "kyL" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -29381,6 +29542,7 @@
 "kyN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "kyW" = (
@@ -29683,6 +29845,9 @@
 /area/station/security/prison)
 "kFK" = (
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kFL" = (
@@ -29932,6 +30097,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"kKd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "kKh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -30030,6 +30199,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"kLN" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/openspace,
+/area/station/cargo/storage)
 "kLO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30041,6 +30214,9 @@
 /area/station/maintenance/department/cargo)
 "kLW" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kLY" = (
@@ -30162,6 +30338,13 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"kNy" = (
+/obj/structure/chair/sofa/bench{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "kNG" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -30571,6 +30754,10 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"kUQ" = (
+/obj/structure/hoop,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "kVm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30792,11 +30979,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"kYZ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/costume/elpresidente,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "kZe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30931,6 +31113,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"laV" = (
+/obj/machinery/shower/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lbr" = (
 /obj/machinery/light/small/red/directional/east,
 /obj/effect/spawner/random/structure/crate,
@@ -31733,11 +31920,16 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
 "lmV" = (
-/obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/mining{
+	name = "Warehouse"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -32565,6 +32757,7 @@
 "lAj" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "lAp" = (
@@ -32761,6 +32954,10 @@
 /obj/structure/sign/clock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"lDu" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lEn" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -33331,6 +33528,9 @@
 /obj/item/hand_labeler{
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "lNh" = (
@@ -33550,6 +33750,9 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"lQW" = (
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "lQY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -33746,7 +33949,9 @@
 "lUE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/cargo/miningdock)
 "lUK" = (
 /obj/structure/table,
@@ -33784,11 +33989,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"lVa" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/costume/mafia,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "lVq" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -34020,6 +34220,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"mau" = (
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/starboard/lower)
+"maA" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "maC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
@@ -34201,6 +34413,13 @@
 "mcT" = (
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"mdj" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "mdl" = (
 /obj/machinery/duct,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -34699,6 +34918,7 @@
 /obj/item/storage/wallet{
 	pixel_y = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "mli" = (
@@ -35871,6 +36091,10 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
+"mGX" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "mHh" = (
 /obj/structure/guillotine,
 /turf/open/floor/iron/dark,
@@ -36256,6 +36480,9 @@
 "mOA" = (
 /obj/machinery/status_display/supply{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -36797,6 +37024,12 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/camera{
+	c_tag = "Cargo - Mining Dock";
+	dir = 5;
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "mWL" = (
@@ -37784,6 +38017,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"nnE" = (
+/obj/structure/chair/sofa/bench/left{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "nnF" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron,
@@ -37909,15 +38148,15 @@
 /area/station/security/warden)
 "npt" = (
 /obj/machinery/camera{
-	c_tag = "Cargo - Bay";
+	c_tag = "Cargo - Lower Bay";
 	dir = 5;
 	network = list("ss13","qm")
 	},
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "npJ" = (
@@ -38186,13 +38425,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"nuy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "nuD" = (
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Cargo - Mining Office";
-	dir = 10;
-	network = list("ss13","qm")
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -38635,7 +38874,7 @@
 "nBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "nCb" = (
 /obj/machinery/status_display/evac/directional/east,
@@ -38840,6 +39079,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"nEG" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot_red,
+/obj/item/clothing/mask/whistle,
+/obj/effect/spawner/costume/referee,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "nEP" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -39466,6 +39712,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/brig)
+"nNV" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "nOJ" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/carpet/red,
@@ -39592,6 +39844,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "nRq" = (
@@ -39954,6 +40207,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"nZr" = (
+/obj/effect/spawner/costume/mafia,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "nZJ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -40609,6 +40867,10 @@
 "okn" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"okD" = (
+/obj/machinery/light/small/red/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "okM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -40839,7 +41101,9 @@
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/cargo/miningdock)
 "onN" = (
 /obj/machinery/airalarm/directional/east,
@@ -41692,7 +41956,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/corner{
@@ -41953,6 +42217,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
+"oHJ" = (
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "oHL" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42101,6 +42371,12 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/miningdock)
 "oKO" = (
@@ -42202,10 +42478,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"oMB" = (
-/obj/item/wallframe/apc,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "oMM" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -42355,6 +42627,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lower)
+"oQe" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "oQi" = (
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
@@ -42682,6 +42961,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oUS" = (
@@ -42957,15 +43239,14 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"pai" = (
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"pan" = (
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+"pah" = (
+/obj/structure/railing/corner{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"pai" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pap" = (
@@ -43027,9 +43308,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pbi" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/spawner/random/trash/graffiti,
+/turf/closed/wall,
+/area/station/maintenance/port/lower)
 "pbo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -43294,6 +43575,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/tcommsat/computer)
+"peV" = (
+/obj/machinery/shower/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "pfh" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Bathroom"
@@ -43400,6 +43686,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"pgY" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "phh" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/airalarm/directional/east,
@@ -43438,11 +43731,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"phG" = (
-/obj/effect/spawner/random/trash/mopbucket,
-/obj/effect/spawner/random/trash/soap,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "phN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43598,6 +43886,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "pky" = (
@@ -43998,7 +44287,7 @@
 "prB" = (
 /obj/machinery/camera{
 	c_tag = "Command - Quartermaster's Office";
-	dir = 10;
+	dir = 8;
 	network = list("ss13","qm")
 	},
 /obj/machinery/pdapainter/supply,
@@ -44184,6 +44473,13 @@
 /obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/carpet/black,
 /area/station/security/prison/workout)
+"pul" = (
+/obj/item/wallframe/status_display{
+	pixel_y = 4;
+	pixel_x = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "pum" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -44530,8 +44826,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "pAf" = (
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "pAs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44763,6 +45065,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"pDN" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "pDO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -44788,10 +45099,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/large,
 /area/station/cargo/sorting)
 "pEg" = (
 /obj/structure/cable,
@@ -44925,13 +45234,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "pGC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -45243,6 +45552,12 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"pMc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "pMf" = (
 /obj/machinery/plumbing/sender,
 /obj/effect/turf_decal/siding/yellow/end{
@@ -45581,6 +45896,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"pSN" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "pSZ" = (
 /obj/structure/chair{
 	dir = 1
@@ -47141,6 +47460,12 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "qrG" = (
@@ -47913,8 +48238,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qDb" = (
-/obj/machinery/door/airlock/mining,
+/obj/machinery/door/airlock/mining{
+	name = "Warehouse"
+	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "qDt" = (
@@ -48107,6 +48435,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"qGR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "qGU" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -48459,7 +48793,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/cargo/miningdock)
 "qOk" = (
 /obj/structure/cable,
@@ -48561,6 +48897,14 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"qQf" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "qQh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/station_engineer,
@@ -49064,6 +49408,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "qYZ" = (
@@ -49204,6 +49549,14 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"raV" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "rbd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49793,6 +50146,9 @@
 "rkI" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rla" = (
@@ -50871,6 +51227,9 @@
 "rCM" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/arrivals)
+"rDr" = (
+/turf/open/floor/wood/large,
+/area/station/maintenance/port/lower)
 "rDu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -51108,6 +51467,9 @@
 "rHf" = (
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
@@ -51368,6 +51730,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rKx" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "rKX" = (
@@ -51405,6 +51770,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"rLB" = (
+/obj/item/wallframe/apc,
+/turf/open/floor/plating/airless,
+/area/station/maintenance/starboard/lower)
 "rLN" = (
 /obj/machinery/door/window/right/directional/south{
 	name = "Containment Pen #3";
@@ -51605,14 +51974,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rOj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/structure/railing/corner,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rOl" = (
@@ -53119,6 +53488,9 @@
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sns" = (
@@ -53608,6 +53980,12 @@
 "svT" = (
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"svY" = (
+/obj/structure/hoop{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "swn" = (
 /obj/structure/sign/poster/random/directional/south,
 /obj/structure/table,
@@ -53700,6 +54078,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"sxY" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "sya" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54230,6 +54615,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"sFI" = (
+/obj/structure/closet,
+/obj/item/clothing/under/color/jumpskirt/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "sFJ" = (
 /obj/machinery/computer/rdconsole,
 /turf/open/floor/iron/dark/smooth_half,
@@ -54437,6 +54830,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "sIZ" = (
@@ -55347,6 +55741,12 @@
 /obj/structure/closet/crate,
 /obj/item/screwdriver,
 /obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"sYS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "sYT" = (
@@ -56445,6 +56845,14 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"trA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/sepia,
+/area/station/maintenance/port/lower)
 "trT" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/plastic,
@@ -56734,7 +57142,7 @@
 /area/station/service/chapel/office)
 "txB" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+	name = "Delivery Office Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58157,6 +58565,10 @@
 "tZw" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/camera{
+	c_tag = "Cargo - Computer Den";
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "tZE" = (
@@ -58372,6 +58784,9 @@
 "ucu" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ucy" = (
@@ -58743,10 +59158,10 @@
 /area/station/maintenance/starboard/fore)
 "ujF" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance"
+	name = "Computer Den Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "ujJ" = (
 /obj/effect/landmark/start/depsec/supply,
@@ -58778,6 +59193,15 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/lower)
+"ukl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/kirbyplants,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/openspace,
+/area/station/cargo/storage)
 "uko" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications"
@@ -58802,11 +59226,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/lab)
 "ukW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /obj/machinery/light_switch/directional/north{
 	pixel_x = -7
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -58890,6 +59314,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"umy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "umA" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -58964,6 +59393,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"uoj" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "uoo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59187,7 +59627,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "uro" = (
 /obj/structure/table,
@@ -59278,6 +59718,16 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"usY" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "uta" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -61110,13 +61560,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"vbM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "vbN" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -61681,6 +62124,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"vmm" = (
+/obj/structure/closet,
+/obj/item/clothing/under/color/jumpskirt/blue,
+/obj/item/clothing/under/color/blue,
+/obj/item/clothing/under/color/blue,
+/obj/item/clothing/under/color/blue,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "vmA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -62114,6 +62565,13 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"vtp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "vtr" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62250,6 +62708,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"vwe" = (
+/obj/structure/railing/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"vwf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "vwL" = (
 /obj/structure/chair{
 	dir = 8
@@ -62527,7 +62994,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/station/cargo/miningdock)
 "vCP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -62752,6 +63221,12 @@
 /obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
 	},
 /turf/open/floor/iron/textured,
 /area/station/command/heads_quarters/qm)
@@ -62984,6 +63459,9 @@
 "vMq" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "vMu" = (
@@ -64416,6 +64894,10 @@
 "wnC" = (
 /turf/closed/wall,
 /area/station/commons/vacant_room/office)
+"wnE" = (
+/obj/machinery/shower/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wnK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/glass/reinforced,
@@ -64585,6 +65067,9 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wqF" = (
@@ -64616,7 +65101,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "wrh" = (
 /obj/structure/table,
@@ -65403,6 +65888,10 @@
 	name = "Mining RC";
 	pixel_x = -30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wFS" = (
@@ -65539,12 +66028,12 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "wJy" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/break_room)
 "wJP" = (
@@ -65810,6 +66299,10 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"wOV" = (
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "wOX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -66013,6 +66506,7 @@
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/science)
 "wTf" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/miningdock)
 "wTw" = (
@@ -66271,6 +66765,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "wXS" = (
@@ -66570,6 +67067,10 @@
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "xdx" = (
@@ -66776,6 +67277,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "xgM" = (
@@ -68069,6 +68571,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"xDQ" = (
+/obj/machinery/shower/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/port/lower)
 "xDR" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -69055,10 +69562,20 @@
 /area/station/maintenance/starboard/lower)
 "xVP" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xVR" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
+"xVS" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "xWb" = (
@@ -92789,7 +93306,7 @@ cQP
 cQP
 cQP
 bfg
-vbM
+ahI
 sag
 sag
 ymg
@@ -94057,7 +94574,7 @@ ymg
 cQP
 ctw
 aDd
-xVR
+hNg
 aDd
 jkB
 fLP
@@ -94314,7 +94831,7 @@ ymg
 cQP
 aDd
 aDd
-xVR
+hNg
 aDd
 jkB
 fLP
@@ -95082,7 +95599,7 @@ xsG
 xsG
 xsG
 sag
-aDd
+wAn
 dDJ
 aDd
 sag
@@ -95596,7 +96113,7 @@ ymg
 ymg
 ymg
 cQP
-aDd
+lcm
 aDd
 aDd
 sag
@@ -95854,8 +96371,8 @@ cQP
 cQP
 sag
 sag
-xVR
-xVR
+hNg
+hNg
 sag
 cSn
 dRW
@@ -96099,22 +96616,22 @@ cTa
 cdu
 mZq
 lEs
-sag
-sag
 aDd
+sag
+wAn
 jyd
 aDd
 dDJ
 jyd
-kYZ
-dno
-lVa
+aDd
+aDd
+aDd
 sag
 ofn
-aDd
+sYS
 hna
 aDd
-fIx
+evK
 aDd
 sag
 puo
@@ -96355,9 +96872,9 @@ cEA
 kly
 xRe
 lEs
+aDd
 sag
 sag
-wAn
 aDd
 jkB
 dDJ
@@ -96369,9 +96886,9 @@ auY
 ahI
 auY
 sIV
+jcK
 mSr
-mSr
-fIx
+evK
 aDd
 sag
 afD
@@ -96611,24 +97128,24 @@ ppL
 taU
 faF
 sag
+aDd
 sag
 sag
-xGv
 gsO
-dDJ
+aDd
 ldO
-jrJ
+jgo
 hna
 dDJ
 dDJ
 rhb
 aDd
 sag
-dDJ
-kez
-phG
-wAn
-fIx
+sag
+sag
+sag
+sag
+evK
 aDd
 sag
 xPT
@@ -96869,23 +97386,23 @@ bgY
 qrt
 sag
 sag
-aDd
-aDd
+sag
+xGv
 jNE
+aDd
 sag
 sag
 sag
 sag
-jab
+kkw
+dno
+nZr
 sag
+sFI
+nEG
+vmm
 sag
-sag
-sag
-sag
-sag
-sag
-sag
-fIx
+evK
 aDd
 sag
 leJ
@@ -97125,24 +97642,24 @@ sag
 sag
 sag
 sag
-aDd
+sag
 dDJ
 lGv
+xGv
 sag
 sag
-xsG
-xsG
-pai
-pai
-aYp
-pAf
-ymg
-ymg
-ymg
-ymg
-ymg
+dDJ
+nnE
 sag
-fIx
+sag
+sag
+sag
+sag
+nuy
+aDd
+nuy
+sag
+evK
 aDd
 sag
 kMq
@@ -97384,22 +97901,22 @@ aDd
 aDd
 jyd
 aDd
+aDd
 sag
 sag
-ymg
-ymg
-xsG
-pbi
-pan
-oMB
+lQW
+sYS
+kNy
+sag
+cVU
 pAf
-ymg
-ymg
-ymg
-ymg
-ymg
+pah
+ikD
+vwe
+usY
+cVU
 sag
-fIx
+evK
 aDd
 sag
 aDw
@@ -97640,23 +98157,23 @@ dDJ
 jkB
 abc
 dDJ
+aDd
 sag
 sag
-ymg
-ymg
-ymg
-xsG
-xsG
+vwf
+aDd
+ets
+bzy
 pbi
-xsG
-pAf
-ymg
-ymg
-ymg
-ymg
-ymg
+rDr
+rDr
+dDJ
+hxU
+aDd
+rDr
+dDJ
 sag
-fIx
+evK
 aDd
 sag
 xPT
@@ -97879,7 +98396,7 @@ hkY
 sag
 sag
 sag
-lAj
+qQf
 sag
 xQy
 sag
@@ -97896,24 +98413,24 @@ sag
 sag
 sag
 jkB
-dDJ
+kda
 sag
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
-xsG
-xsG
-pAf
-ymg
-ymg
-ymg
-ymg
-ymg
 sag
-fIx
+lQW
+vwf
+lQW
+jcK
+mSr
+cKq
+mSr
+mSr
+eyS
+mSr
+hhT
+aDd
+bjq
+sag
+evK
 aDd
 sag
 aDd
@@ -98153,24 +98670,24 @@ scl
 sag
 kwo
 dDJ
-kda
+dDJ
 sag
-ymg
-ymg
-ymg
-ymg
-xsG
-ymg
-ymg
-xsG
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+laV
+vwf
+wnE
 sag
-fIx
+bko
+sag
+sag
+kUQ
+dDJ
+mGX
+mSr
+dDJ
+dCe
+svY
+sag
+evK
 aDd
 sag
 sag
@@ -98412,22 +98929,22 @@ iGx
 aDd
 ctw
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+hEf
+dDJ
+wOV
 sag
-fIx
+auY
+lDu
+cks
+oHJ
+aDd
+dDJ
+kKd
+mdj
+aDd
+pul
+sag
+evK
 aDd
 sag
 fzK
@@ -98667,24 +99184,24 @@ sag
 sag
 sag
 sag
-lAj
+qQf
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+xDQ
+umy
+wOV
 sag
-fIx
+pcr
+eUg
+cks
+rDr
+aDd
+aDd
+hxU
+aDd
+dCe
+rDr
+sag
+evK
 aDd
 xVR
 dDJ
@@ -98696,7 +99213,7 @@ jIF
 jLs
 wsF
 iop
-nBU
+qGR
 fdC
 nBU
 onL
@@ -98926,22 +99443,22 @@ tNw
 sag
 aDd
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
+dDn
+vwf
+peV
 sag
-fIx
+koP
+lDu
+cks
+oQe
+pDN
+xVS
+trA
+pgY
+maA
+sxY
+sag
+evK
 aDd
 sag
 iDD
@@ -98957,7 +99474,7 @@ rHf
 dEz
 wrc
 epa
-aqN
+xUz
 qYR
 aDd
 sag
@@ -99181,24 +99698,24 @@ qse
 nWu
 rRi
 sag
-dDJ
+uDU
 sag
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
-ymg
 sag
-fIx
+sag
+sag
+sag
+sag
+sag
+sag
+sag
+sag
+sag
+uoj
+sag
+sag
+sag
+sag
+evK
 aDd
 sag
 sag
@@ -99211,7 +99728,7 @@ sag
 sag
 hhk
 wTf
-xUz
+eiK
 cnf
 lUE
 mWG
@@ -99438,24 +99955,24 @@ diJ
 sag
 sag
 sag
-uDU
+dDJ
+aDd
 sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-fIx
+aDd
+aDd
+aDd
+aDd
+aDd
+aDd
+aDd
+aDd
+okD
+mqU
+okD
+aDd
+aDd
+aDd
+evK
 aDd
 aDd
 aDd
@@ -99468,9 +99985,9 @@ vAG
 sag
 hhk
 wTf
-xUz
+eiK
 url
-epa
+jvH
 gSZ
 sag
 aDd
@@ -99706,13 +100223,13 @@ owa
 wPR
 wPR
 jOI
-kyH
 wPR
+hAE
 dxp
-sag
-aDd
-aDd
-fIx
+pMc
+pMc
+pMc
+evK
 fIx
 fIx
 rbW
@@ -100466,7 +100983,7 @@ gWe
 dDJ
 sag
 cfw
-fIx
+vtp
 wPR
 obK
 raI
@@ -102044,7 +102561,7 @@ sag
 sag
 sag
 sag
-hNg
+raV
 sag
 sag
 ymg
@@ -110220,7 +110737,7 @@ xsG
 neJ
 xsG
 xsG
-qEp
+rLB
 gXm
 wWd
 vAL
@@ -110472,7 +110989,7 @@ pWB
 sgh
 eGZ
 xdU
-qEp
+mau
 xsG
 xsG
 gtW
@@ -160109,7 +160626,7 @@ wcb
 sdO
 slw
 ljN
-ejm
+dpA
 nJz
 xzK
 xzK
@@ -161409,7 +161926,7 @@ pWS
 exb
 oHi
 prB
-cca
+slw
 cRp
 ejm
 qgM
@@ -161650,7 +162167,7 @@ iKd
 uBV
 qTX
 lVu
-gEU
+jzi
 rmi
 qMT
 naU
@@ -162170,7 +162687,7 @@ eNy
 jBb
 xFk
 ifT
-wmw
+dIq
 wmw
 wmw
 wmw
@@ -162427,7 +162944,7 @@ qHd
 pEc
 jqt
 ifT
-wmw
+kLN
 wmw
 wmw
 wmw
@@ -162935,7 +163452,7 @@ iNV
 uBV
 eHL
 xUa
-gRQ
+hcA
 iHN
 xfv
 fXv
@@ -163192,7 +163709,7 @@ ldP
 uBV
 qTX
 lVu
-gRQ
+nNV
 eTv
 gRQ
 aJo
@@ -163455,7 +163972,7 @@ mDv
 ryX
 kpk
 ifT
-bzK
+ukl
 kbn
 odA
 bnt
@@ -163969,7 +164486,7 @@ lvV
 lvV
 rTD
 oUJ
-aoq
+biT
 kiU
 kiU
 kiU
@@ -164225,7 +164742,7 @@ sti
 orE
 bID
 aMF
-rKx
+pSN
 mOA
 kFK
 ucu
@@ -166539,7 +167056,7 @@ pgQ
 djz
 bNB
 gTh
-fVL
+aRJ
 fKl
 rGI
 oyd

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -34,11 +34,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
-"aaU" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "abc" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
@@ -472,7 +467,8 @@
 "akI" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "akP" = (
@@ -539,11 +535,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"amr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "amu" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/east,
@@ -847,6 +838,9 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/lounge)
+"aqN" = (
+/turf/open/floor/iron/dark,
+/area/space/nearstation)
 "arc" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center"
@@ -2020,7 +2014,7 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "aOu" = (
 /obj/structure/cable,
@@ -2192,12 +2186,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"aRR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "aRY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2982,8 +2970,8 @@
 /area/station/security/warden)
 "bfY" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bfZ" = (
@@ -3231,6 +3219,7 @@
 /area/station/commons/dorms)
 "bkc" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "bkm" = (
@@ -3455,6 +3444,12 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bnB" = (
@@ -3477,6 +3472,17 @@
 /obj/item/radio,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"bnW" = (
+/obj/structure/table,
+/obj/item/vending_refill/custom{
+	pixel_y = 5
+	},
+/obj/item/circuitboard/machine/vending{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "bob" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -3707,6 +3713,10 @@
 	dir = 9;
 	network = list("ss13","qm")
 	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "bsM" = (
@@ -3869,7 +3879,8 @@
 	network = list("ss13","qm")
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bvU" = (
 /obj/structure/grille,
@@ -4085,6 +4096,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/openspace,
 /area/station/cargo/storage)
 "bzN" = (
@@ -5107,6 +5119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/space)
 "bSE" = (
@@ -5178,12 +5191,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/structure/chair,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
 /area/station/cargo/miningdock)
 "bUJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodelivery";
 	pixel_x = -8;
@@ -5452,6 +5466,7 @@
 /area/station/hallway/secondary/service)
 "cav" = (
 /obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/wood/large,
 /area/space)
 "caw" = (
@@ -5739,15 +5754,6 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
-"cgy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "cgD" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -5870,10 +5876,8 @@
 "cjl" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cjJ" = (
@@ -5903,6 +5907,9 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ckh" = (
+/turf/open/openspace,
+/area/station/cargo/miningdock)
 "cks" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -5972,6 +5979,12 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"cnf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "cnt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6461,11 +6474,10 @@
 	req_access = list("cargo")
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/closet/cardboard,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cvn" = (
@@ -7178,6 +7190,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"cHu" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/closet/crate,
+/turf/open/floor/iron,
+/area/space)
 "cHI" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
@@ -8150,11 +8168,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dbf" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dbi" = (
@@ -8295,13 +8309,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"ddc" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "ddg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -8336,9 +8343,6 @@
 /area/station/engineering/atmos)
 "ddC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "ddR" = (
@@ -8617,6 +8621,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"diK" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "diM" = (
 /obj/structure/rack,
 /obj/machinery/newscaster/directional/north,
@@ -9158,9 +9166,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dtQ" = (
-/obj/item/banner/cargo/mundane,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "dtT" = (
@@ -9746,6 +9754,8 @@
 /obj/item/paper_bin,
 /obj/item/folder/yellow,
 /obj/item/stamp/head/qm,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/space)
 "dEK" = (
@@ -9792,18 +9802,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
-"dFQ" = (
-/obj/structure/rack,
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/machinery/newscaster/directional/west,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "dGl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10159,8 +10157,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "dML" = (
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/space)
 "dMP" = (
@@ -10601,6 +10601,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dVw" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	space_dir = null
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "dVy" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -10690,6 +10701,8 @@
 /area/station/hallway/primary/aft)
 "dXK" = (
 /obj/item/radio/intercom/directional/east,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dXY" = (
@@ -11449,6 +11462,9 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
+"epa" = (
+/turf/open/floor/iron/dark,
+/area/space)
 "epe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -11462,6 +11478,9 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"epu" = (
+/turf/open/space/basic,
+/area/station/maintenance/port/lower)
 "epw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -12739,8 +12758,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eKN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -13650,16 +13667,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"faV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "fba" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -13710,6 +13717,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "fci" = (
@@ -14093,6 +14103,12 @@
 /area/station/hallway/secondary/exit)
 "fjk" = (
 /obj/structure/filingcabinet,
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 5
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_y = -5
+	},
 /turf/open/floor/wood/large,
 /area/space)
 "fjv" = (
@@ -14401,11 +14417,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"foi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "fom" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
@@ -14725,10 +14736,9 @@
 /area/station/science/robotics/abandoned)
 "ftE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -14753,16 +14763,9 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"fua" = (
-/obj/docking_port/stationary/mining_home{
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space)
 "fub" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "ful" = (
@@ -14797,6 +14800,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fuX" = (
+/obj/effect/turf_decal/arrows/red,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "fvb" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -14876,7 +14884,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fxK" = (
@@ -15041,6 +15048,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fBF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "fBK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -15432,6 +15447,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fIb" = (
+/obj/machinery/light/small/red/directional/north,
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "fIt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -15549,6 +15569,13 @@
 "fKf" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/east,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = -3
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "fKl" = (
@@ -15557,6 +15584,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/effect/landmark/start/shaft_miner,
+/obj/structure/chair,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -15599,12 +15628,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
-"fKP" = (
-/obj/structure/stairs/west{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/station/maintenance/port/lower)
 "fKT" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -15870,6 +15893,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"fQQ" = (
+/obj/structure/table,
+/obj/item/circuitboard/machine/cell_charger{
+	pixel_y = 4
+	},
+/obj/item/circuitboard/computer/cargo/request{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/circuitboard/machine/scanner_gate{
+	pixel_x = 6
+	},
+/obj/item/circuitboard/computer/slot_machine{
+	pixel_y = 2;
+	pixel_x = -4
+	},
+/obj/item/circuitboard/computer/slot_machine{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "fQT" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
@@ -15944,6 +15989,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"fSi" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "fSl" = (
 /turf/closed/wall,
 /area/station/commons/dorms)
@@ -16312,13 +16363,6 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/circuit,
 /area/station/engineering/storage)
-"fYI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "fYP" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
@@ -16456,8 +16500,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodelivery2";
 	pixel_x = -8;
@@ -16637,6 +16679,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "ghn" = (
@@ -17686,16 +17729,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "gAc" = (
-/obj/effect/turf_decal/loading_area,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock"
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/obj/effect/landmark/navigate_destination,
+/obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "gAl" = (
@@ -17879,7 +17919,8 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "gDp" = (
@@ -17952,6 +17993,13 @@
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"gEd" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "gEj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -18743,10 +18791,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gSr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light_switch/directional/west{
-	pixel_y = 4
+/obj/machinery/status_display/supply{
+	pixel_y = -30
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -18791,9 +18837,10 @@
 /turf/open/floor/iron/textured,
 /area/station/security/prison)
 "gSZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/iron,
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/lower)
 "gTa" = (
 /obj/item/wrench,
@@ -18929,8 +18976,7 @@
 /area/station/security/prison)
 "gVI" = (
 /obj/effect/decal/cleanable/generic,
-/obj/structure/closet/crate/trashcart/filled,
-/obj/item/relic,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "gVK" = (
@@ -19567,6 +19613,10 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/heads_quarters/captain)
+"hhk" = (
+/obj/structure/stairs/north,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "hhv" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Pure Chamber";
@@ -20109,6 +20159,10 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/science/robotics/lab)
+"hsR" = (
+/obj/machinery/rnd/bepis,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "hsV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -20144,7 +20198,6 @@
 "htk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/three,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "htl" = (
@@ -20582,8 +20635,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "hBC" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "hBI" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -20818,6 +20874,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"hFS" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "hFZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -20829,6 +20894,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"hGA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/cargo/miningdock)
 "hGB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21315,10 +21389,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "hNq" = (
-/obj/machinery/computer/order_console/mining,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hNu" = (
 /obj/structure/closet/lasertag/blue,
@@ -21730,6 +21804,10 @@
 "hVB" = (
 /turf/closed/wall,
 /area/station/medical/morgue)
+"hVD" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/space)
 "hVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -21854,6 +21932,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/brig)
+"hXr" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/item/kirbyplants/random,
+/obj/machinery/light_switch/directional/east{
+	pixel_y = -5
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 5
+	},
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "hXx" = (
 /obj/structure/chair/sofa/middle/brown,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
@@ -22032,8 +22123,8 @@
 /area/station/science/xenobiology)
 "ibE" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -22640,6 +22731,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"iop" = (
+/obj/machinery/door/airlock/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron/dark,
+/area/space)
 "iov" = (
 /obj/item/target,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -22762,12 +22858,6 @@
 	dir = 1
 	},
 /area/station/security/office)
-"iqu" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "iqw" = (
 /obj/structure/flora/bush/stalky/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -23801,9 +23891,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "iJA" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -24172,13 +24259,6 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
-"iPf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "iPl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -25259,6 +25339,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
+"jos" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/space)
 "joE" = (
 /obj/structure/bookcase,
 /obj/effect/mapping_helpers/broken_floor,
@@ -25335,6 +25419,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jqm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "jqq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -25964,13 +26052,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jAB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/item/flashlight,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "jAF" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Chamber"
@@ -26386,11 +26467,16 @@
 /area/station/security/brig)
 "jIA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command/glass{
-	name = "Quartermaster's Office"
+/obj/machinery/door/airlock/maintenance{
+	name = "Quartermaster Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
 /turf/open/floor/iron/textured,
 /area/space)
+"jIF" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "jIN" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
@@ -27007,7 +27093,10 @@
 	codes_txt = "delivery;dir=8";
 	location = "QM #2"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "jTh" = (
 /obj/effect/spawner/structure/window,
@@ -27515,7 +27604,7 @@
 /obj/machinery/computer/security/qm{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "kaB" = (
 /obj/item/radio/intercom/directional/west,
@@ -27608,6 +27697,12 @@
 "kbn" = (
 /obj/structure/railing/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -28823,6 +28918,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"kvW" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/space)
 "kwg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -29052,6 +29155,11 @@
 /obj/structure/closet/crate/goldcrate,
 /turf/open/floor/vault,
 /area/station/ai_monitored/command/nuke_storage)
+"kyN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/dark,
+/area/space)
 "kyW" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -29085,6 +29193,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
+"kAA" = (
+/obj/docking_port/stationary/mining_home{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "kAC" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
@@ -29903,6 +30017,7 @@
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "kPI" = (
@@ -29953,15 +30068,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kQj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "kQo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30304,6 +30411,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "kWm" = (
@@ -30467,12 +30575,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kZf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/item/relic,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "kZq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30647,6 +30752,10 @@
 /turf/open/floor/iron/airless,
 /area/station/tcommsat/oldaisat/stationside)
 "lco" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "lcp" = (
@@ -30735,10 +30844,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ldq" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/chair{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "ldw" = (
@@ -30771,6 +30878,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"ldL" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "ldO" = (
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/iron,
@@ -31379,6 +31492,13 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
+"lmV" = (
+/obj/machinery/door/airlock/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31877,11 +31997,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "lvw" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/machinery/firealarm/directional/east,
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/space)
 "lvy" = (
@@ -32600,11 +32718,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"lHU" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "lHZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32950,10 +33063,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lMT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lMU" = (
@@ -33292,9 +33401,8 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "lTH" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lTI" = (
@@ -33380,6 +33488,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"lUE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "lUK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/janitor_supplies,
@@ -33782,6 +33894,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "mcm" = (
@@ -34009,12 +34123,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
-"mfU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "mfX" = (
 /turf/closed/wall,
 /area/station/commons/lounge)
@@ -34136,6 +34244,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"mia" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/space)
 "min" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34754,6 +34866,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"mtu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/space)
 "mtv" = (
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage)
@@ -35949,9 +36065,7 @@
 /area/station/cargo/drone_bay)
 "mPR" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "mPZ" = (
@@ -36036,13 +36150,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mQT" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/chair,
 /obj/machinery/light/directional/north,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 22
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "mRa" = (
@@ -36050,6 +36158,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "mRo" = (
@@ -36371,6 +36480,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"mWG" = (
+/obj/structure/rack,
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "mWL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36572,6 +36693,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "nab" = (
@@ -36618,11 +36741,8 @@
 /turf/open/floor/grass,
 /area/station/service/chapel/funeral)
 "nbo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -37165,6 +37285,13 @@
 /obj/item/computer_disk/engineering,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"nkB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "nkM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -37756,9 +37883,6 @@
 	network = list("ss13","qm")
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "nuJ" = (
@@ -38825,7 +38949,6 @@
 /area/station/service/bar)
 "nKx" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "nKy" = (
@@ -39202,6 +39325,8 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/space)
 "nSN" = (
@@ -39736,6 +39861,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"odA" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "odJ" = (
 /obj/structure/table_frame/wood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -40481,13 +40615,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
-"opv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "opD" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -40512,9 +40639,9 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/atmos/experiment_room)
 "oqc" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "oqB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -40554,9 +40681,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oqU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "oqX" = (
@@ -40619,10 +40745,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"orL" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "orW" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/directional/west,
@@ -40688,14 +40810,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"osO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "osQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -40958,10 +41072,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "oyd" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/secure_closet/miner,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/landmark/start/shaft_miner,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "oyh" = (
 /obj/effect/turf_decal/tile/blue,
@@ -41495,7 +41611,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/ordnance/testlab)
 "oHi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/space)
 "oHw" = (
@@ -41510,13 +41629,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
-"oHz" = (
-/obj/structure/sign/warning/docking/directional/south,
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "oHL" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -41659,10 +41771,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oKM" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/miningdock)
 "oKO" = (
@@ -41934,6 +42048,10 @@
 	},
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/clothing/shoes/wheelys/rollerskates{
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/wheelys/rollerskates,
 /turf/open/floor/iron,
 /area/space)
 "oQK" = (
@@ -42056,9 +42174,6 @@
 /area/station/science/xenobiology)
 "oSp" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -42236,6 +42351,12 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"oUS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "oVj" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -42784,11 +42905,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"pep" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pev" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43131,6 +43247,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/experiment_room)
+"pkb" = (
+/obj/structure/sign/warning/docking/directional/south,
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "pky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43510,6 +43633,10 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
+"prx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "prB" = (
 /obj/machinery/camera{
 	c_tag = "Command - Quartermaster's Office";
@@ -44209,6 +44336,7 @@
 "pDe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pDf" = (
@@ -44327,6 +44455,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
+"pEx" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "pEy" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -44440,6 +44575,9 @@
 "pGC" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -44683,6 +44821,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "pKF" = (
@@ -45185,6 +45325,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"pUD" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/space/nearstation)
 "pUE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45283,6 +45429,12 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"pWj" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron,
+/area/space)
 "pWp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45339,6 +45491,7 @@
 /area/station/cargo/storage)
 "pWS" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/space)
 "pWZ" = (
@@ -46206,18 +46359,10 @@
 /turf/open/floor/iron,
 /area/station/medical/surgery)
 "qli" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = 3
-	},
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet{
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
+/obj/machinery/recharge_station,
+/obj/machinery/status_display/evac/directional/south,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "qlv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -46625,12 +46770,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qrC" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "qrG" = (
@@ -47004,8 +47149,10 @@
 /turf/open/floor/iron/sepia,
 /area/station/service/library)
 "qwW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qwY" = (
@@ -47030,7 +47177,7 @@
 /area/station/science/xenobiology)
 "qxk" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "qxp" = (
@@ -47083,7 +47230,8 @@
 "qxI" = (
 /obj/structure/table,
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 4;
+	pixel_x = -4
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -47305,6 +47453,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"qBi" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/space)
 "qBC" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -47390,6 +47545,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"qDb" = (
+/obj/machinery/door/airlock/mining,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "qDt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -47505,6 +47664,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/cyan,
 /area/station/hallway/primary/port)
+"qFr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "qFy" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47914,9 +48077,10 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "qOj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/plastic,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/lower)
 "qOk" = (
 /obj/structure/cable,
@@ -48010,12 +48174,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/bar)
-"qQa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "qQd" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -48092,9 +48250,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "qRj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/structure/chair{
+	dir = 1
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "qRl" = (
@@ -48520,6 +48680,12 @@
 "qYG" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/lower)
+"qYR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance"
+	},
+/turf/open/floor/plating,
+/area/space)
 "qYZ" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -48882,15 +49048,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "reD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/clothing/shoes/wheelys/rollerskates,
-/obj/item/clothing/shoes/wheelys/rollerskates{
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
+/obj/machinery/suit_storage_unit/industrial/loader,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "reF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49249,6 +49409,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"rkI" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "rla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -49542,7 +49707,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "rqt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -49678,9 +49842,12 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "rsH" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/miner,
-/turf/open/floor/iron/dark,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rsJ" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -49989,6 +50156,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
+"rxH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "rxM" = (
 /obj/effect/landmark/start/mime,
 /obj/structure/mirror/directional/west,
@@ -50342,9 +50516,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rDP" = (
-/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/rnd/bepis,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "rEe" = (
@@ -50517,8 +50690,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "rGI" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/table,
+/obj/item/flashlight,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rGO" = (
@@ -50540,6 +50713,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lower)
+"rHf" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/space)
 "rHE" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room B"
@@ -50585,8 +50764,10 @@
 /area/station/command/heads_quarters/hos)
 "rHZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 8
+	},
 /obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "rIi" = (
@@ -50780,11 +50961,8 @@
 /turf/closed/wall,
 /area/station/medical/pharmacy)
 "rKu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/item/banner/cargo/mundane,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "rKw" = (
 /obj/item/tank/internals/oxygen/empty,
@@ -51033,6 +51211,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "rOl" = (
@@ -51214,6 +51395,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"rRo" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard{
+	amount = 8
+	},
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "rRq" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office"
@@ -51649,12 +51841,6 @@
 /obj/structure/chair/sofa/corp/corner,
 /turf/open/floor/iron,
 /area/station/medical/break_room)
-"rXB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "rXI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/airalarm/directional/east,
@@ -51693,6 +51879,13 @@
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"rXY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "rYn" = (
 /obj/structure/closet/crate/critter,
 /obj/item/banhammer,
@@ -52307,7 +52500,6 @@
 /area/station/service/bar)
 "sjB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "sjT" = (
@@ -52828,9 +53020,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
 "ssl" = (
-/obj/structure/stairs/west{
-	dir = 4
-	},
+/obj/structure/stairs/east,
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "ssv" = (
@@ -53409,7 +53599,6 @@
 "sCk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "sCq" = (
@@ -53554,12 +53743,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"sEm" = (
-/obj/machinery/computer/security/mining{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "sEn" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/service_all,
@@ -53967,11 +54150,9 @@
 /area/station/service/hydroponics/park)
 "sLc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/rods/fifty,
-/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "sLq" = (
@@ -54501,6 +54682,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"sSW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/space)
 "sTe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -54847,7 +55033,8 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/turf/open/floor/wood/large,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "tak" = (
 /obj/machinery/computer/exodrone_control_console{
@@ -55001,12 +55188,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tcl" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "tcr" = (
@@ -55039,7 +55222,6 @@
 "tcI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "tcV" = (
@@ -55182,6 +55364,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"tfm" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "tfn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -55441,7 +55629,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
@@ -55915,6 +56102,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"ttf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "ttp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/south,
@@ -56161,6 +56353,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "txC" = (
@@ -56564,18 +56757,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"tFG" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	space_dir = null
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "tFO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/flasher{
@@ -56899,6 +57080,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"tME" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/turf/open/floor/wood/large,
+/area/space)
 "tMI" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -57229,6 +57417,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"tSF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "tSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57550,15 +57744,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"tZu" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/port/lower)
 "tZv" = (
 /obj/machinery/camera{
 	c_tag = "Service - Library Quiet Room";
@@ -57569,6 +57754,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"tZw" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "tZE" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/machinery/camera{
@@ -57648,10 +57837,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/service)
-"uay" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
 "uaM" = (
 /obj/effect/spawner/random/maintenance/three,
 /obj/structure/closet,
@@ -58154,6 +58339,13 @@
 /obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/iron/checker,
 /area/station/maintenance/starboard/fore)
+"ujF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "ujJ" = (
 /obj/effect/landmark/start/depsec/supply,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -58210,6 +58402,9 @@
 "ukW" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -7
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -58311,8 +58506,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "unl" = (
-/obj/machinery/suit_storage_unit/industrial/loader,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "unr" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -58495,11 +58693,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "upJ" = (
@@ -58585,8 +58779,10 @@
 /turf/open/floor/wood,
 /area/station/service/barber)
 "url" = (
-/obj/machinery/light/small/red/directional/west,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/lower)
 "uro" = (
 /obj/structure/table,
@@ -58863,6 +59059,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
+"uvX" = (
+/obj/machinery/computer/order_console/mining,
+/turf/open/floor/iron/dark,
+/area/space)
 "uwg" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -58970,6 +59170,13 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"uyw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "uyQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/east,
@@ -59204,19 +59411,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"uDF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Cargo - Mining Shuttle Dock";
-	dir = 8;
-	network = list("ss13","qm")
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock)
 "uDL" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -59257,6 +59451,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"uEN" = (
+/obj/machinery/rnd/bepis,
+/turf/open/space/basic,
+/area/space)
 "uEQ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
@@ -59827,6 +60025,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"uOX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "uPj" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59997,6 +60200,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
 /area/station/service/library)
+"uRy" = (
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/space)
 "uRz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61426,7 +61633,10 @@
 	codes_txt = "delivery;dir=8";
 	location = "QM #4"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/brown{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/station/cargo/storage)
 "vsr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -61676,7 +61886,7 @@
 /area/station/maintenance/department/engine/atmos)
 "vyd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vyh" = (
@@ -61901,6 +62111,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"vCI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/space)
 "vCP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/black,
@@ -61969,7 +62183,10 @@
 	home_destination = "QM #3";
 	suffix = "#3"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/cargo/storage)
 "vDW" = (
 /obj/structure/cable,
@@ -62081,12 +62298,6 @@
 "vFM" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"vGb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "vGd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62118,7 +62329,6 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "vGI" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Quartermaster's Office"
@@ -62980,8 +63190,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vYl" = (
@@ -63540,12 +63748,6 @@
 /area/station/security/prison/rec)
 "wkA" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/status_display/supply{
-	pixel_y = -30
-	},
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "wkO" = (
@@ -63581,6 +63783,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"wlf" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "wlg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -63910,8 +64118,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "wqb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "wqf" = (
@@ -63939,10 +64147,10 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
 "wqD" = (
-/obj/machinery/computer/order_console/mining,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/machinery/computer/order_console/mining,
+/turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wqF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -64736,9 +64944,6 @@
 	name = "Mining RC";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wFS" = (
@@ -64874,6 +65079,15 @@
 /obj/structure/flora/bush/reed/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
+"wJy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "wJP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/hydroponics/constructable,
@@ -65055,6 +65269,21 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
+"wMS" = (
+/obj/structure/table,
+/obj/item/electronics/firelock{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/obj/item/electronics/airlock{
+	pixel_y = 7
+	},
+/obj/item/electronics/airlock{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "wMV" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
@@ -65212,7 +65441,10 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/structure/window/spawner/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/brown{
+	dir = 5
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "wQK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -65324,6 +65556,9 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/maintenance/department/science)
+"wTf" = (
+/turf/open/floor/iron/dark/side,
+/area/station/maintenance/port/lower)
 "wTw" = (
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -66219,9 +66454,7 @@
 /area/station/medical/pharmacy)
 "xiu" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xiN" = (
@@ -66284,8 +66517,6 @@
 	},
 /area/station/science/robotics/lab)
 "xjB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
@@ -66469,7 +66700,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
@@ -67397,6 +67627,11 @@
 "xEr" = (
 /turf/closed/wall,
 /area/station/medical/coldroom)
+"xEv" = (
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "xEz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -67485,7 +67720,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xGo" = (
-/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "xGv" = (
@@ -67531,7 +67768,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
 "xHu" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron,
 /area/space)
 "xHB" = (
@@ -67800,6 +68037,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "xLZ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/space/nearstation)
 "xMg" = (
@@ -67919,17 +68158,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"xOE" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 4;
-	height = 7;
-	shuttle_id = "cargo_home";
-	name = "Cargo Bay";
-	width = 10
-	},
-/turf/open/space/openspace,
-/area/space)
 "xOF" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/full,
@@ -68242,6 +68470,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xUz" = (
+/turf/open/floor/iron/dark,
+/area/station/maintenance/port/lower)
 "xUE" = (
 /obj/structure/window/reinforced/spawner/directional/west{
 	layer = 2.9
@@ -68355,9 +68586,6 @@
 /area/station/maintenance/starboard/lower)
 "xVP" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xWb" = (
@@ -68837,6 +69065,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/machinery/status_display/supply{
+	pixel_y = -32
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/department/cargo)
 "yew" = (
@@ -68940,11 +69173,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"yfv" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "yfI" = (
 /turf/open/openspace,
 /area/station/service/bar)
@@ -94920,7 +95148,7 @@ mZz
 vEP
 vEP
 sag
-sag
+rxH
 sag
 sag
 ymg
@@ -95167,9 +95395,9 @@ iii
 uNK
 uNK
 rqt
-opv
+vYk
 bUJ
-amr
+sgr
 gdw
 vYk
 pWO
@@ -95179,7 +95407,7 @@ fxn
 upH
 gSr
 sag
-sag
+epu
 ymg
 ymg
 wNX
@@ -95424,7 +95652,7 @@ sag
 puo
 xhz
 ovc
-sgr
+tSF
 sgr
 eKN
 vBr
@@ -95432,7 +95660,7 @@ gkN
 bLD
 pdF
 rxw
-rXB
+sjB
 ftE
 dbf
 sag
@@ -95683,7 +95911,7 @@ afD
 fGj
 sgr
 sgr
-pep
+sgr
 sgr
 sgr
 nyj
@@ -95940,7 +96168,7 @@ sag
 afV
 xMK
 eDl
-qQa
+cdK
 qyx
 ltP
 npt
@@ -95949,7 +96177,7 @@ xGo
 xom
 sjB
 wkA
-hGZ
+jqm
 ymg
 ymg
 wNX
@@ -96204,7 +96432,7 @@ fub
 sfW
 bsK
 mPR
-orL
+lMT
 bfY
 hGZ
 ymg
@@ -96452,16 +96680,16 @@ hGZ
 kMq
 bTd
 aDa
-xMK
+fuX
 cdK
-aRR
+cdK
 cdK
 ltP
 xHu
-sfW
+qDb
 sLc
 lTH
-osO
+sjB
 cjl
 hGZ
 ymg
@@ -96711,16 +96939,16 @@ bTd
 wXS
 rOj
 qTw
-tZu
+qTw
 qTw
 pGC
 kWg
 hGZ
-eep
-eep
+tfm
+pWj
 eep
 xLZ
-hGZ
+jqm
 ymg
 ymg
 wNX
@@ -96967,16 +97195,16 @@ hGZ
 hGZ
 tAa
 hMb
-fKP
+ssl
 ssl
 ssl
 bTd
 fxW
 hGZ
+pEx
+cHu
 eep
-eep
-eep
-xLZ
+pUD
 hGZ
 ymg
 ymg
@@ -97220,7 +97448,7 @@ hGZ
 fzK
 fzK
 hGZ
-eep
+fzK
 hGZ
 oQI
 fKf
@@ -97230,10 +97458,10 @@ sag
 vle
 qxI
 hGZ
+rRo
 eep
-eep
-eep
-xLZ
+oUS
+pAf
 pAf
 xsG
 wNX
@@ -97477,21 +97705,21 @@ hGZ
 fzK
 fzK
 hGZ
-eep
+hGZ
 hGZ
 hGZ
 sag
 sag
-hna
+hsR
 sag
 hGZ
 hGZ
 hGZ
-eep
-eep
-eep
-xLZ
 hGZ
+lmV
+hGZ
+pAf
+ymg
 ymg
 wNX
 ymg
@@ -97734,21 +97962,21 @@ hGZ
 fzK
 fzK
 hGZ
-eep
-eep
-eep
-hna
-hna
-hna
-hna
-eep
-eep
-eep
-eep
-eep
-eep
-xLZ
+fzK
+fzK
 hGZ
+fQQ
+prx
+xUz
+fSi
+qBi
+hGZ
+kyN
+mia
+vCI
+uvX
+pAf
+ymg
 ymg
 wNX
 ymg
@@ -97990,24 +98218,24 @@ ymg
 hGZ
 fzK
 fzK
+fzK
+fzK
+fzK
 hGZ
-eep
-eep
-eep
-hna
-hna
-hna
-hna
-eep
-eep
-eep
-eep
-eep
-eep
-xLZ
+wMS
+xUz
+jIF
+xUz
+epa
+iop
+epa
+vCI
+epa
+uvX
+pAf
 hGZ
-ymg
-xsG
+hGZ
+pAf
 ymg
 ymg
 ymg
@@ -98248,23 +98476,23 @@ hGZ
 fzK
 fzK
 hGZ
-eep
-eep
-eep
-hna
-hna
-hna
-hna
-eep
-eep
-eep
-eep
-eep
-eep
-xLZ
+hVD
+jos
 hGZ
-ymg
-xsG
+bnW
+qFr
+xUz
+tZw
+hGZ
+hGZ
+rHf
+vCI
+epa
+epa
+aqN
+qYR
+fzK
+pAf
 ymg
 ymg
 ymg
@@ -98510,20 +98738,20 @@ hGZ
 hGZ
 sag
 sag
+ujF
 sag
 sag
+hhk
+wTf
+xUz
+cnf
+lUE
+mWG
+sag
+aDd
 sag
 sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-sag
-xsG
+pAf
 xsG
 xsG
 wNX
@@ -98766,20 +98994,20 @@ fzK
 fzK
 fzK
 aDd
-foi
-ptl
-owa
-sag
-aDd
 dDJ
-jkB
-url
+ptl
 aDd
-gSZ
-hna
-aDd
-vCU
 sag
+hhk
+wTf
+xUz
+url
+xUz
+gSZ
+sag
+aDd
+crf
+qfc
 sag
 ymg
 ymg
@@ -99023,19 +99251,19 @@ fzK
 fzK
 fzK
 aDd
-fVj
-fra
-nHh
-iPf
-nHh
-dDJ
-hna
-qOj
-dDJ
 aDd
-nHh
-nHh
-nHh
+ptl
+dDJ
+sag
+sag
+fBF
+lUE
+qOj
+lUE
+pkb
+sag
+aDd
+dDJ
 awv
 sag
 xsG
@@ -99281,18 +99509,18 @@ xKy
 xKy
 sag
 sag
-vGb
-vjV
+rbW
+hna
 bfg
-cMi
-cMi
-cMi
-cMi
-cMi
-cMi
-cMi
+sag
+sag
+cQP
+dVw
+cQP
+sag
+sag
 bfg
-nHh
+dDJ
 oIQ
 sag
 ymg
@@ -99539,17 +99767,17 @@ rol
 apH
 sag
 rbW
-nHh
-cMi
+dDJ
+fLP
 ymg
 ymg
 ymg
+kAA
 ymg
 ymg
 ymg
-ymg
-cMi
-yfv
+cQP
+fmq
 jkB
 sag
 ymg
@@ -99797,7 +100025,7 @@ gps
 sag
 hmI
 aDd
-cMi
+fLP
 ymg
 ymg
 ymg
@@ -99805,7 +100033,7 @@ ymg
 ymg
 ymg
 ymg
-cMi
+cQP
 aDd
 dDJ
 sag
@@ -100054,7 +100282,7 @@ sya
 wXI
 jZY
 kVL
-cMi
+fLP
 ymg
 ymg
 ymg
@@ -100062,7 +100290,7 @@ ymg
 ymg
 ymg
 ymg
-cMi
+cQP
 aDd
 tcI
 sag
@@ -100309,9 +100537,9 @@ arM
 sQM
 kfh
 sag
-deJ
-uaw
-cMi
+fIb
+xEv
+fLP
 ymg
 ymg
 ymg
@@ -100319,7 +100547,7 @@ ymg
 ymg
 ymg
 ymg
-cMi
+cQP
 aDd
 bRy
 sag
@@ -100568,7 +100796,7 @@ iKc
 sag
 opT
 uaw
-cMi
+fLP
 ymg
 ymg
 ymg
@@ -100576,8 +100804,8 @@ ymg
 ymg
 ymg
 ymg
-cMi
-nHh
+cQP
+dDJ
 eJI
 sag
 ymg
@@ -100826,15 +101054,15 @@ sag
 eCp
 wBl
 bfg
-cMi
-cMi
-cMi
-cMi
-cMi
-cMi
-cMi
+cQP
+cQP
+cQP
+cQP
+cQP
+cQP
+cQP
 bfg
-nHh
+dDJ
 ety
 sag
 ymg
@@ -101089,9 +101317,9 @@ aDd
 dDJ
 dDJ
 aDd
-owa
-owa
-vjV
+aDd
+aDd
+jkB
 tTW
 sag
 ymg
@@ -104159,7 +104387,7 @@ eoC
 wcl
 wcl
 ymg
-ymg
+uEN
 ymg
 ymg
 ymg
@@ -159421,7 +159649,7 @@ xzK
 xzK
 xzK
 xzK
-xOE
+xzK
 xzK
 xzK
 xzK
@@ -160195,9 +160423,9 @@ hPv
 hPv
 hPv
 xPT
-ivt
-ivt
-ivt
+uOX
+uOX
+uOX
 slw
 rJt
 pyX
@@ -160695,7 +160923,7 @@ muC
 muC
 iKd
 uBV
-iKd
+kdW
 slw
 jdy
 rvX
@@ -160710,7 +160938,7 @@ vls
 vls
 hGZ
 pWS
-cdw
+uRy
 oHi
 prB
 cca
@@ -160952,7 +161180,7 @@ sAn
 muC
 iKd
 uBV
-iKd
+qTX
 vPg
 nKD
 nKD
@@ -161209,7 +161437,7 @@ iiO
 muC
 okU
 uBV
-kdW
+qTX
 lVu
 vMq
 gRQ
@@ -161482,7 +161710,7 @@ wmw
 fnd
 cdw
 oio
-oio
+kvW
 iJA
 ohA
 slw
@@ -161737,9 +161965,9 @@ wmw
 wmw
 wmw
 fnd
-cdw
-oio
-oio
+tME
+mtu
+sSW
 tKq
 gvK
 slw
@@ -161987,7 +162215,7 @@ qRN
 sNT
 dpy
 mog
-ifT
+lVu
 wmw
 wmw
 wmw
@@ -162244,7 +162472,7 @@ iHN
 xfv
 fXv
 mog
-ifT
+lVu
 wmw
 wmw
 wmw
@@ -162252,8 +162480,8 @@ wmw
 wmw
 xPT
 sdD
-sdD
-sdD
+uyw
+ttf
 vGI
 slw
 slw
@@ -162501,7 +162729,7 @@ eTv
 hsu
 aJo
 mog
-ifT
+lVu
 wmw
 wmw
 wmw
@@ -162761,7 +162989,7 @@ kpk
 ifT
 bzK
 kbn
-sgr
+odA
 bnt
 bzK
 suT
@@ -163017,14 +163245,14 @@ lVu
 ifT
 ifT
 suT
-suT
 syT
+suT
 iul
 suT
-suT
+xPT
 sdD
-pKm
-lco
+hFS
+ldL
 bkc
 mcl
 slw
@@ -163274,14 +163502,14 @@ lvV
 rTD
 oUJ
 aoq
-biT
+kiU
 kiU
 kiU
 biT
 nRn
 kPA
-pKm
-lco
+wJy
+nkB
 rDP
 slw
 slw
@@ -163537,8 +163765,8 @@ wSc
 kLW
 xdf
 mPI
-pKm
-lco
+hXr
+wlf
 qwW
 slw
 ovY
@@ -163794,13 +164022,13 @@ gAG
 gAG
 gAG
 sdD
-ddc
+sdD
 reD
 qli
 slw
 nfZ
 gWb
-ejm
+rXY
 jGt
 eei
 hql
@@ -164047,14 +164275,14 @@ gAG
 gAG
 wqD
 hNq
-dFQ
+dyi
 wFR
-sEm
-dXi
-dXi
-dXi
-dXi
-eei
+ckh
+ckh
+gAG
+gAG
+gAG
+slw
 gVI
 gEm
 slw
@@ -164303,16 +164531,16 @@ ujJ
 gTh
 nuD
 ibE
-mfU
+dyi
 nbo
 xVP
-oHz
-dXi
-faV
-uDF
+ckh
+ckh
+gAG
+kQj
 kQj
 wqb
-aaU
+ejm
 iiq
 xiu
 jGt
@@ -164565,10 +164793,10 @@ vyd
 qrC
 oKM
 gAc
-cgy
+gAG
 rKu
 kZf
-wqb
+slw
 htk
 dtQ
 sCk
@@ -164819,14 +165047,14 @@ dyi
 tcl
 ldq
 oqU
+dXi
 nKx
 nKx
-nKx
-nKx
-tFG
-nKx
-wqb
-wqb
+dXi
+dXi
+dXi
+eei
+eei
 jKf
 stF
 ejm
@@ -165073,18 +165301,18 @@ eIb
 gNX
 gAG
 mQT
-jAB
-edQ
-dyi
+tcl
+gEd
+diK
 nKx
 xzK
 xzK
 xzK
-fua
 xzK
 xzK
 xzK
-wqb
+xzK
+nJz
 oSq
 suW
 seh
@@ -165341,7 +165569,7 @@ xzK
 xzK
 xzK
 xzK
-wqb
+nJz
 pDe
 ejm
 slw
@@ -165588,9 +165816,9 @@ nrd
 gTh
 aRJ
 fKl
-rGI
+edQ
 oyd
-dXi
+nKx
 xzK
 xzK
 xzK
@@ -165598,9 +165826,9 @@ xzK
 xzK
 xzK
 xzK
-wqb
+nJz
 ghd
-uay
+ejm
 slw
 gHX
 bmL
@@ -165846,8 +166074,8 @@ gTh
 fVL
 fKl
 rGI
-iqu
-dXi
+oyd
+nKx
 xzK
 xzK
 xzK
@@ -165855,7 +166083,7 @@ xzK
 xzK
 xzK
 xzK
-wqb
+nJz
 pDe
 ejm
 slw
@@ -166101,10 +166329,10 @@ ndy
 hWG
 iPM
 hWK
-fKl
+hGA
 rHZ
 oqc
-dXi
+nKx
 xzK
 xzK
 xzK
@@ -166112,7 +166340,7 @@ xzK
 xzK
 xzK
 xzK
-wqb
+nJz
 oSq
 ejm
 slw
@@ -166359,16 +166587,16 @@ vjz
 gTh
 jhE
 oDp
-fYI
+dyi
 rsH
 eei
-wqb
-wqb
-wqb
-wqb
-wqb
-wqb
-wqb
+nJz
+nJz
+nJz
+nJz
+nJz
+nJz
+nJz
 jKf
 oSq
 gqr
@@ -166615,7 +166843,7 @@ dNg
 pjL
 gTh
 dXK
-dyi
+rkI
 akI
 bvK
 eDO
@@ -166625,8 +166853,8 @@ ejm
 bdD
 urM
 ejm
-jGt
-lHU
+ejm
+bdD
 oSq
 bdD
 slw

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -798,6 +798,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/teleporter)
+"apX" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "aqh" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/effect/spawner/random/structure/barricade,
@@ -2021,6 +2025,9 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "aOu" = (
@@ -3229,7 +3236,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "bkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4108,7 +4115,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
+/obj/item/kirbyplants,
 /turf/open/openspace,
 /area/station/cargo/storage)
 "bzN" = (
@@ -4170,11 +4177,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"bAW" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "bBg" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -4656,7 +4658,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "bJI" = (
 /obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/stripes/box,
@@ -4758,6 +4760,14 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/computer)
+"bLQ" = (
+/obj/machinery/light/small/red/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "bLV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5193,8 +5203,6 @@
 "bTh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 40
@@ -5238,6 +5246,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bUO" = (
@@ -6015,6 +6026,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "cnt" = (
@@ -6587,11 +6599,9 @@
 "cwn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -7226,6 +7236,8 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cHI" = (
@@ -7274,6 +7286,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "cIR" = (
@@ -7296,6 +7309,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"cJl" = (
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "cJo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -7544,10 +7561,6 @@
 "cOO" = (
 /obj/machinery/light/small/red/directional/east,
 /obj/effect/spawner/random/decoration/glowstick,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
-"cOW" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
@@ -8213,6 +8226,7 @@
 "dbf" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dbi" = (
@@ -9678,6 +9692,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"dCb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "dCh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -9806,7 +9826,6 @@
 /obj/item/folder/yellow,
 /obj/item/stamp/head/qm,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "dEz" = (
@@ -10216,10 +10235,10 @@
 /area/station/maintenance/port/lower)
 "dML" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "dMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10374,6 +10393,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"dPy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/cargo)
 "dQq" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -10742,6 +10767,7 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "dXi" = (
@@ -11277,6 +11303,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/maintenance/solars/starboard/aft)
+"ekC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
 "ekX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11975,6 +12006,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"exb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/command/heads_quarters/qm)
 "exd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -12396,6 +12432,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
 /area/station/security/prison)
+"eEk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "eEp" = (
 /obj/structure/chair{
 	dir = 8;
@@ -12601,6 +12641,11 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
+"eHF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "eHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -13285,6 +13330,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "eTC" = (
@@ -13734,6 +13782,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"faT" = (
+/obj/item/wheelchair,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "fba" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -13787,11 +13841,16 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "fci" = (
 /turf/closed/wall,
 /area/station/maintenance/port)
+"fcs" = (
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fcu" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/three,
@@ -13887,6 +13946,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"fdC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "fdF" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -13998,6 +14066,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/lobby)
+"ffg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/engine/atmos)
 "ffi" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/siding/yellow{
@@ -14176,7 +14251,10 @@
 /obj/machinery/light_switch/directional/east{
 	pixel_y = -5
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "fjv" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -14518,6 +14596,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"foH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "foP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -14812,7 +14895,6 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
 "ftE" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -14880,6 +14962,8 @@
 "fuX" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fvb" = (
@@ -14961,6 +15045,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fxK" = (
@@ -15048,6 +15135,7 @@
 /area/station/science/xenobiology)
 "fzK" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "fzS" = (
@@ -16398,9 +16486,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "fXv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/door/window/left/directional/south{
 	name = "Cargo Disposal";
 	req_access = list("shipping")
@@ -16592,6 +16677,9 @@
 	pixel_x = -8;
 	pixel_y = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gdy" = (
@@ -16972,6 +17060,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gla" = (
@@ -17558,7 +17647,11 @@
 "gvK" = (
 /obj/machinery/photocopier,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "gwd" = (
 /obj/structure/closet/firecloset,
@@ -18135,6 +18228,10 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"gEU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "gFe" = (
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /obj/effect/decal/cleanable/dirt,
@@ -18342,6 +18439,13 @@
 /obj/machinery/fax,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
+"gJR" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/cargo)
 "gKc" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -18881,6 +18985,7 @@
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "gSs" = (
@@ -19781,11 +19886,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/auxlab/firing_range)
-"hkb" = (
-/obj/structure/closet,
-/obj/item/wheelchair,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hkg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
@@ -19797,6 +19897,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"hkn" = (
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "hkp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -19899,11 +20003,6 @@
 "hmb" = (
 /turf/closed/wall,
 /area/station/medical/storage)
-"hme" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hmf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -20059,6 +20158,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hon" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/qm)
 "hop" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20221,11 +20329,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"hsu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
 "hsx" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -20364,13 +20467,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"huW" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/janitor_supplies,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "hvo" = (
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/catwalk_floor,
@@ -20728,7 +20824,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "hBI" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -20974,7 +21070,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "hFZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -21425,6 +21521,7 @@
 "hMb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/railing,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "hMg" = (
@@ -21884,7 +21981,6 @@
 /area/station/service/kitchen/coldroom)
 "hVj" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/lower)
 "hVt" = (
@@ -21906,6 +22002,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hVJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "hWe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -22033,7 +22134,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "hXx" = (
 /obj/structure/chair/sofa/middle/brown,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
@@ -22468,6 +22569,12 @@
 /obj/structure/flora/bush/stalky/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
+"ihe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "ihg" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -22550,6 +22657,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "iij" = (
@@ -22751,7 +22861,10 @@
 /obj/machinery/status_display/supply{
 	pixel_y = -32
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "ilN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -22827,6 +22940,8 @@
 /obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "iov" = (
@@ -23170,6 +23285,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"itH" = (
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "itQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/evidence,
@@ -23647,6 +23770,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"iDD" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "iDH" = (
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Pens D Upper";
@@ -23655,12 +23783,6 @@
 	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
-"iDO" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "iDV" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -23881,12 +24003,12 @@
 /area/station/medical/abandoned)
 "iHN" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "iHW" = (
@@ -24350,12 +24472,6 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
-"iPl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "iPn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -24508,6 +24624,11 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
+"iSa" = (
+/obj/effect/spawner/random/maintenance/three,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "iSg" = (
 /obj/structure/chair{
 	dir = 8
@@ -24883,8 +25004,6 @@
 /area/station/solars/starboard/aft)
 "iZN" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -24977,17 +25096,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"jdh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "jdy" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "jdI" = (
@@ -25016,7 +25131,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "jem" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
@@ -25359,6 +25474,9 @@
 	},
 /turf/open/floor/iron/half,
 /area/station/security/prison/garden)
+"jmV" = (
+/turf/closed/wall,
+/area/station/cargo/break_room)
 "jmX" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -26432,10 +26550,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jFf" = (
-/obj/structure/chair/comfy,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "jFs" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance"
@@ -26568,6 +26682,8 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "jIN" = (
@@ -26795,6 +26911,8 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "jLB" = (
@@ -27209,12 +27327,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"jTA" = (
-/obj/machinery/light/small/red/directional/north,
-/obj/effect/spawner/random/trash/hobo_squat,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "jTL" = (
 /obj/machinery/camera{
 	c_tag = "Science - Nanite Lab";
@@ -27655,8 +27767,8 @@
 /area/station/service/kitchen/abandoned)
 "jZY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "kaa" = (
@@ -27705,6 +27817,9 @@
 "kax" = (
 /obj/machinery/keycard_auth/directional/north,
 /obj/machinery/computer/security/qm{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -27819,13 +27934,6 @@
 /obj/machinery/air_sensor/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
-"kbC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/decoration/glowstick,
-/obj/structure/rack,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "kbE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29013,6 +29121,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"kvS" = (
+/obj/machinery/light/small/red/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "kvT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen"
@@ -29026,8 +29140,14 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/qm)
+"kwe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "kwg" = (
 /obj/machinery/door/poddoor/preopen{
@@ -29292,6 +29412,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kzt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/port/lower)
 "kzN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -29801,6 +29927,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"kJT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "kKh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -29930,6 +30061,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
+"kMh" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "kMk" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable,
@@ -30117,7 +30257,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "kPI" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -30851,7 +30991,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "lcp" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/green/filled/end{
@@ -30977,7 +31117,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "ldO" = (
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/iron,
@@ -31407,6 +31547,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"ljN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "ljO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/workout)
@@ -31591,6 +31736,8 @@
 /obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -32003,6 +32150,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ltV" = (
@@ -32085,10 +32233,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "lvw" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "lvy" = (
 /obj/effect/landmark/start/xenobiologist,
@@ -32324,6 +32478,10 @@
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/workout)
+"lyd" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lyj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/grimy,
@@ -33408,6 +33566,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"lRi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lRr" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -33491,6 +33656,8 @@
 "lTH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "lTI" = (
@@ -33641,6 +33808,11 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"lVv" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "lVM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
@@ -33843,6 +34015,11 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"mar" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "maC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
@@ -33985,8 +34162,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "mcm" = (
 /obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/east,
@@ -34207,9 +34385,10 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Old Server Room"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "mfX" = (
@@ -34893,6 +35072,11 @@
 "mqR" = (
 /turf/open/floor/engine,
 /area/station/science/auxlab)
+"mqU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "mqW" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/reagent_dispensers/watertank,
@@ -35536,8 +35720,6 @@
 /area/station/medical/virology)
 "mDv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -35604,6 +35786,11 @@
 /obj/structure/closet/l3closet/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"mFl" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "mFn" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -35972,10 +36159,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"mNp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
 "mNv" = (
 /obj/structure/rack,
 /obj/item/rcl/pre_loaded,
@@ -36179,7 +36362,7 @@
 "mPI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "mPQ" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -36188,6 +36371,8 @@
 "mPR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "mPZ" = (
@@ -36616,8 +36801,6 @@
 /area/station/cargo/miningdock)
 "mWL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 2
 	},
@@ -36817,8 +37000,10 @@
 	},
 /obj/structure/table,
 /obj/structure/cable,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "nab" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office/light{
@@ -37255,6 +37440,7 @@
 /area/station/cargo/miningdock)
 "nhE" = (
 /obj/effect/decal/cleanable/shreds,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "nhG" = (
@@ -37321,12 +37507,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"niA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "niG" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -37426,7 +37606,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "nkM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -37882,11 +38062,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/chapel)
-"nsG" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "nsM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -38457,6 +38632,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"nBU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "nCb" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -39463,7 +39643,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "nSN" = (
@@ -39859,6 +40038,12 @@
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"oaU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/grille/broken,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/port/lower)
 "obi" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/iron,
@@ -40296,9 +40481,6 @@
 "oig" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/rec)
-"oio" = (
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
 "oit" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40360,7 +40542,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "ojA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -41755,7 +41937,7 @@
 "oHi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
@@ -41943,6 +42125,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
+"oLc" = (
+/obj/structure/girder,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "oLr" = (
@@ -42319,6 +42506,8 @@
 "oSp" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "oSq" = (
@@ -43289,6 +43478,18 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"piF" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "piL" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -44977,8 +45178,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "pKF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45587,6 +45789,8 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/random/maintenance/three,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "pWp" = (
@@ -45641,6 +45845,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pWS" = (
@@ -46521,7 +46728,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "qlv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -47115,12 +47322,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "quB" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
-/obj/item/book/random,
-/obj/item/storage/box/lights/mixed{
-	pixel_y = -6
-	},
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "quD" = (
@@ -47306,13 +47508,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/sepia,
 /area/station/service/library)
+"qwM" = (
+/obj/item/screwdriver,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "qwW" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "qwY" = (
 /obj/structure/table,
 /obj/item/stack/ducts/fifty,
@@ -48479,6 +48686,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qRO" = (
@@ -49227,7 +49435,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "reF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49662,6 +49870,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
+"rmi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "rml" = (
 /obj/structure/flora/bush/leafy,
 /turf/open/floor/grass,
@@ -49889,6 +50103,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rqM" = (
@@ -50263,6 +50480,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rwb" = (
@@ -50334,6 +50552,7 @@
 	name = "Cargo Bay Warehouse Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "rxM" = (
@@ -50636,11 +50855,9 @@
 "rCI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office"
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -50692,8 +50909,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "rEe" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -51090,6 +51308,11 @@
 /area/station/science/explab)
 "rJt" = (
 /obj/structure/table,
+/obj/item/book/random,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/storage/box/lights/mixed{
+	pixel_y = -6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "rJE" = (
@@ -51389,6 +51612,7 @@
 	dir = 8
 	},
 /obj/structure/railing/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "rOl" = (
@@ -52580,10 +52804,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/morgue)
-"shr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall,
-/area/station/maintenance/port/lower)
 "shv" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -52758,13 +52978,6 @@
 	dir = 4
 	},
 /area/station/engineering/engine_smes)
-"slp" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "slv" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -54223,7 +54436,6 @@
 "sIV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
@@ -54850,11 +55062,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"sSW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
 "sTe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55202,6 +55409,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/qm)
 "tak" = (
@@ -55802,6 +56012,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tli" = (
@@ -56524,6 +56737,8 @@
 	name = "Cargo Bay Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "txC" = (
@@ -56646,6 +56861,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "tAw" = (
@@ -56821,11 +57037,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"tDy" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "tDN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57037,6 +57248,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/service/abandoned_gambling_den)
+"tJc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "tJd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57111,12 +57328,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"tKq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/qm)
 "tKs" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -57252,10 +57463,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tME" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "tMI" = (
@@ -57401,6 +57609,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"tOz" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "tOP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/research{
@@ -57592,6 +57812,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tSS" = (
@@ -57827,6 +58049,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"tXl" = (
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "tXs" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
@@ -58685,7 +58914,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "unr" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
@@ -58866,8 +59095,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "upJ" = (
@@ -58956,6 +59185,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "uro" = (
@@ -59185,6 +59416,8 @@
 /area/station/hallway/secondary/service)
 "uuK" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "uuL" = (
@@ -59210,6 +59443,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "uvq" = (
@@ -60006,12 +60240,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"uLo" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/crayons,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "uLp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60157,6 +60385,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uNV" = (
@@ -61083,7 +61314,6 @@
 "vfw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "vfA" = (
@@ -61318,10 +61548,10 @@
 "vjM" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
-"vjV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+"vjS" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lower)
 "vjY" = (
 /obj/machinery/button/door{
@@ -61980,10 +62210,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
-"vvG" = (
-/obj/item/screwdriver,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "vvJ" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -62299,6 +62525,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "vCP" = (
@@ -62587,6 +62815,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"vIy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "vIR" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
@@ -62749,6 +62983,7 @@
 /area/station/hallway/secondary/service)
 "vMq" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "vMu" = (
@@ -62955,6 +63190,7 @@
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "vPQ" = (
@@ -63380,6 +63616,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vYl" = (
@@ -63400,6 +63639,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"vYt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port/lower)
 "vYu" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -63978,7 +64223,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "wlg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -64367,6 +64612,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
+"wrc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "wrh" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -64452,6 +64703,8 @@
 /obj/machinery/firealarm/directional/east{
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "wtd" = (
@@ -65293,7 +65546,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "wJP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/hydroponics/constructable,
@@ -65779,6 +66032,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/research,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"wTP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/crayons,
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lower)
 "wTV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -66005,13 +66264,13 @@
 /area/station/service/abandoned_gambling_den)
 "wXI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/door/airlock/maintenance{
 	name = "Abandoned Garden"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
 "wXS" = (
@@ -66437,8 +66696,6 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "xfv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
@@ -66908,6 +67165,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "xon" = (
@@ -67004,9 +67263,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"xpn" = (
-/turf/open/floor/engine/hull,
-/area/station/cargo/storage)
 "xpq" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/directional/west,
@@ -67706,6 +67962,9 @@
 	name = "Warehouse Shutters";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/cargo/warehouse)
 "xCs" = (
@@ -68291,6 +68550,8 @@
 /area/station/security/courtroom)
 "xMK" = (
 /obj/effect/turf_decal/arrows/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xMQ" = (
@@ -69169,12 +69430,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lower)
-"yci" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lower)
 "ycp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -69283,7 +69538,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/break_room)
 "yew" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/south,
@@ -69522,6 +69777,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "yin" = (
@@ -89177,7 +89433,7 @@ aDd
 moF
 dDJ
 dDJ
-bAW
+wAr
 rOE
 sdM
 tmg
@@ -90203,10 +90459,10 @@ hyS
 pWK
 kGj
 sag
-yiL
-hna
-wAr
-rOU
+tXl
+ihe
+kMh
+ffg
 sdU
 wAr
 xsG
@@ -90460,7 +90716,7 @@ bep
 fBM
 nHh
 sag
-fbZ
+bLQ
 aDd
 wAr
 bDA
@@ -90715,10 +90971,10 @@ tNS
 xuH
 kQg
 nhE
-owa
+mar
 mfP
-nHh
-owa
+lRi
+aDd
 wAr
 fcD
 sdM
@@ -90971,11 +91227,11 @@ xHC
 caJ
 iJy
 caJ
-wDS
+tJc
 uvm
 cID
-dDJ
-nsG
+foH
+jyd
 sag
 sag
 aYS
@@ -91232,7 +91488,7 @@ vXE
 owa
 sag
 deJ
-niA
+qii
 sag
 aDd
 wlt
@@ -91489,7 +91745,7 @@ bKk
 kGj
 sag
 dDJ
-vjV
+jkB
 sag
 fbZ
 hwR
@@ -92003,10 +92259,10 @@ sag
 sag
 sag
 jyd
-nHh
-slp
-owa
-owa
+auY
+mSr
+mSr
+mSr
 aDd
 aDd
 jkB
@@ -92017,7 +92273,7 @@ jkB
 dDJ
 dDJ
 aDd
-ymh
+hna
 jkB
 auY
 dDJ
@@ -92248,7 +92504,7 @@ ymg
 cMi
 jkB
 aDd
-sag
+aDd
 sag
 ymg
 ymg
@@ -92259,10 +92515,10 @@ ymg
 sag
 sag
 sYK
-dDJ
-nHh
-sag
-sag
+aDd
+rhb
+aDd
+aDd
 jSw
 xQy
 dDJ
@@ -92274,7 +92530,7 @@ hna
 aDd
 dDJ
 aDd
-pcr
+aDd
 aDd
 mSr
 xQy
@@ -92504,20 +92760,20 @@ ymg
 ymg
 cMi
 hna
+aDd
+aDd
 sag
-sag
-ymg
 ymg
 ymg
 xsG
 xsG
 ymg
 ymg
-ymg
 sag
-sag
-dDJ
-vjV
+blm
+aDd
+aDd
+jkB
 yiL
 bfg
 cQP
@@ -92761,21 +93017,21 @@ ymg
 ymg
 cMi
 owa
+aDd
+aDd
 sag
-ymg
-ymg
 ymg
 ymg
 xsG
 xsG
 ymg
 ymg
-ymg
-ymg
 sag
-cjW
-vjV
-owa
+wTP
+oxz
+aDd
+jkB
+aDd
 fLP
 epu
 epu
@@ -93020,19 +93276,19 @@ xhh
 mVO
 sag
 sag
-ymg
+sag
 ymg
 ymg
 xsG
 xsG
 ymg
 ymg
-ymg
 sag
-sag
-sag
-shr
-owa
+lVv
+faT
+iSa
+dDJ
+aDd
 fLP
 ymg
 ymg
@@ -93047,7 +93303,7 @@ ymg
 ymg
 ymg
 cQP
-auY
+rhb
 dDJ
 sag
 xsG
@@ -93276,20 +93532,20 @@ nHh
 sIZ
 owa
 vCU
+moF
+sag
+xsG
+xsG
+xsG
+xsG
+xsG
+xsG
 sag
 sag
-xsG
-xsG
-xsG
-xsG
-xsG
-xsG
 sag
 sag
-yci
-uLo
-sag
-iPl
+aDd
+cIo
 fLP
 ymg
 ymg
@@ -93542,11 +93798,11 @@ xsG
 ymg
 ymg
 sag
-jFf
 aDd
 aDd
 sag
-nHh
+aDd
+dDJ
 fLP
 ymg
 ymg
@@ -93561,7 +93817,7 @@ ymg
 ymg
 ymg
 cQP
-kbC
+dDQ
 dDJ
 sag
 xsG
@@ -93799,11 +94055,11 @@ xsG
 ymg
 ymg
 cQP
-jTA
-dDJ
+ctw
 aDd
-tDy
-vjV
+xVR
+aDd
+jkB
 fLP
 ymg
 ymg
@@ -93818,7 +94074,7 @@ ymg
 ymg
 ymg
 cQP
-jdh
+xdF
 dDJ
 sag
 ymg
@@ -94056,11 +94312,11 @@ xsG
 ymg
 ymg
 cQP
-cOW
-dDJ
-oxz
-sag
-vjV
+aDd
+aDd
+xVR
+aDd
+jkB
 fLP
 ymg
 ymg
@@ -94075,7 +94331,7 @@ ymg
 ymg
 ymg
 cQP
-auY
+hVJ
 hna
 sag
 xsG
@@ -94313,11 +94569,11 @@ xsG
 ymg
 ymg
 sag
-qfc
 aDd
-blm
+aDd
 sag
-nHh
+aDd
+hVJ
 fLP
 ymg
 ymg
@@ -94332,7 +94588,7 @@ ymg
 ymg
 ymg
 cQP
-fra
+cJl
 wWl
 sag
 ymg
@@ -94570,12 +94826,12 @@ xsG
 ymg
 sag
 sag
+aDd
+aDd
 sag
+vjS
 sag
-sag
-sag
-owa
-fLP
+imb
 ymg
 ymg
 xoF
@@ -94588,9 +94844,9 @@ xoF
 ymg
 ymg
 ymg
-cQP
-fra
-aDd
+imb
+sag
+lyd
 sag
 ymg
 ymg
@@ -94826,13 +95082,13 @@ xsG
 xsG
 xsG
 sag
-hme
-huW
-hkb
+aDd
+dDJ
+aDd
 sag
-wAn
-owa
-fLP
+kzt
+tOz
+imb
 ymg
 ymg
 xoF
@@ -94845,9 +95101,9 @@ xoF
 ymg
 ymg
 ymg
-cQP
-mSr
-vvG
+imb
+apX
+aDd
 sag
 ymg
 ymg
@@ -95087,8 +95343,8 @@ dDJ
 aDd
 dDJ
 sag
+oaU
 sag
-aDd
 bfg
 xoF
 xoF
@@ -95103,8 +95359,8 @@ sfW
 ivt
 ivt
 bfg
-aDd
-aDd
+owa
+qwM
 sag
 ymg
 ymg
@@ -95340,11 +95596,11 @@ ymg
 ymg
 ymg
 cQP
-phG
+aDd
+aDd
 aDd
 sag
-sag
-deJ
+mqU
 aDd
 sag
 qtv
@@ -95598,18 +95854,18 @@ cQP
 cQP
 sag
 sag
-iDO
+xVR
+xVR
 sag
-aDd
-dDJ
-aDd
+cSn
+dRW
 iii
 uNK
 uNK
 rqt
 vYk
 bUJ
-sgr
+vIy
 gdw
 vYk
 pWO
@@ -95858,7 +96114,7 @@ ofn
 aDd
 hna
 aDd
-aDd
+fIx
 aDd
 sag
 puo
@@ -95872,7 +96128,7 @@ gkN
 bLD
 pdF
 rxw
-sjB
+dCb
 ftE
 dbf
 sfW
@@ -96113,19 +96369,19 @@ auY
 ahI
 auY
 sIV
-owa
-aDd
-aDd
+mSr
+mSr
+fIx
 aDd
 sag
 afD
 mJO
 fGj
+eHF
 sgr
+fcs
 sgr
-sgr
-sgr
-sgr
+eEk
 nyj
 sfW
 cvd
@@ -96370,9 +96626,9 @@ aDd
 sag
 dDJ
 kez
-aDd
-aDd
-aDd
+phG
+wAn
+fIx
 aDd
 sag
 xPT
@@ -96629,17 +96885,17 @@ sag
 sag
 sag
 sag
-aDd
+fIx
 aDd
 sag
 leJ
 gdc
 sNy
-sgr
+eHF
 myV
 xjB
 sgr
-sgr
+eEk
 fub
 sfW
 bsK
@@ -96886,7 +97142,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 kMq
@@ -97143,7 +97399,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 aDw
@@ -97400,7 +97656,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 xPT
@@ -97657,7 +97913,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 aDd
@@ -97671,7 +97927,7 @@ vle
 qxI
 sfW
 rRo
-lMT
+kJT
 oUS
 sfW
 sfW
@@ -97914,7 +98170,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 sag
@@ -98171,7 +98427,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 fzK
@@ -98428,11 +98684,11 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 xVR
-aDd
-aDd
+dDJ
+dDJ
 sag
 wMS
 bPO
@@ -98440,9 +98696,9 @@ jIF
 jLs
 wsF
 iop
-aqN
-dEz
-aqN
+nBU
+fdC
+nBU
 onL
 gAG
 sag
@@ -98685,21 +98941,21 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
-faa
+iDD
 fVj
 sag
 bnW
 qFr
-dXh
+itH
 tZw
 gAG
 gAG
 rHf
 dEz
-aqN
+wrc
 epa
 aqN
 qYR
@@ -98942,7 +99198,7 @@ ymg
 ymg
 ymg
 sag
-aDd
+fIx
 aDd
 sag
 sag
@@ -99199,7 +99455,7 @@ sag
 sag
 sag
 sag
-aDd
+fIx
 aDd
 aDd
 aDd
@@ -99456,15 +99712,15 @@ dxp
 sag
 aDd
 aDd
-aDd
-aDd
-aDd
-dDJ
-aDd
-dDJ
-aDd
-aDd
-jkB
+fIx
+fIx
+fIx
+rbW
+fIx
+rbW
+fIx
+fIx
+vYt
 dDJ
 sag
 gAG
@@ -99721,7 +99977,7 @@ xKy
 xKy
 sag
 sag
-dDJ
+rbW
 hna
 bfg
 dXi
@@ -99978,7 +100234,7 @@ rol
 rol
 apH
 sag
-dDJ
+rbW
 dDJ
 fLP
 ymg
@@ -100235,7 +100491,7 @@ jFN
 aBV
 gps
 sag
-deJ
+kvS
 aDd
 fLP
 ymg
@@ -159081,7 +159337,7 @@ wcb
 bOS
 eyG
 slw
-ejm
+ljN
 jUM
 nJz
 xzK
@@ -159338,7 +159594,7 @@ vKh
 wcb
 vkV
 slw
-ejm
+ljN
 bdD
 nJz
 xzK
@@ -159595,7 +159851,7 @@ vKh
 wcb
 ezo
 slw
-ejm
+ljN
 bdD
 nJz
 xzK
@@ -159852,7 +160108,7 @@ vKh
 wcb
 sdO
 slw
-ejm
+ljN
 ejm
 nJz
 xzK
@@ -160109,22 +160365,22 @@ vKh
 wcb
 iOR
 slw
-ejm
-bdD
-nJz
+dPy
+slw
+slw
 xzK
 xzK
-xpn
-xpn
-xpn
-xpn
-xpn
-xpn
-xpn
+caL
+caL
+caL
+caL
+caL
+caL
+caL
 xzK
 xzK
 xzK
-nJz
+slw
 rEY
 ejm
 wnY
@@ -160366,9 +160622,9 @@ vKh
 wcb
 pvu
 slw
-bdD
-ejm
-nJz
+gJR
+piF
+slw
 caL
 caL
 xPT
@@ -160381,10 +160637,10 @@ xPT
 caL
 caL
 caL
-nJz
+slw
 quB
-ejm
-urM
+jGt
+mFl
 cfy
 sQr
 sQr
@@ -160628,19 +160884,19 @@ slw
 slw
 hEk
 hEk
-xPT
+ifT
 mwH
 fjA
 cVt
 pqK
 hPv
-xPT
+sdD
 ttf
 ttf
 ttf
 slw
 rJt
-pyX
+hkn
 ejm
 lIw
 slw
@@ -160897,7 +161153,7 @@ aOk
 sZH
 slw
 slw
-ejm
+oLc
 lHx
 xqh
 slw
@@ -161150,7 +161406,7 @@ vls
 vls
 sdD
 pWS
-uRy
+exb
 oHi
 prB
 cca
@@ -161394,8 +161650,8 @@ iKd
 uBV
 qTX
 lVu
-gRQ
-gRQ
+gEU
+rmi
 qMT
 naU
 naU
@@ -161407,7 +161663,7 @@ rJp
 jVx
 aQn
 vEn
-bVu
+ekC
 nSK
 bVu
 jIA
@@ -161652,7 +161908,7 @@ uBV
 qTX
 lVu
 vMq
-gRQ
+gEU
 qMT
 naU
 naU
@@ -161909,7 +162165,7 @@ uBV
 xuP
 ifT
 alQ
-gRQ
+gEU
 eNy
 jBb
 xFk
@@ -161921,7 +162177,7 @@ wmw
 wmw
 fnd
 cdw
-oio
+mtu
 kvW
 iJA
 ohA
@@ -162173,14 +162429,14 @@ jqt
 ifT
 wmw
 wmw
-naU
+wmw
 wmw
 wmw
 dnq
 tME
-mtu
-sSW
-tKq
+kwe
+uRy
+rpw
 gvK
 slw
 eoB
@@ -162437,7 +162693,7 @@ nHW
 fjk
 lvw
 dML
-rpw
+hon
 ilF
 slw
 llI
@@ -162679,7 +162935,7 @@ iNV
 uBV
 eHL
 xUa
-mNp
+gRQ
 iHN
 xfv
 fXv
@@ -162690,7 +162946,7 @@ wmw
 wmw
 wmw
 wmw
-xPT
+sdD
 sdD
 uyw
 ttf
@@ -162938,7 +163194,7 @@ qTX
 lVu
 gRQ
 eTv
-hsu
+gRQ
 aJo
 mog
 lVu
@@ -162947,7 +163203,7 @@ wmw
 wmw
 wmw
 wmw
-suT
+mPI
 unl
 fcf
 mZX
@@ -163204,7 +163460,7 @@ kbn
 odA
 bnt
 bzK
-suT
+mPI
 hBC
 pKm
 lco
@@ -163461,8 +163717,8 @@ iul
 suT
 iul
 suT
-xPT
-sdD
+jmV
+jmV
 hFS
 ldL
 bkc
@@ -164233,8 +164489,8 @@ gAG
 gAG
 gAG
 gAG
-sdD
-sdD
+jmV
+jmV
 reD
 qli
 slw

--- a/maplestation_modules/code/game/area/space_station_13_areas.dm
+++ b/maplestation_modules/code/game/area/space_station_13_areas.dm
@@ -46,6 +46,10 @@
 /area/station/tcommsat/oldaisat/stationside
 	name = "\improper Abandoned AI Satellite"
 
+/area/station/cargo/break_room
+	name = "\improper Cargo Break Room"
+	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
+
 //Berry Physics Space Ruin
 /area/ruin/space/has_grav/powered/berry_physics
 	name = "Berry Physics"

--- a/maplestation_modules/code/game/area/space_station_13_areas.dm
+++ b/maplestation_modules/code/game/area/space_station_13_areas.dm
@@ -37,11 +37,9 @@
 
 /area/station/maintenance/starboard/lower
 	name = "Lower Starboard Maintenance"
-	icon_state = "smaint"
 
 /area/station/maintenance/port/lower
 	name = "Lower Port Maintenance"
-	icon_state = "pmaint"
 
 /area/station/tcommsat/oldaisat/stationside
 	name = "\improper Abandoned AI Satellite"

--- a/maplestation_modules/code/game/area/space_station_13_areas.dm
+++ b/maplestation_modules/code/game/area/space_station_13_areas.dm
@@ -41,6 +41,11 @@
 /area/station/maintenance/port/lower
 	name = "Lower Port Maintenance"
 
+/area/station/maintenance/old_rec
+	name = "\improper Abandoned Recreation Room"
+	icon_state = "maint_dorms"
+	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+
 /area/station/tcommsat/oldaisat/stationside
 	name = "\improper Abandoned AI Satellite"
 


### PR DESCRIPTION
As a soft-preparation for Bitrunners + I just wanted to work on Lima a bit: Lima's cargo department is now larger and vertical.

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/6c0bb34d-9c72-4acf-9a61-f477d61b3c65)

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/111c891a-1c6c-437d-a9c9-51bf84e34e03)
