### PR TITLE
Adds Blood Volume and ""Heart Rate"" to operating consoles

### DIFF
--- a/maplestation_modules/code/game/objects/structures/surgery_table.dm
+++ b/maplestation_modules/code/game/objects/structures/surgery_table.dm
@@ -218,6 +218,8 @@
 
 	var/obj/item/organ/patient_brain = table.patient.get_organ_slot(ORGAN_SLOT_BRAIN)
 	data["patient"]["brain"] = isnull(patient_brain) ? 100 : ((patient_brain.damage / patient_brain.maxHealth) * 100)
+	data["patient"]["bloodVolumePercent"] = round((table.patient.blood_volume / BLOOD_VOLUME_NORMAL) * 100)
+	data["patient"]["heartRate"] = table.patient.get_pretend_heart_rate()
 	// We can also show pain and stuff here if we want.
 
 	return data
@@ -245,3 +247,46 @@
 		if("disable_failsafe")
 			table.failsafe_time = INFINITY
 			return TRUE
+
+/// I fully intend on adding real heart rate eventually, but now we fake it
+/// This also serves as a nice way to collect things which should affect heart rate later.
+/mob/living/carbon/proc/get_pretend_heart_rate()
+	if(stat == DEAD)
+		return 0
+
+	var/obj/item/organ/internal/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)
+	if(isnull(heart) || !heart.beating)
+		return 0
+
+	var/base_amount = 0
+
+	if(has_status_effect(/datum/status_effect/jitter))
+		base_amount = 100 + rand(0, 25)
+	else if(stat == SOFT_CRIT || stat == HARD_CRIT)
+		base_amount = 60 + rand(-15, -10)
+	else
+		base_amount = 90 + rand(-10, 10)
+
+	switch(pain_controller?.get_average_pain()) // pain raises it a bit
+		if(25 to 50)
+			base_amount += 5
+		if(50 to 75)
+			base_amount += 10
+		if(75 to INFINITY)
+			base_amount += 15
+
+	switch(pain_controller?.pain_modifier) // numbness lowers it a bit
+		if(0.25 to 0.5)
+			base_amount -= 15
+		if(0.5 to 0.75)
+			base_amount -= 10
+		if(0.75 to 1)
+			base_amount -= 5
+
+	if(has_status_effect(/datum/status_effect/determined)) // adrenaline
+		base_amount += 10
+
+	if(has_reagent(/datum/reagent/consumable/coffee)) // funny
+		base_amount += 10
+
+	return round(base_amount * clamp(1.5 * ((heart.maxHealth - heart.damage) / heart.maxHealth), 0.5, 1)) // heart damage puts a multiplier on it

--- a/tgui/packages/tgui/interfaces/_OperatingComputer.tsx
+++ b/tgui/packages/tgui/interfaces/_OperatingComputer.tsx
@@ -43,6 +43,8 @@ type Patient = {
   fireLoss: number | null;
   toxLoss: number | null;
   oxyLoss: number | null;
+  bloodVolumePercent: number | null;
+  heartRate: number | null;
 };
 
 type Procedure = {
@@ -123,6 +125,16 @@ const PatientStateView = (
     return Math.round(num * 10) / 10 + '%';
   };
 
+  const num_to_color = (num: number | null) => {
+    if (!num || num <= 33) {
+      return 'bad';
+    }
+    if (num <= 66) {
+      return 'average';
+    }
+    return 'good';
+  };
+
   return (
     <>
       <Section title="Patient State">
@@ -132,20 +144,30 @@ const PatientStateView = (
               {patient.stat || 'No patient detected'}
             </LabeledList.Item>
             <LabeledList.Item label="Blood Type">
-              {patient.blood_type || 'Unable to determine blood type'}
+              {patient.blood_type || 'Unknown'}
+            </LabeledList.Item>
+            <LabeledList.Item label="Heart Rate">
+              {patient.heartRate ? patient.heartRate + ' BPM' : 'No pulse'}
             </LabeledList.Item>
             <LabeledList.Item label="Health">
               <ProgressBar
                 value={patient.health || 0}
                 minValue={patient.minHealth || -100}
                 maxValue={patient.maxHealth || 100}
-                color={
-                  patient.health !== null && patient.health >= 0
-                    ? 'good'
-                    : 'average'
-                }>
+                color={num_to_color(patient.health)}>
                 <AnimatedNumber
                   value={patient.health || 0}
+                  format={num_to_percent}
+                />
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item label="Blood Level">
+              <ProgressBar
+                value={patient.bloodVolumePercent || 0}
+                color={num_to_color(patient.bloodVolumePercent)}
+                maxValue={100}>
+                <AnimatedNumber
+                  value={patient.bloodVolumePercent || 0}
                   format={num_to_percent}
                 />
               </ProgressBar>


### PR DESCRIPTION
Operating consoles now reports patient blood volume and ""Heart rate"". 

We don't have real heart rate, so this number is faked, based on some conditions about the patient. _(One day it will not be faked, though.)_ The primary intent of this is to tell you when their heart is stopped and they require CPR or defibrillator, but it can also show you stuff like "are they in crit" if their heart rate is very high. 