### PR TITLE
Makes some loadout-only items obtainable ingame.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5708,6 +5708,7 @@
 #include "maplestation_modules\code\modules\vehicles\mecha\equipment\weapons\missile.dm"
 #include "maplestation_modules\code\modules\vehicles\mecha\equipment\weapons\ppc.dm"
 #include "maplestation_modules\code\modules\vending\_vending.dm"
+#include "maplestation_modules\code\modules\vending\clothesmate.dm"
 #include "maplestation_modules\code\modules\vending\wardrobes.dm"
 #include "maplestation_modules\story_content\albert_equipment\code\albertclothing.dm"
 #include "maplestation_modules\story_content\albert_equipment\code\albertitem.dm"

--- a/maplestation_modules/code/modules/cargo/packs.dm
+++ b/maplestation_modules/code/modules/cargo/packs.dm
@@ -221,3 +221,14 @@
 	access = ACCESS_SURGERY
 	contains = list(/obj/item/autosurgeon/only_on_damaged_organs/lungs)
 	crate_name = "autosurgeon crate"
+
+/datum/supply_pack/costumes_toys/ornithid_mask
+	name = "Ornithid Mask Crate"
+	desc = "A cheap bundle containing all kinds of Ornithid masks."
+	cost = PAYCHECK_COMMAND * 3 //300 cr, selling the crate back actually makes 284 cr
+	contains = list(
+		/obj/item/clothing/mask/breath/ornithid/cardinal,
+		/obj/item/clothing/mask/breath/ornithid/secretary,
+		/obj/item/clothing/mask/breath/ornithid/toucan,
+		/obj/item/clothing/mask/breath/ornithid/bluejay,
+	)

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -1,6 +1,6 @@
 /obj/machinery/vending/clothing
 	added_categories = list(
-	list(
+		list(
 			"name" = "Head",
 			"products" = list(
 				/obj/item/clothing/head/beret/greyscale_badge = 2,

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -21,7 +21,7 @@
 			),
 		),
 
-	list(
+		list(
 			"name" = "Suits & Skirts",
 			"icon" = "vest",
 			"products" = list(

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -7,7 +7,7 @@
 			),
 		),
 
-	list(
+		list(
 			"name" = "Under",
 			"icon" = "shirt",
 			"products" = list(

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -30,7 +30,6 @@
 
 		list(
 			"name" = "Shoes",
-			"icon" = "socks",
 			"products" = list(
 				/obj/item/clothing/shoes/heels = 3,
 			),

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -2,7 +2,6 @@
 	added_categories = list(
 	list(
 			"name" = "Head",
-			"icon" = "hat-cowboy",
 			"products" = list(
 				/obj/item/clothing/head/beret/greyscale_badge = 2,
 			),

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -1,0 +1,44 @@
+/obj/machinery/vending/clothing
+	added_categories = list(
+	list(
+			"name" = "Head",
+			"icon" = "hat-cowboy",
+			"products" = list(
+				/obj/item/clothing/head/beret/greyscale_badge = 2,
+			),
+		),
+
+	list(
+			"name" = "Under",
+			"icon" = "shirt",
+			"products" = list(
+				/obj/item/clothing/under/color/greyscale = 5,
+				/obj/item/clothing/under/color/jumpskirt/greyscale = 5,
+				/obj/item/clothing/under/spacer_turtleneck = 3,
+				/obj/item/clothing/under/spacer_turtleneck/plain = 3,
+				/obj/item/clothing/under/spacer_turtleneck/skirt = 3,
+				/obj/item/clothing/under/spacer_turtleneck/skirt/plain = 3,
+				/obj/item/clothing/under/arbitersuit = 2,
+				/obj/item/clothing/under/chesedsuit = 2,
+			),
+		),
+
+	list(
+			"name" = "Suits & Skirts",
+			"icon" = "vest",
+			"products" = list(
+				/obj/item/clothing/suit/toggle/flannel = 3,
+			),
+		),
+
+	list(
+			"name" = "Shoes",
+			"icon" = "socks",
+			"products" = list(
+				/obj/item/clothing/shoes/heels = 3,
+			),
+		),
+	)
+	added_premium = list(
+		/obj/item/clothing/shoes/heels/fancy = 2,
+	)

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -23,7 +23,6 @@
 
 		list(
 			"name" = "Suits & Skirts",
-			"icon" = "vest",
 			"products" = list(
 				/obj/item/clothing/suit/toggle/flannel = 3,
 			),

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -28,7 +28,7 @@
 			),
 		),
 
-	list(
+		list(
 			"name" = "Shoes",
 			"icon" = "socks",
 			"products" = list(

--- a/maplestation_modules/code/modules/vending/clothesmate.dm
+++ b/maplestation_modules/code/modules/vending/clothesmate.dm
@@ -9,7 +9,6 @@
 
 		list(
 			"name" = "Under",
-			"icon" = "shirt",
 			"products" = list(
 				/obj/item/clothing/under/color/greyscale = 5,
 				/obj/item/clothing/under/color/jumpskirt/greyscale = 5,


### PR DESCRIPTION
Pretty much all the generic modular loadout-only items are now obtainable ingame.
The exceptions to this being story content (including kimonos for technical reasons) and the chesed jacket, which the author wanted to remain loadout-only.

You can get them all at the clothesmate, aside from the Ornithid Masks, which are a 300 credit crate containing one of every mask type.