### PR TITLE
Adds in the caffeinated quirk. More sprint... If you can keep it.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -5353,6 +5353,7 @@
 #include "maplestation_modules\code\datums\greyscale\_greyscale_config.dm"
 #include "maplestation_modules\code\datums\id_trim\jobs.dm"
 #include "maplestation_modules\code\datums\keybinding\communication.dm"
+#include "maplestation_modules\code\datums\mood_events\quirk_mood_events.dm"
 #include "maplestation_modules\code\datums\mood_events\reagent_mood_events.dm"
 #include "maplestation_modules\code\datums\pain\pain.dm"
 #include "maplestation_modules\code\datums\pain\pain_bodyparts.dm"

--- a/maplestation_modules/code/__DEFINES/_module_defines.dm
+++ b/maplestation_modules/code/__DEFINES/_module_defines.dm
@@ -40,3 +40,12 @@
 
 /// Max loadout presets available
 #define MAX_LOADOUTS 5
+
+/// How much "caffeine points" does 1 metabolization tick (0.2u) of a "weak" drink provide
+#define CAFFEINE_POINTS_WEAK 0.1
+
+/// How much "caffeine points" does 1 metabolization tick (0.2u) of coffee provide
+#define CAFFEINE_POINTS_COFFEE 0.2
+
+/// How much "caffeine points" does 1 metabolization tick (0.2u) of energy drinks provide
+#define CAFFEINE_POINTS_ENERGY 0.8 //yes i know energy drinks actually have less caffeine than coffee IRL but this is the FUTURE

--- a/maplestation_modules/code/__DEFINES/signals.dm
+++ b/maplestation_modules/code/__DEFINES/signals.dm
@@ -13,3 +13,6 @@
 
 /// A carbon is being flashed - actually being blinded and taking (eye) damage
 #define COMSIG_CARBON_FLASH_ACT "carbon_flash_act"
+
+/// A carbon drank some caffeine. (signal, caffeine_content)
+#define COMSIG_CARBON_DRINK_CAFFEINE "carbon_drink_caffeine"

--- a/maplestation_modules/code/__DEFINES/traits.dm
+++ b/maplestation_modules/code/__DEFINES/traits.dm
@@ -1,3 +1,5 @@
 // --Adds the trait for the cardcollector quirk
 #define TRAIT_CARDCOLLECTOR "cardcollector"
 #define TRAIT_SHARPNESS_VULNERABLE "sharpnessvulnerable"
+///Gives positive mood on drinking anything caffeinated, kinda generic so people can like coffee, tea, energy drinks, whatever.
+#define TRAIT_CAFFEINE_LOVER "caffeine_lover"

--- a/maplestation_modules/code/datums/mood_events/quirk_mood_events.dm
+++ b/maplestation_modules/code/datums/mood_events/quirk_mood_events.dm
@@ -1,0 +1,19 @@
+/datum/mood_event/no_coffee
+	description = "DON'T TALK TO ME, UNTIL I'VE HAD MY COFFEE!!"
+	mood_change = -8
+
+/datum/mood_event/low_caffeine
+	description = "I'm feeling low on caffeine... I'm so tired..."
+	mood_change = -4
+
+/datum/mood_event/high_caffeine
+	description = "That caffeine really helped me to be so energetic!"
+	mood_change = 2
+
+/datum/mood_event/way_too_high_caffeine
+	description = "CAFFEINE IS MY GOD, AND I AM THE HUMAN INSTRUMENT OF ITS WILL!!!"
+	mood_change = 10
+
+/datum/mood_event/caffeine_death
+	description = "OW GOD MY HEART IS BEATING REALLY FAST- AAAAND I THINK IT JUST STOPPED BEATING."
+	mood_change = -10

--- a/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
+++ b/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
@@ -1,30 +1,45 @@
 
 // Reagent moodlets
 /datum/mood_event/gojuice
-	description = "<span class='nicegreen'>Feeling pumped but calm. I am the sniper bullet in flight, ready to cut through you.</span>\n"
+	description = "Feeling pumped but calm. I am the sniper bullet in flight, ready to cut through you."
 	mood_change = 3
 
 /datum/mood_event/flake
-	description = "<span class='nicegreen'>So good, so good.</span>\n"
+	description = "So good, so good."
 	mood_change = 20
 
 /datum/mood_event/yayo
-	description = "<span class='nicegreen'>Feeling pumped! Let's do this!</span>\n"
+	description = "Feeling pumped! Let's do this!"
 	mood_change = 20
 
 /datum/mood_event/psychite_tea
-	description = "<span class='nicegreen'>I drank some nice, calming psychite tea.</span>\n"
+	description = "I drank some nice, calming psychite tea."
 	mood_change = 8
 
 /datum/mood_event/full_on_pilk
-	description = "<span class='nicegreen'>I am now full on pilk! That was some amazing bubbly goodness!</span>\n"
+	description = "I am now full on pilk! That was some amazing bubbly goodness!"
 	mood_change = 7
 	timeout = 7 MINUTES
 
 /datum/mood_event/pegged
-	description = "<span class='nicegreen'>OH YEAH, NOW I'M PEGGED!</span>\n" //:uncannycat:
+	description = "OH YEAH, NOW IM PEGGED!"
 	mood_change = 8
 	timeout = 7 MINUTES
+
+/datum/mood_event/coffee_lover
+	description = "That coffee hit the spot! I feel so energized!"
+	mood_change = 3
+	timeout = 7 MINUTES
+
+/datum/mood_event/tea_lover
+	description = "That was a most wonderful spot of tea."
+	mood_change = 3
+	timeout = 7 MINUTES
+
+/datum/mood_event/energy_lover
+	description = "That energy drink was the perfect mix to get you energized! Shame it only really tasted of chemicals."
+	mood_change = 0
+	timeout = 12 MINUTES //lasts longer but you're not really happy
 
 // Addiction moodlets
 /datum/mood_event/luciferium_light

--- a/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
+++ b/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
@@ -27,7 +27,7 @@
 	timeout = 7 MINUTES
 
 /datum/mood_event/coffee_lover
-	description = "That coffee hit the spot! I feel so energized!"
+	description = "That coffee was truly delectable!"
 	mood_change = 3
 	timeout = 7 MINUTES
 

--- a/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
+++ b/maplestation_modules/code/datums/mood_events/reagent_mood_events.dm
@@ -22,7 +22,7 @@
 	timeout = 7 MINUTES
 
 /datum/mood_event/pegged
-	description = "OH YEAH, NOW IM PEGGED!"
+	description = "OH YEAH, NOW I'M PEGGED!" //:uncannycat:
 	mood_change = 8
 	timeout = 7 MINUTES
 

--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -43,7 +43,7 @@
 	mob_trait = TRAIT_CAFFEINE_LOVER //Might aswell love the drinks while we're at it
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	gain_text = span_notice("You can't wait to start your day with a nice energizing drink!")
-	lose_text = span_danger("You realize excess amounts caffeine likely has detrimental effects on your cardiovascular system.")
+	lose_text = span_danger("You realize excessive amounts of caffeine likely has detrimental effects on your cardiovascular system.")
 	medical_record_text = "Patient snatched the observation officer's coffee, drank it and then asked for seconds."
 	/// Did we drink literally anything caffeinated in the round?
 	var/caffeine_drank = FALSE

--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -60,7 +60,7 @@
 
 /datum/quirk/caffeinated/add(client/client_source)
 	adjust_sprint_multipliers(0.33, 0.2)
-	RegisterSignals(quirk_holder, list(COMSIG_CARBON_DRINK_CAFFEINE), PROC_REF(drank_caffeine))
+	RegisterSignals(quirk_holder, COMSIG_CARBON_DRINK_CAFFEINE, PROC_REF(drank_caffeine))
 	quirk_holder.add_mood_event("caffeine", /datum/mood_event/no_coffee)
 
 /datum/quirk/caffeinated/process(seconds_per_tick)
@@ -77,7 +77,7 @@
 		if(!caffeine_overdosed)
 			quirk_holder.add_mood_event("caffeine", /datum/mood_event/way_too_high_caffeine)
 			caffeine_overdosed = TRUE
-			addtimer(CALLBACK(PROC_REF(caffeine_overdose)), 4 MINUTES) //wuh oh
+			addtimer(src, CALLBACK(PROC_REF(caffeine_overdose)), 4 MINUTES) //wuh oh
 		return
 
 	if(caffeine_content > 4)
@@ -102,7 +102,7 @@
 	if(caffeine_overdosed)
 		quirk_holder.add_mood_event("caffeine", /datum/mood_event/caffeine_death)
 		var/mob/living/carbon/quirk_carbon = quirk_holder
-		if(quirk_carbon.can_heartattack())
+		if(quirk_carbon.can_heartattack() && !quirk_carbon.undergoing_cardiac_arrest())
 			to_chat(quirk_carbon, span_userdanger("Your heart stops!"))
 			quirk_carbon.visible_message(span_danger("[quirk_carbon] grabs at their chest and collapses!"), ignored_mobs = quirk_carbon)
 			quirk_carbon.set_heartattack(TRUE)

--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -34,3 +34,89 @@
 	icon = FA_ICON_HEARTBEAT
 	value = 0
 	mob_trait = TRAIT_CPR_CERTIFIED
+
+/datum/quirk/caffeinated
+	name = "Caffeinated"
+	desc = "You just can't imagine a day without some sort of caffeinated beverage. You're slightly weaker without caffeine, but slightly boosted with it."
+	icon = FA_ICON_COFFEE
+	value = 0
+	mob_trait = TRAIT_CAFFEINE_LOVER //Might aswell love the drinks while we're at it
+	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
+	gain_text = span_notice("You can't wait to start your day with a nice energizing drink!")
+	lose_text = span_danger("You realize excess amounts caffeine likely has detrimental effects on your cardiovascular system.")
+	medical_record_text = "Patient snatched the observation officer's coffee, drank it and then asked for seconds."
+	/// Did we drink literally anything caffeinated in the round?
+	var/caffeine_drank = FALSE
+	/// Are we going to fucking die?
+	var/caffeine_overdosed = FALSE
+	/// The current sprint length multiplier
+	var/sprint_length_multiplier = 1
+	/// The current sprint regen multiplier
+	var/sprint_regen_multiplier = 1
+	/// How much caffeine is currently in our system
+	var/caffeine_content = 0
+	/// Decay rate on caffeine content, pretty much for varedits
+	var/caffeine_decay_rate = 0.05
+
+/datum/quirk/caffeinated/add(client/client_source)
+	adjust_sprint_multipliers(0.33, 0.2)
+	RegisterSignals(quirk_holder, list(COMSIG_CARBON_DRINK_CAFFEINE), PROC_REF(drank_caffeine))
+	quirk_holder.add_mood_event("caffeine", /datum/mood_event/no_coffee)
+
+/datum/quirk/caffeinated/process(seconds_per_tick)
+	if(HAS_TRAIT(quirk_holder, TRAIT_NOMETABOLISM))
+		return
+	if(!caffeine_drank)
+		return
+
+	if(caffeine_content > 0)
+		caffeine_content = max(caffeine_content - caffeine_decay_rate * seconds_per_tick, 0)
+
+	if(caffeine_content >= 400 || caffeine_overdosed) //we're becoming downright godly at this point, also you have to either slam down >100 units of energy drinks back-to-back or >400 units of coffee.
+		adjust_sprint_multipliers(2, 4)
+		if(!caffeine_overdosed)
+			quirk_holder.add_mood_event("caffeine", /datum/mood_event/way_too_high_caffeine)
+			caffeine_overdosed = TRUE
+			addtimer(CALLBACK(PROC_REF(caffeine_overdose)), 4 MINUTES) //wuh oh
+		return
+
+	if(caffeine_content > 4)
+		quirk_holder.add_mood_event("caffeine", /datum/mood_event/high_caffeine)
+		adjust_sprint_multipliers(1.25, 1.5)
+		return
+
+	if(caffeine_content <= 4)
+		quirk_holder.add_mood_event("caffeine", /datum/mood_event/low_caffeine)
+		adjust_sprint_multipliers(0.75, 0.5)
+		return
+
+	//We should've returned by now, if we didn't, that means caffeine_content is somehow not a number
+	CRASH("Someone has transcended spacetime and become so caffeinated that it's not even a number anymore.")
+
+/datum/quirk/caffeinated/proc/drank_caffeine(mob/living/carbon/source, beverage_caffeine_content)
+	if(!caffeine_drank)
+		caffeine_drank = TRUE
+	caffeine_content += beverage_caffeine_content
+
+/datum/quirk/caffeinated/proc/caffeine_overdose()
+	if(caffeine_overdosed)
+		quirk_holder.add_mood_event("caffeine", /datum/mood_event/caffeine_death)
+		var/mob/living/carbon/quirk_carbon = quirk_holder
+		if(quirk_carbon.can_heartattack())
+			to_chat(quirk_carbon, span_userdanger("Your heart stops!"))
+			quirk_carbon.visible_message(span_danger("[quirk_carbon] grabs at their chest and collapses!"), ignored_mobs = quirk_carbon)
+			quirk_carbon.set_heartattack(TRUE)
+		caffeine_overdosed = FALSE
+
+/datum/quirk/caffeinated/proc/adjust_sprint_multipliers(new_sprint_length, new_sprint_regen)
+	if((new_sprint_length == sprint_length_multiplier) && (new_sprint_regen == sprint_regen_multiplier))
+		return
+	var/mob/living/carbon/human/quirk_human = quirk_holder
+	//Reset to 1.
+	quirk_human.sprint_length_max /= sprint_length_multiplier
+	quirk_human.sprint_regen_per_second /= sprint_regen_multiplier
+	sprint_length_multiplier = new_sprint_length
+	sprint_regen_multiplier = new_sprint_regen
+	quirk_human.sprint_length_max *= new_sprint_length
+	quirk_human.sprint_regen_per_second *= new_sprint_regen
+

--- a/maplestation_modules/code/modules/clothing/suits/loadout_suits.dm
+++ b/maplestation_modules/code/modules/clothing/suits/loadout_suits.dm
@@ -52,3 +52,4 @@
 	icon_state = "chesed_jacket"
 	worn_icon = 'maplestation_modules/icons/mob/clothing/suit.dmi'
 	blood_overlay_type = "armor"
+	clothing_traits = list(TRAIT_CAFFEINE_LOVER)

--- a/maplestation_modules/code/modules/clothing/under/loadout_under.dm
+++ b/maplestation_modules/code/modules/clothing/under/loadout_under.dm
@@ -73,5 +73,5 @@
 	icon = 'maplestation_modules/icons/obj/clothing/under/ornithid_clothes.dmi'
 	worn_icon = 'maplestation_modules/icons/mob/clothing/under/ornithid_clothes.dmi'
 	icon_state = "chesed_suit"
-
+	clothing_traits = list(TRAIT_CAFFEINE_LOVER)
 

--- a/maplestation_modules/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/maplestation_modules/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -226,3 +226,121 @@
 	icon_state = "blood_wine"
 	name = "Tiziran Blood Wine"
 	desc = "A wine made from fermented blood originating from Tizira. Despite the name, the drink does not taste of blood."
+
+//the big chunk of caffeine-related additions
+
+//Weak-Level Caffeinated Drinks
+/datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/ethanol/irishcoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/pumpkin_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick) //girl, you are OPPRESSING the coffee
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/medicine/painkiller/aspirin_para_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick)
+
+/datum/reagent/consumable/ethanol/bastion_bourbon/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+/datum/reagent/consumable/tea/arnold_palmer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_WEAK * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+//Coffee-Level Caffeinated Drinks
+
+/datum/reagent/consumable/coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER)) //we love coffee.
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/ethanol/thirteenloko/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+
+/datum/reagent/consumable/icecoffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/hot_ice_coffee/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/soy_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/coffee_lover)
+
+/datum/reagent/consumable/tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+/datum/reagent/consumable/icetea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+/datum/reagent/consumable/green_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+/datum/reagent/consumable/ice_greentea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_COFFEE * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+//Energy-Level Caffeinated Drinks
+
+/datum/reagent/consumable/green_hill_tea/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_ENERGY * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/tea_lover)
+
+/datum/reagent/consumable/grey_bull/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_ENERGY * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/energy_lover)
+
+/datum/reagent/consumable/monkey_energy/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	SEND_SIGNAL(affected_mob, COMSIG_CARBON_DRINK_CAFFEINE, CAFFEINE_POINTS_ENERGY * seconds_per_tick)
+	if(HAS_TRAIT(affected_mob, TRAIT_CAFFEINE_LOVER))
+		affected_mob.add_mood_event("caffeine_lover", /datum/mood_event/energy_lover)
+


### PR DESCRIPTION
**THE BALANCING IN THIS PR IS NOWHERE NEAR FINAL. TESTMERGE BEFORE MERGING IF POSSIBLE.**

This PR adds in the "Caffeinated" quirk, a quirk all about beverages with that tasty, amazing molecule known as 
1,3,7-Trimethylxanthine.

![image](https://github.com/MrMelbert/MapleStationCode/assets/13697285/75473684-ad1c-4814-8f35-1d9a5690a685)

When starting the round, you have a huge negative moodlet and very low sprint energy, this lasts until you take your first sip of a caffeinated beverage, and pretty much immediately after, you won't ever drop that low again.

From there, drinking a modest amount of caffeinated beverage will allow you to feel energetic, and gain more sprint energy than a normal crew member! You will have less energy than a crew member if your caffeine levels drop low though, so make sure to get a refill once in a while.

You also get some moodlets depending on the type of caffeinated beverage. Energy drinks for example, do not change your mood, because they taste like chemicals. If you wear two specific pieces of clothing, you get the trait that makes you get these moodlets as a small easter egg.

A bunch of drinks were given the caffeinated treatment. They can be weak (half as much as coffee), coffee-equivalent... Or energy drink, which is about 4x as good as coffee. I don't recommend slamming down several energy drink cans back-to-back. It might be bad for you.

This PR does not add sprint modifiers to caffeinated beverages themselves. Those will require some code work to add a proper sprint modifier system.

This PR also doesn't add the Charged Lemonade. Yet.