### PR TITLE
Changes one character, fixes the entirety of caffeine.

### DIFF
--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -60,7 +60,7 @@
 
 /datum/quirk/caffeinated/add(client/client_source)
 	adjust_sprint_multipliers(0.33, 0.2)
-	RegisterSignals(quirk_holder, COMSIG_CARBON_DRINK_CAFFEINE, PROC_REF(drank_caffeine))
+	RegisterSignal(quirk_holder, COMSIG_CARBON_DRINK_CAFFEINE, PROC_REF(drank_caffeine))
 	quirk_holder.add_mood_event("caffeine", /datum/mood_event/no_coffee)
 
 /datum/quirk/caffeinated/process(seconds_per_tick)


### PR DESCRIPTION
proof of fixing:
![image](https://github.com/MrMelbert/MapleStationCode/assets/13697285/a245c427-5bd1-4324-ab6c-65f35ea6124a)

Caffeinated now works properly.
There are some things to be said about good coding practices given how this bug came about, but that's a discussion on upstream's end, not ours.