### PR TITLE
Vitals Scanner Fixes

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -399,7 +399,7 @@
 	else
 		return(jointext(render_list, ""))
 
-/proc/chemscan(mob/living/user, mob/living/target)
+/proc/chemscan(mob/living/user, mob/living/target, tochat = TRUE) // NON-MODULE CHANGE
 	if(user.incapacitated())
 		return
 
@@ -461,8 +461,13 @@
 				render_list += "<span class='alert ml-1'>Subject is extremely allergic to the following chemicals:</span>\n"
 				render_list += "<span class='alert ml-2'>[allergies]</span>\n"
 
-		// we handled the last <br> so we don't need handholding
-		to_chat(user, examine_block(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		// NON-MODULE CHANGE
+		if(tochat)
+			// we handled the last <br> so we don't need handholding
+			to_chat(user, examine_block(jointext(render_list, "")), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
+		else
+			return jointext(render_list, "")
+		// NON-MODULE CHANGE END
 
 /obj/item/healthanalyzer/AltClick(mob/user)
 	..()

--- a/maplestation_modules/code/game/objects/structures/vital_floor_scanner.dm
+++ b/maplestation_modules/code/game/objects/structures/vital_floor_scanner.dm
@@ -169,7 +169,7 @@
 
 /obj/machinery/vital_floor_scanner/screwdriver_act(mob/living/user, obj/item/tool)
 	balloon_alert(user, "deconstructing...")
-	if(!tool.use_tool(src, user, 4 SECONDS))
+	if(!tool.use_tool(src, user, 4 SECONDS, volume = 50))
 		return ITEM_INTERACT_BLOCKING
 
 	deconstruct(TRUE)

--- a/maplestation_modules/code/game/objects/structures/vital_floor_scanner.dm
+++ b/maplestation_modules/code/game/objects/structures/vital_floor_scanner.dm
@@ -54,6 +54,7 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	update_appearance(UPDATE_OVERLAYS)
+	register_context()
 
 /obj/machinery/vital_floor_scanner/examine(mob/user)
 	. = ..()
@@ -61,6 +62,11 @@
 		. += span_notice("To use: Step on the pad and wait for the scan to complete. \
 			Your results will be displayed on nearby vitals monitors. \
 			<b>Examine</b> the monitor for a detailed breakdown of your vitals.")
+
+/obj/machinery/vital_floor_scanner/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(held_item?.tool_behaviour == TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/vital_floor_scanner/update_overlays()
 	. = ..()
@@ -108,9 +114,9 @@
 			reader.set_patient(occupant)
 			return
 
-/obj/machinery/vital_floor_scanner/proc/disable_vitals_nearby()
+/obj/machinery/vital_floor_scanner/proc/disable_vitals_nearby(mob/leaving = occupant)
 	for(var/obj/machinery/computer/vitals_reader/reader in range(LINK_RANGE, src))
-		if(reader.patient == occupant)
+		if(reader.active && reader.patient == leaving)
 			reader.toggle_active()
 			return
 
@@ -146,7 +152,7 @@
 		scan_effect()
 
 	else if(!isnull(old_occupant))
-		disable_vitals_nearby()
+		disable_vitals_nearby(old_occupant)
 
 /obj/machinery/vital_floor_scanner/proc/scan_effect()
 	var/image/scan_effect = image(
@@ -160,6 +166,14 @@
 	animate(scan_effect, alpha = 200, time = SCAN_EFFECT_DURATION * 0.25, loop = -1)
 	SET_PLANE_EXPLICIT(scan_effect, occupant.plane, occupant)
 	occupant.flick_overlay_view(scan_effect, SCAN_EFFECT_DURATION)
+
+/obj/machinery/vital_floor_scanner/screwdriver_act(mob/living/user, obj/item/tool)
+	balloon_alert(user, "deconstructing...")
+	if(!tool.use_tool(src, user, 4 SECONDS))
+		return ITEM_INTERACT_BLOCKING
+
+	deconstruct(TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 #undef LINK_RANGE
 #undef SCAN_EFFECT_DURATION


### PR DESCRIPTION
- Vitals Floor Scanner can be deconstructed
- Vitals Floor Scanner disables the screen instantly on exit
- Vitals Screen shows you chemicals