### PR TITLE
Lizard Livers Let You Eat Rat (Safely) 

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -59,6 +59,12 @@
 /datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER
 
+	// NON-MODULE CHANGE
+	var/obj/item/organ/internal/liver/liver = eater.get_organ_slot(ORGAN_SLOT_LIVER)
+	if(is_type_in_typecache(parent, liver?.disease_free_foods))
+		return
+	// NON-MODULE CHANGE END
+
 	if(!eater.has_quirk(/datum/quirk/deviant_tastes))
 		eater.add_mood_event("disgust", /datum/mood_event/disgust/dirty_food)
 

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6449,6 +6449,7 @@
 #include "maplestation_modules\code\modules\surgery\organs\autosurgeon.dm"
 #include "maplestation_modules\code\modules\surgery\organs\ears.dm"
 #include "maplestation_modules\code\modules\surgery\organs\eyes.dm"
+#include "maplestation_modules\code\modules\surgery\organs\liver.dm"
 #include "maplestation_modules\code\modules\surgery\organs\tails.dm"
 #include "maplestation_modules\code\modules\surgery\organs\tongue.dm"
 #include "maplestation_modules\code\modules\uplink\uplink_devices.dm"

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,5 +1,6 @@
 // -- Lizardperson species additions --
 /datum/species/lizard
+	mutantliver = /obj/item/organ/internal/liver/lizard
 
 /datum/species/lizard/get_species_speech_sounds(sound_type)
 	// These sounds have been ported from Goonstation.

--- a/maplestation_modules/code/modules/surgery/organs/liver.dm
+++ b/maplestation_modules/code/modules/surgery/organs/liver.dm
@@ -1,0 +1,14 @@
+// Liver stuff
+/obj/item/organ/internal/liver
+	/// Typecache of food we can eat that will never give us disease.
+	var/list/disease_free_foods
+
+// Lizard liver to Let Them Eat Rat
+/obj/item/organ/internal/liver/lizard
+	name = "lizardperson liver"
+	desc = "A liver native to a Lizardperson of Tiziran... or maybe one of its colonies."
+	color = COLOR_VERY_DARK_LIME_GREEN
+
+/obj/item/organ/internal/liver/lizard/Initialize(mapload)
+	. = ..()
+	disease_free_foods = typecacheof(/obj/item/food/deadmouse)


### PR DESCRIPTION
Lizardperson Livers can safely consume rats without risk of catching disease. They've adapted to it. Don't think about it too much. 