### PR TITLE
Buffing leylines

### DIFF
--- a/maplestation_modules/code/__DEFINES/magic/magic_defines.dm
+++ b/maplestation_modules/code/__DEFINES/magic/magic_defines.dm
@@ -5,7 +5,7 @@
 
 // Assumes we are at average leyline intensity
 #define LEYLINE_BASE_CAPACITY 600
-#define LEYLINE_BASE_RECHARGE 0.1 // Per second, we recharge this much mana
+#define LEYLINE_BASE_RECHARGE 2 // Per second, we recharge this much mana
 
 #define MAGIC_MATERIAL_NAME "Volite"
 #define MAGIC_UNIT_OF_MEASUREMENT "Vol"

--- a/maplestation_modules/code/modules/magic/mana/sources/leylines/leyline_intensities.dm
+++ b/maplestation_modules/code/modules/magic/mana/sources/leylines/leyline_intensities.dm
@@ -1,9 +1,4 @@
 GLOBAL_LIST_INIT(leyline_intensities, list(
-	/datum/leyline_intensity/none = 200,
-	/datum/leyline_intensity/minimal = 8000,
-	/datum/leyline_intensity/extremely_low = 11000,
-	/datum/leyline_intensity/low = 5000,
-	/datum/leyline_intensity/below_average = 1000,
 	/datum/leyline_intensity/average = 500,
 	/datum/leyline_intensity/above_average = 100,
 	/datum/leyline_intensity/high = 2,


### PR DESCRIPTION
Increases base mana recharge.
Leyline strength picked will be average or higher, so will always be at base mana recharge rate or higher.