### PR TITLE
QoL / tweaks to stackable item component

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -662,21 +662,14 @@ generate/load female uniform sprites matching all previously decided variables
 	use_height_offset = TRUE,
 )
 
+	// NON-MODULE CHANGE // UPSTREAM ME
 	//Find a valid icon_state from variables+arguments
-	var/t_state
-	if(override_state)
-		t_state = override_state
-	else
-		t_state = !isinhands ? (worn_icon_state ? worn_icon_state : icon_state) : (inhand_icon_state ? inhand_icon_state : icon_state)
-
+	var/t_state = override_state || (isinhands ? inhand_icon_state : worn_icon_state) || icon_state
 	//Find a valid icon file from variables+arguments
-	var/file2use
-	if(override_file)
-		file2use = override_file
-	else
-		file2use = !isinhands ? (worn_icon ? worn_icon : default_icon_file) : default_icon_file
+	var/file2use = override_file || (isinhands ? null : worn_icon) || default_icon_file
 	//Find a valid layer from variables+arguments
-	var/layer2use = alternate_worn_layer ? alternate_worn_layer : default_layer
+	var/layer2use = alternate_worn_layer || default_layer
+	// NON-MODULE CHANGE END
 
 	var/mutable_appearance/standing
 	if(female_uniform)
@@ -687,7 +680,7 @@ generate/load female uniform sprites matching all previously decided variables
 	//Get the overlays for this item when it's being worn
 	//eg: ammo counters, primed grenade flashes, etc.
 	var/list/worn_overlays = worn_overlays(standing, isinhands, file2use)
-	if(worn_overlays?.len)
+	if(length(worn_overlays)) // NON-MODULE CHANGE
 		if(!isinhands && default_layer && ishuman(loc) && use_height_offset)
 			var/mob/living/carbon/human/human_loc = loc
 			if(human_loc.get_mob_height() != HUMAN_HEIGHT_MEDIUM)

--- a/maplestation_modules/code/__DEFINES/signals.dm
+++ b/maplestation_modules/code/__DEFINES/signals.dm
@@ -3,9 +3,6 @@
 /// (Flavor text should stay at the very very bottom though)
 #define COMSIG_LIVING_LATE_EXAMINE "late_examine"
 
-/// Item generating their worn icon
-#define COMSIG_ITEM_WORN_ICON_MADE "item_worn_icon_made"
-
 /// Entering or exiting a vent.
 #define COMSIG_HANDLE_VENTCRAWLING "handle_ventcrawl"
 	/// Return to block entrance / exit

--- a/maplestation_modules/code/modules/clothing/glasses/hud_eyepatches.dm
+++ b/maplestation_modules/code/modules/clothing/glasses/hud_eyepatches.dm
@@ -8,22 +8,21 @@
 	. = ..()
 	AddComponent(/datum/component/stackable_item, \
 		wearables = list(/obj/item/clothing/glasses/hud), \
+		wearable_descriptor = "a HUD", \
 		can_stack = CALLBACK(src, PROC_REF(can_attach_hud)), \
 		on_drop = CALLBACK(src, PROC_REF(on_drop_patch)), \
 	)
 
 /obj/item/clothing/glasses/eyepatch/proc/can_attach_hud(obj/item/source, obj/item/clothing/glasses/hud/incoming_hud, mob/user)
 	// Basically, stops you from attaching HUDglasses. We only want the ones with one eye covered.
-	return (incoming_hud.flash_protect == 0 && incoming_hud.tint == 0)
+	return !(incoming_hud.flags_cover & GLASSESCOVERSEYES)
 
 /obj/item/clothing/glasses/eyepatch/proc/on_drop_patch(obj/item/clothing/glasses/hud/equipped_hud, mob/living/carbon/user, silent)
-	if(!istype(user))
+	if(!equipped_hud.hud_type)
 		return
-	if(user.glasses != src)
-		return
-	// This is HUGE hack but hud glasses rely on the user.glasses var to be set to the hud glasses
-	// If this ever changes this must be removed because then it will call dropped twice, which isn't bad but can be weird
-	var/obj/item/pre_slot = user.glasses
-	user.glasses = equipped_hud
-	equipped_hud.dropped(user, silent)
-	user.glasses = pre_slot
+
+	// A bit of a hack but HUD code checks that user.glasses == equipped_hud
+	// Which it is not here
+	// So even though equipping the hud works fine, unequipping it will fail
+	var/datum/atom_hud/our_hud = GLOB.huds[equipped_hud.hud_type]
+	our_hud.hide_from(user)


### PR DESCRIPTION
- Examining items that are stackable gives you a hint what you may be able to attach. 
- I realized I could use an existing signal rather than add a new one, so I changed it to use it. 
- I let the intrusive thoughts win and rewrote a bit of `build_worn_icon` to be more readable. 
- Minor improvements thanks to the recent merge. 