### PR TITLE
Removes Unused Ma

### DIFF
--- a/maplestation_modules/code/modules/art/statuettes.dm
+++ b/maplestation_modules/code/modules/art/statuettes.dm
@@ -149,7 +149,6 @@
 		current_target = original.content_ma
 	else
 		current_target = target.appearance
-	var/mutable_appearance/ma = current_target
 	user.balloon_alert(user, "sculpting [target.name]")
 
 /obj/item/modeling_block/attack_self(mob/user)


### PR DESCRIPTION
Gets rid of the warning of defined but unused variable.
![dances5](https://github.com/MrMelbert/MapleStationCode/assets/16868239/770c112b-142e-48e8-954a-fb3d5a521595)
