### PR TITLE
Being held at gunpoint stops you from using your headset

### DIFF
--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -43,7 +43,7 @@
 		COMSIG_MOB_FIRED_GUN,
 		COMSIG_MOVABLE_SET_GRAB_STATE,
 		COMSIG_LIVING_START_PULL), PROC_REF(trigger_reaction))
-	RegisterSignal(targ, COMSIG_MOVABLE_USING_RADIO, PROC_REF(radio_trigger_reaction))
+	RegisterSignal(targ, COMSIG_MOVABLE_USING_RADIO, PROC_REF(radio_trigger_reaction)) // NON-MODULE CHANGE
 	RegisterSignal(targ, COMSIG_ATOM_EXAMINE, PROC_REF(examine_target))
 	RegisterSignal(targ, COMSIG_LIVING_PRE_MOB_BUMP, PROC_REF(block_bumps_target))
 	RegisterSignals(targ, list(COMSIG_LIVING_DISARM_HIT, COMSIG_LIVING_GET_PULLED), PROC_REF(cancel))
@@ -152,6 +152,7 @@
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(async_trigger_reaction))
 
+// NON-MODULE CHANGE
 /datum/component/gunpoint/proc/radio_trigger_reaction(datum/source, obj/item/radio)
 	SIGNAL_HANDLER
 	if(radio.loc != source)
@@ -159,6 +160,7 @@
 	INVOKE_ASYNC(src, PROC_REF(async_trigger_reaction))
 	to_chat(source, span_warning("You fail to reach [radio]!"))
 	return COMPONENT_CANNOT_USE_RADIO
+// NON-MODULE CHANGE END
 
 /datum/component/gunpoint/proc/async_trigger_reaction()
 	var/mob/living/shooter = parent

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -43,6 +43,7 @@
 		COMSIG_MOB_FIRED_GUN,
 		COMSIG_MOVABLE_SET_GRAB_STATE,
 		COMSIG_LIVING_START_PULL), PROC_REF(trigger_reaction))
+	RegisterSignal(targ, COMSIG_MOVABLE_USING_RADIO, PROC_REF(radio_trigger_reaction))
 	RegisterSignal(targ, COMSIG_ATOM_EXAMINE, PROC_REF(examine_target))
 	RegisterSignal(targ, COMSIG_LIVING_PRE_MOB_BUMP, PROC_REF(block_bumps_target))
 	RegisterSignals(targ, list(COMSIG_LIVING_DISARM_HIT, COMSIG_LIVING_GET_PULLED), PROC_REF(cancel))
@@ -150,6 +151,14 @@
 /datum/component/gunpoint/proc/trigger_reaction()
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(async_trigger_reaction))
+
+/datum/component/gunpoint/proc/radio_trigger_reaction(datum/source, obj/item/radio)
+	SIGNAL_HANDLER
+	if(radio.loc != source)
+		return NONE
+	INVOKE_ASYNC(src, PROC_REF(async_trigger_reaction))
+	to_chat(source, span_warning("You fail to reach [radio]!"))
+	return COMPONENT_CANNOT_USE_RADIO
 
 /datum/component/gunpoint/proc/async_trigger_reaction()
 	var/mob/living/shooter = parent


### PR DESCRIPTION
What
- Trying to use your headset radio while at gunpoint will block the attempt and trigger the gunpoint reaction fire. 
- Speaking into handheld radios also fails (with `.r` or `.l`). 
- However you can still speak into nearby intercoms (with `.i`)
- This also doesn't affect radio implant. And genetics antenna. 
- Also, open-micing is completely unaffected. 

Why
- Makes gunpoint a bit more usable for setting up hostage situations. Stop people from immediately saying `; Hey I'm being held at gunpoint by Urist McSyndie`. 
- And if you're holding someone at gunpoint and want them to say something to the station you can just use open mic. 