### PR TITLE
Fixes round and station time.

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -9,13 +9,15 @@
 /proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
 	if(!wtime)
 		wtime = world.time
-	return time2text(wtime - GLOB.timezoneOffset, format)
+	return time2text(wtime, format, 0)
 
 /proc/station_time(display_only = FALSE, wtime=world.time)
-	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) + (display_only? GLOB.timezoneOffset : 0)
 
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)
-	return time2text(station_time(TRUE, wtime), format)
+	if(!wtime)
+		wtime = world.time
+	return time2text(station_time(TRUE, wtime), format, 0)
 
 /proc/station_time_debug(force_set)
 	if(isnum(force_set))


### PR DESCRIPTION
This PR fixes round and station time being incredibly broken on any machine that has a timezone that isn't "0".

Non-modular changes that aren't marked ahead, but it's likely upstream is going to either pretty much port this or refactor the code outright.

Also station time doesn't exactly have feature parity with how it's supposed to work, but only really manifests in some slightly different hour offsets. The original way it worked _does not work in 515_, as negative values no longer work in time2text.