### PR TITLE
Syringe Gun Rework

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -62,6 +62,10 @@
 	if(!iscarbon(parent) || !isitem(I))
 		return COMPONENT_INCOMPATIBLE
 
+	if(QDELETED(I))
+		stack_trace("QDELETING item [I] trying to embedded!")
+		return COMPONENT_INCOMPATIBLE
+
 	if(part)
 		limb = part
 	src.embed_chance = embed_chance
@@ -234,7 +238,7 @@
 		if(to_hands)
 			INVOKE_ASYNC(to_hands, TYPE_PROC_REF(/mob, put_in_hands), weapon)
 		else
-			weapon.forceMove(get_turf(victim))
+			weapon.forceMove(victim.drop_location())
 
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -43,9 +43,9 @@
 		missing -= BP.body_zone
 		for(var/obj/item/I in BP.embedded_objects)
 			if(I.isEmbedHarmless())
-				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] stuck to [t_his] [BP.name]!</B>\n"
+				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] stuck to [t_his] [BP.plaintext_zone]!</B>\n"
 			else
-				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] embedded in [t_his] [BP.name]!</B>\n"
+				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] embedded in [t_his] [BP.plaintext_zone]!</B>\n"
 		for(var/i in BP.wounds)
 			var/datum/wound/W = i
 			msg += "[W.get_examine_description(user)]\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -139,9 +139,9 @@
 		missing -= body_part.body_zone
 		for(var/obj/item/I in body_part.embedded_objects)
 			if(I.isEmbedHarmless())
-				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] stuck to [t_his] [body_part.name]!</B>\n"
+				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] stuck to [t_his] [body_part.plaintext_zone]!</B>\n"
 			else
-				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] embedded in [t_his] [body_part.name]!</B>\n"
+				msg += "<B>[t_He] [t_has] [icon2html(I, user)] \a [I] embedded in [t_his] [body_part.plaintext_zone]!</B>\n"
 
 		for(var/i in body_part.wounds)
 			var/datum/wound/iter_wound = i
@@ -239,31 +239,20 @@
 			msg += "[span_deadsay("<b>[t_He] resemble[p_s()] a crushed, empty juice pouch.</b>")]\n"
 
 	if(is_bleeding())
-		var/list/obj/item/bodypart/bleeding_limbs = list()
+		var/list/bleeding_limbs = list()
 		var/list/obj/item/bodypart/grasped_limbs = list()
 
 		for(var/obj/item/bodypart/body_part as anything in bodyparts)
 			if(body_part.get_modified_bleed_rate())
-				bleeding_limbs += body_part
+				bleeding_limbs += body_part.plaintext_zone
 			if(body_part.grasped_by)
-				grasped_limbs += body_part
-
-		var/num_bleeds = LAZYLEN(bleeding_limbs)
+				grasped_limbs += body_part.plaintext_zone
 
 		var/list/bleed_text
 		if(appears_dead)
 			bleed_text = list("<span class='deadsay'><B>Blood is visible in [t_his] open")
 		else
-			bleed_text = list("<B>[t_He] [t_is] bleeding from [t_his]")
-
-		switch(num_bleeds)
-			if(1 to 2)
-				bleed_text += " [bleeding_limbs[1].name][num_bleeds == 2 ? " and [bleeding_limbs[2].name]" : ""]"
-			if(3 to INFINITY)
-				for(var/i in 1 to (num_bleeds - 1))
-					var/obj/item/bodypart/body_part = bleeding_limbs[i]
-					bleed_text += " [body_part.name],"
-				bleed_text += " and [bleeding_limbs[num_bleeds].name]"
+			bleed_text = list("<B>[t_He] [t_is] bleeding from [t_his] [english_list(bleeding_limbs)]")
 
 		if(appears_dead)
 			bleed_text += ", but it has pooled and is not flowing.</span></B>\n"
@@ -273,9 +262,8 @@
 
 			bleed_text += "!</B>\n"
 
-		for(var/i in grasped_limbs)
-			var/obj/item/bodypart/grasped_part = i
-			bleed_text += "[t_He] [t_is] holding [t_his] [grasped_part.name] to slow the bleeding!\n"
+		for(var/limb in grasped_limbs)
+			bleed_text += "[t_He] [t_is] holding [t_his] [limb] to slow the bleeding!\n"
 
 		msg += bleed_text.Join()
 

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -168,6 +168,23 @@
 /obj/item/ammo_casing/shotgun/dart/attackby()
 	return
 
+// NON-MODULE CHANGE
+/obj/item/ammo_casing/shotgun/dart/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
+	if(!istype(loaded_projectile, /obj/projectile/bullet/dart))
+		return ..()
+
+	var/obj/projectile/bullet/dart/loaded_dart = loaded_projectile
+
+	var/obj/item/reagent_containers/syringe/real_dart = new()
+	real_dart.reagents.maximum_volume = reagents.maximum_volume
+	real_dart.name = name
+	real_dart.item_flags |= DROPDEL
+
+	reagents.trans_to(real_dart, reagents.maximum_volume, transferred_by = user)
+
+	loaded_dart.add_syringe(real_dart)
+	return ..()
+
 /obj/item/ammo_casing/shotgun/dart/bioterror
 	desc = "An improved shotgun dart filled with deadly toxins. Can be injected with up to 30 units of any chemical."
 	reagent_amount = 30

--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -1,3 +1,4 @@
+// NON-MODULE CHANGE : this whole file
 /obj/item/ammo_casing/syringegun
 	name = "syringe gun spring"
 	desc = "A high-power spring that throws syringes."
@@ -5,67 +6,72 @@
 	projectile_type = /obj/projectile/bullet/dart/syringe
 	firing_effect_type = null
 
-/obj/item/ammo_casing/syringegun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
-	if(!loaded_projectile)
-		return
+/obj/item/ammo_casing/syringegun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", atom/fired_from)
+	if(!istype(loaded_projectile, /obj/projectile/bullet/dart))
+		return ..()
+
+	var/obj/projectile/bullet/dart/loaded_dart = loaded_projectile
 	if(istype(loc, /obj/item/gun/syringe))
-		var/obj/item/gun/syringe/SG = loc
-		if(!SG.syringes.len)
-			return
+		var/obj/item/gun/syringe/syringe_gun = loc
+		if(!length(syringe_gun.syringes))
+			return ..()
 
-		var/obj/item/reagent_containers/syringe/S = SG.syringes[1]
+		loaded_dart.add_syringe(popleft(syringe_gun.syringes))
 
-		S.reagents.trans_to(loaded_projectile, S.reagents.total_volume, transferred_by = user)
-		loaded_projectile.name = S.name
-		var/obj/projectile/bullet/dart/D = loaded_projectile
-		D.inject_flags = S.inject_flags
-		SG.syringes.Remove(S)
-		qdel(S)
 	else if(istype(loc, /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun))
 		var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/syringe_gun = loc
-		var/obj/item/reagent_containers/syringe/loaded_syringe = syringe_gun.syringes[1]
-		var/obj/projectile/bullet/dart/shot_dart = loaded_projectile
-		syringe_gun.reagents.trans_to(shot_dart, min(loaded_syringe.volume, syringe_gun.reagents.total_volume), transferred_by = user)
-		shot_dart.name = loaded_syringe.name
-		shot_dart.inject_flags = loaded_syringe.inject_flags
-		LAZYREMOVE(syringe_gun.syringes, loaded_syringe)
-		qdel(loaded_syringe)
+		if(!LAZYLEN(syringe_gun.syringes))
+			return ..()
+
+		loaded_dart.add_syringe(popleft(syringe_gun.syringes))
+		loaded_dart.range *= 4
+
 	return ..()
 
 /obj/item/ammo_casing/chemgun
 	name = "dart synthesiser"
 	desc = "A high-power spring, linked to an energy-based piercing dart synthesiser."
-	projectile_type = /obj/projectile/bullet/dart/piercing
+	projectile_type = /obj/projectile/bullet/dart
 	firing_effect_type = null
 
-/obj/item/ammo_casing/chemgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
-	if(!loaded_projectile)
-		return
+/obj/item/ammo_casing/chemgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", atom/fired_from)
+	if(!istype(loaded_projectile, /obj/projectile/bullet/dart))
+		return ..()
 	if(istype(loc, /obj/item/gun/chem))
-		var/obj/item/gun/chem/CG = loc
-		if(CG.syringes_left <= 0)
-			return
-		CG.reagents.trans_to(loaded_projectile, 15, transferred_by = user)
-		loaded_projectile.name = "piercing chemical dart"
-		CG.syringes_left--
+		var/obj/item/gun/chem/chem_gun = loc
+		if(chem_gun.syringes_left <= 0)
+			return ..()
+
+		var/obj/item/reagent_containers/syringe/synthed_dart = new()
+		synthed_dart.name = "piercing chemical dart"
+		synthed_dart.inject_flags |= INJECT_CHECK_PENETRATE_THICK
+		synthed_dart.item_flags |= DROPDEL
+
+		chem_gun.reagents.trans_to(synthed_dart, synthed_dart.reagents.maximum_volume, transferred_by = user)
+		chem_gun.syringes_left--
+
+		var/obj/projectile/bullet/dart/loaded_dart = loaded_projectile
+		loaded_dart.add_syringe(synthed_dart)
+
 	return ..()
 
 /obj/item/ammo_casing/dnainjector
 	name = "rigged syringe gun spring"
 	desc = "A high-power spring that throws DNA injectors."
-	projectile_type = /obj/projectile/bullet/dnainjector
+	projectile_type = /obj/projectile/bullet/dart/syringe
 	firing_effect_type = null
 
 /obj/item/ammo_casing/dnainjector/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
-	if(!loaded_projectile)
-		return
-	if(istype(loc, /obj/item/gun/syringe/dna))
-		var/obj/item/gun/syringe/dna/SG = loc
-		if(!SG.syringes.len)
-			return
+	if(!istype(loaded_projectile, /obj/projectile/bullet/dart))
+		return ..()
 
-		var/obj/item/dnainjector/S = popleft(SG.syringes)
-		var/obj/projectile/bullet/dnainjector/D = loaded_projectile
-		S.forceMove(D)
-		D.injector = S
+	var/obj/projectile/bullet/dart/loaded_dart = loaded_projectile
+	if(istype(loc, /obj/item/gun/syringe/dna))
+		var/obj/item/gun/syringe/dna/dna_syringe_gun = loc
+		if(!length(dna_syringe_gun.syringes))
+			return ..()
+
+		loaded_dart.add_syringe(popleft(dna_syringe_gun.syringes))
+		loaded_dart.name = "\improper DNA injector"
+
 	return ..()

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -1,50 +1,120 @@
+// NON-MODULE CHANGE : this whole file
 /obj/projectile/bullet/dart
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
 	embedding = null
 	shrapnel_type = null
-	var/inject_flags = null
+	range = 15
+	var/obj/item/syringe
 
-/obj/projectile/bullet/dart/Initialize(mapload)
+/obj/projectile/bullet/dart/proc/add_syringe(obj/item/new_syringe)
+	syringe = new_syringe
+	syringe.forceMove(src)
+
+/obj/projectile/bullet/dart/Exited(atom/movable/gone, direction)
 	. = ..()
-	create_reagents(50, NO_REACT)
+	if(gone == syringe)
+		if(!QDELETED(syringe) && (syringe.item_flags & DROPDEL))
+			qdel(syringe)
+		syringe = null
 
-/obj/projectile/bullet/dart/on_hit(atom/target, blocked = 0, pierce_hit)
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		if(blocked != 100) // not completely blocked
-			if(M.can_inject(target_zone = def_zone, injection_flags = inject_flags)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
-				..()
-				reagents.trans_to(M, reagents.total_volume, methods = INJECT)
-				return BULLET_ACT_HIT
-			else
-				blocked = 100
-				target.visible_message(span_danger("\The [src] is deflected!"), \
-									   span_userdanger("You are protected against \the [src]!"))
+/obj/projectile/bullet/dart/on_range()
+	syringe.forceMove(drop_location())
+	return ..()
 
-	..(target, blocked)
-	reagents.flags &= ~(NO_REACT)
-	reagents.handle_reactions()
+/obj/projectile/bullet/dart/on_hit(mob/living/carbon/target, blocked = 0, pierce_hit)
+	. = ..()
+	if(pierce_hit || isnull(syringe))
+		return .
+	var/obj/item/syringe_ref = syringe
+	if(!istype(target))
+		syringe.forceMove(drop_location())
+		if(!QDELETED(syringe_ref))
+			target.Bumped(syringe_ref) // So it will do stuff like get dusted by the SM
+		return BULLET_ACT_BLOCK
+
+	var/real_zone = target.get_random_valid_zone(def_zone)
+	var/injection_flags = NONE
+	if(istype(syringe, /obj/item/reagent_containers/syringe))
+		var/obj/item/reagent_containers/syringe/real_syringe = syringe
+		injection_flags |= real_syringe.inject_flags
+
+	if(!target.can_inject(target_zone = real_zone, injection_flags = injection_flags))
+		blocked = 100
+
+	if(. == BULLET_ACT_BLOCK || blocked >= 100)
+		syringe.forceMove(drop_location())
+		if(!QDELETED(syringe_ref))
+			target.Bumped(syringe_ref) // Ditto
+		return BULLET_ACT_BLOCK
+
+	syringe = null
+	target.AddComponent( \
+		/datum/component/embedded, \
+		I = syringe_ref, \
+		part = target.get_bodypart(real_zone), \
+		fall_chance = 0, \
+		pain_chance = 0, \
+		rip_time = 1.5 SECONDS, \
+		jostle_chance = 0, \
+	)
 	return BULLET_ACT_HIT
-
-/obj/projectile/bullet/dart/metalfoam/Initialize(mapload)
-	. = ..()
-	reagents.add_reagent(/datum/reagent/aluminium, 15)
-	reagents.add_reagent(/datum/reagent/foaming_agent, 5)
-	reagents.add_reagent(/datum/reagent/toxin/acid/fluacid, 5)
 
 /obj/projectile/bullet/dart/syringe
 	name = "syringe"
 	icon_state = "syringeproj"
 
-/obj/projectile/bullet/dart/syringe/Initialize(mapload)
+// Code to handle what happens when a syringe is embedded in a mob
+/obj/item/reagent_containers/syringe/embedded(mob/living/embedded_target, obj/item/bodypart/part)
 	. = ..()
+	if(!istype(embedded_target))
+		return
+	addtimer(CALLBACK(src, PROC_REF(inject_embedded_target), embedded_target, part), 5 SECONDS)
 
-	// This prevents the Ody from being used as a combat mech spamming RDX/Teslium syringes all over the place.
-	// Other syringe guns are loaded manually with pre-filled syringes which will react chems themselves.
-	// The traitor chem dartgun uses /obj/projectile/bullet/dart/piercing, so this does not impact it.
-	reagents.flags &= ~NO_REACT
+/obj/item/reagent_containers/syringe/proc/inject_embedded_target(mob/living/embedded_target, obj/item/bodypart/part)
+	if(QDELETED(embedded_target) || QDELETED(part))
+		return
+	if(part.owner != embedded_target || !(src in part.embedded_objects))
+		return
+	if(!embedded_target.can_inject(target_zone = part, injection_flags = inject_flags))
+		// This is turbo cringe but embedded itself is cringe so I don't feel so bad
+		var/datum/component/embedded/embed_comp = embedded_target.GetComponent(/datum/component/embedded)
+		embed_comp?.fallOut()
+		update_appearance()
+		return
 
-/obj/projectile/bullet/dart/piercing
-	inject_flags = INJECT_CHECK_PENETRATE_THICK
+	reagents.trans_to(embedded_target, reagents.maximum_volume * (1 / 3), methods = INJECT)
+	if(reagents.total_volume <= 1)
+		// More cringe. When we're done injecting add a chance to fall out moving forward
+		var/datum/component/embedded/embed_comp = embedded_target.GetComponent(/datum/component/embedded)
+		embed_comp?.fall_chance = 20
+		update_appearance()
+		return
+
+	addtimer(CALLBACK(src, PROC_REF(inject_embedded_target), embedded_target, part), 2 SECONDS)
+
+// Code to handle what happens when a DNA injector is embedded in a mob
+/obj/item/dnainjector/embedded(mob/living/embedded_target, obj/item/bodypart/part)
+	. = ..()
+	if(!istype(embedded_target))
+		return
+	addtimer(CALLBACK(src, PROC_REF(inject_embedded_target), embedded_target, part), 5 SECONDS)
+
+/obj/item/dnainjector/proc/inject_embedded_target(mob/living/embedded_target, obj/item/bodypart/part)
+	if(QDELETED(embedded_target) || QDELETED(part))
+		return
+	if(part.owner != embedded_target || !(src in part.embedded_objects))
+		return
+	if(used)
+		// This is also cringe etc etc etc
+		var/datum/component/embedded/embed_comp = embedded_target.GetComponent(/datum/component/embedded)
+		embed_comp?.fallOut()
+		return
+
+	if(embedded_target.can_inject(target_zone = part))
+		inject(embedded_target) // Falls out regardless of success or failure
+
+	used = TRUE
+	update_appearance()
+	addtimer(CALLBACK(src, PROC_REF(inject_embedded_target), embedded_target, part), 5 SECONDS)

--- a/code/modules/projectiles/projectile/bullets/dnainjector.dm
+++ b/code/modules/projectiles/projectile/bullets/dnainjector.dm
@@ -1,4 +1,6 @@
-/obj/projectile/bullet/dnainjector
+// NON-MODULE CHANGE : this whole file
+/*
+/obj/projectile/bullet/dart/dnainjector
 	name = "\improper DNA injector"
 	icon_state = "syringeproj"
 	var/obj/item/dnainjector/injector
@@ -24,3 +26,4 @@
 /obj/projectile/bullet/dnainjector/Destroy()
 	QDEL_NULL(injector)
 	return ..()
+*/

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -284,7 +284,7 @@
 /// Screen alert for being tased, clicking does a resist (like being on fire or w/e)
 /atom/movable/screen/alert/status_effect/tazed
 	name = "Tased!"
-	desc = "Taser electrodes are shocking you! You can resist to try to remove them."
+	desc = "Taser electrodes are shocking you! You can click this or resist to try to remove them."
 	icon_state = "stun"
 
 /atom/movable/screen/alert/status_effect/tazed/Click(location, control, params)


### PR DESCRIPTION
- Syringe guns now embed their syringe in the target
   - Fired syringes are no longer deleted, IE, can be reused and even picked up if you miss
   - Range has been reduced from 50 tiles(???) to 15 tiles
       - Mech fired syringes get a range boost, though.
- Embedded syringes will slowly inject their contents into a mob over time
   - This means someone with quick wits can attempt to remove the syringe _before_ it starts to inject them.
- DNA Injector Syringe Gun functions similarly, embedding an injector and injecting after a delay
- Shotgun Dart and Chem Dart Gun functions similarly, embedding darts and injecting after a delay. 
   - These darts are not reusable and delete when removed 

![image](https://github.com/MrMelbert/MapleStationCode/assets/51863163/8016a884-e1e2-4dcf-9c60-01e617abd21d)
_(pictured: Rapid Syringe Gun)_

The intent behind this is to transform the Syringe gun from a "poke! now i run away and hide until they die" to a "poke, and now i need to keep up the pressure so the guy doesn't remove the syringe, which in turn gives the guy who is shot an interesting dilemma where they have to decide to disengage or attempt to end the fight fast"

