### PR TITLE
Converts designs to defines, removes unused scatter laser change.

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6429,7 +6429,6 @@
 #include "maplestation_modules\code\modules\paperwork\stamps.dm"
 #include "maplestation_modules\code\modules\pixel_shift\code\pixel_shift_component.dm"
 #include "maplestation_modules\code\modules\pixel_shift\code\pixel_shift_keybind.dm"
-#include "maplestation_modules\code\modules\projectiles\ammunition\ballistic\shotgun.dm"
 #include "maplestation_modules\code\modules\projectiles\projectile\bullets\autocannon.dm"
 #include "maplestation_modules\code\modules\projectiles\projectile\bullets\gauss.dm"
 #include "maplestation_modules\code\modules\projectiles\projectile\bullets\shotgun.dm"

--- a/maplestation_modules/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -1,4 +1,0 @@
-///Overrides for shotgun ammo and any new shotgun ammo
-//Overrides laser scatter ammo to fire a unique projectile with a different damage value
-/obj/item/ammo_casing/shotgun/laserslug
-	projectile_type = /obj/projectile/beam/weak/laser_scatter

--- a/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/maplestation_modules/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -4,10 +4,6 @@
 	damage = 0
 	paralyze = 0
 
-//New laser scatter projectile type, 11 damage for 6 pellets doing 66 damage in total
-/obj/projectile/beam/weak/laser_scatter
-	damage = 11
-
 //Overrides meteorslug to have no stun, lower knockdown but also causes a lot of PAIN
 /obj/projectile/bullet/shotgun_meteorslug
 	paralyze = 0

--- a/maplestation_modules/code/modules/research/designs/autolathe_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/autolathe_designs.dm
@@ -2,7 +2,7 @@
 	name = "Item Dispenser Frame"
 	id = "item_d_frame"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 100, /datum/material/plastic = 500)
+	materials = list(/datum/material/iron = SMALL_MATERIAL AMOUNT, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 2.5)
 	build_path = /obj/item/wallframe/item_dispenser
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -13,7 +13,7 @@
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/ammo_casing/shotgun
 	category = list(
 		RND_CATEGORY_HACKED,
@@ -25,7 +25,7 @@
 	name = "Buckshot Shell"
 	id = "buckshot_shell"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list(
 		RND_CATEGORY_HACKED,

--- a/maplestation_modules/code/modules/research/designs/autolathe_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/autolathe_designs.dm
@@ -2,7 +2,7 @@
 	name = "Item Dispenser Frame"
 	id = "item_d_frame"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL AMOUNT, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 2.5)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/plastic = SMALL_MATERIAL_AMOUNT * 2.5)
 	build_path = /obj/item/wallframe/item_dispenser
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/maplestation_modules/code/modules/research/designs/mecha_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/mecha_designs.dm
@@ -4,7 +4,7 @@
 	id = "mech_ppc"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ppc
-	materials = list(/datum/material/iron=10000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5)
 	construction_time = 100
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT,
@@ -38,7 +38,7 @@
 	id = "mech_ac5"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/autocannon_5
-	materials = list(/datum/material/iron=10000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5)
 	construction_time = 100
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT,
@@ -60,7 +60,7 @@
 	id = "mech_ac5_ammo"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/autocannon_5
-	materials = list(/datum/material/iron=4000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	construction_time = 20
 	category = list(
 		RND_CATEGORY_MECHFAB_EQUIPMENT,
@@ -81,7 +81,7 @@
 	desc = "A weapon for combat exosuits. Fires a singular armor-piercing round."
 	id = "mech_ac10"
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/autocannon_10
-	materials = list(/datum/material/iron=10000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5)
 
 /datum/design/mech_ac5_ammo/mech_ac10_ammo
 	name = "Autocannon/10 Ammunition"
@@ -89,8 +89,8 @@
 	id = "mech_ac10_ammo"
 	build_path = /obj/item/mecha_ammo/autocannon_10
 	materials = list(
-		/datum/material/iron = 4000,
-		/datum/material/uranium = 1000,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT,
 		)
 
 /datum/design/mech_ac5/mech_ac20
@@ -98,7 +98,7 @@
 	desc = "A weapon for combat exosuits. Fires a singular slow gigantic slug."
 	id = "mech_ac20"
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/autocannon_20
-	materials = list(/datum/material/iron=10000)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5)
 
 /datum/design/mech_ac5_ammo/mech_ac20_ammo
 	name = "Autocannon/20 Ammunition"
@@ -106,9 +106,9 @@
 	id = "mech_ac20_ammo"
 	build_path = /obj/item/mecha_ammo/autocannon_20
 	materials = list(
-		/datum/material/titanium = 2000,
-		/datum/material/plasma = 500,
-		/datum/material/diamond = 400,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT,
+		/datum/material/plasma = SMALL_MATERIAL_AMOUNT * 5,
+		/datum/material/diamond = SMALL_MATERIAL_AMOUNT * 4,
 		)
 	construction_time = 50
 
@@ -119,8 +119,8 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gauss
 	materials = list(
-		/datum/material/iron=10000,
-		/datum/material/gold=2000,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 5,
+		/datum/material/gold = SHEET_MATERIAL_AMOUNT,
 		)
 	construction_time = 100
 	category = list(
@@ -144,8 +144,8 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_ammo/gauss
 	materials = list(
-		/datum/material/iron = 5000,
-		/datum/material/titanium = 1000,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5,
+		/datum/material/titanium = HALF_SHEET_MATERIAL_AMOUNT,
 		)
 	construction_time = 20
 	category = list(
@@ -169,9 +169,9 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/er_laser
 	materials = list(
-		/datum/material/iron = 8000,
-		/datum/material/gold = 2000,
-		/datum/material/diamond = 2000,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 4,
+		/datum/material/gold = SHEET_MATERIAL_AMOUNT,
+		/datum/material/diamond = SHEET_MATERIAL_AMOUNT,
 	)
 	construction_time = 100
 	category = list(
@@ -195,9 +195,9 @@
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulsed_laser
 	materials = list(
-		/datum/material/iron = 6000,
-		/datum/material/gold = 2000,
-		/datum/material/titanium = 4000,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 3,
+		/datum/material/gold = SHEET_MATERIAL_AMOUNT,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 2,
 	)
 	construction_time = 100
 	category = list(

--- a/maplestation_modules/code/modules/research/designs/medical_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/medical_designs.dm
@@ -4,7 +4,7 @@
 	id = "cybernetic_cat_ears"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 30
-	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, SMALL_MATERIAL_AMOUNT * 4)
 	build_path = /obj/item/organ/internal/ears/cat/cybernetic
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC

--- a/maplestation_modules/code/modules/research/designs/medical_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/medical_designs.dm
@@ -4,7 +4,7 @@
 	id = "cybernetic_cat_ears"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 30
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, SMALL_MATERIAL_AMOUNT * 4)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 4)
 	build_path = /obj/item/organ/internal/ears/cat/cybernetic
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC

--- a/maplestation_modules/code/modules/research/designs/wiremod_designs.dm
+++ b/maplestation_modules/code/modules/research/designs/wiremod_designs.dm
@@ -1,18 +1,18 @@
 /// Multitool has no right to be that expensive compared to normal multitools
 /datum/design/circuit_multitool
-	materials = list(/datum/material/iron = 200, /datum/material/glass = 200)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT)
 
-// Wiremod components are 1/4th the glass cost.
+// Wiremod components are 1/5th the glass cost.
 /datum/design/component
-	materials = list(/datum/material/glass = 250)
+	materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT)
 
 // Drone shells don't cost gold.
 /datum/design/drone_shell
 	materials = list(
-		/datum/material/glass = 2000,
-		/datum/material/iron = 12000, // (+1 iron sheet in compensation)
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 6, // (+1 iron sheet in compensation)
 	)
 
 // The module duplicate is also 1/4th the cost.
 /obj/machinery/module_duplicator
-	cost_per_component = 250
+	cost_per_component = SHEET_MATERIAL_AMOUNT * 0.025


### PR DESCRIPTION
![image](https://github.com/MrMelbert/MapleStationCode/assets/13697285/8403a272-a915-463b-a802-c70a431a7c1a)
i just wanna print an ER laser man

Aside from fixing material costs being ~20x higher on non-modular designs, this PR also removes some deadcode intended to nerf the scatter laser. It doesn't work anymore and upstream brought in an even bigger nerf. going from a 2-shot kill here to a 3 shot kill with very punishing fall-off, youch.