### PR TITLE
You walk faster with canes on missing limbs

### DIFF
--- a/code/__DEFINES/living.dm
+++ b/code/__DEFINES/living.dm
@@ -5,6 +5,9 @@
 // NON-MODULE CHANGE
 // Sticking these here for now because i'm dumb
 
+/// Updating a mob's movespeed when lacking limbs. (list/modifiers)
+#define COMSIG_LIVING_LIMBLESS_MOVESPEED_UPDATE "living_get_movespeed_modifiers"
+
 // -- Defines for the pain system. --
 
 /// Sent when a carbon gains pain. (source = mob/living/carbon/human, obj/item/bodypart/affected_bodypart, amount, type)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -450,18 +450,21 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	custom_materials = list(/datum/material/iron= SMALL_MATERIAL_AMOUNT * 0.5)
 	attack_verb_continuous = list("bludgeons", "whacks", "disciplines", "thrashes")
 	attack_verb_simple = list("bludgeon", "whack", "discipline", "thrash")
+	/// Only exists so the white cane doesn't spawn with its "effects" while unextended
+	var/start_with_effects = TRUE
 
 /obj/item/cane/Initialize(mapload)
 	. = ..()
+	if(start_with_effects)
+		add_effects()
+
+/obj/item/cane/proc/add_effects()
 	ADD_TRAIT(src, TRAIT_BLIND_TOOL, INNATE_TRAIT)
+	AddComponent(/datum/component/limbless_aid)
 
-/obj/item/cane/equipped(mob/living/user, slot, initial)
-	. = ..()
-	user.update_limbless_movespeed_mod()
-
-/obj/item/cane/dropped(mob/living/user, silent)
-	. = ..()
-	user.update_limbless_movespeed_mod()
+/obj/item/cane/proc/remove_effects()
+	REMOVE_TRAIT(src, TRAIT_BLIND_TOOL, INNATE_TRAIT)
+	qdel(GetComponent(/datum/component/limbless_aid))
 
 /obj/item/cane/white
 	name = "white cane"
@@ -473,6 +476,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 1
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 6)
+	start_with_effects = FALSE
 
 /obj/item/cane/white/Initialize(mapload)
 	. = ..()
@@ -494,6 +498,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
  */
 /obj/item/cane/white/proc/on_transform(obj/item/source, mob/user, active)
 	SIGNAL_HANDLER
+
+	if(active)
+		add_effects()
+	else
+		remove_effects()
 
 	if(user)
 		balloon_alert(user, active ? "extended" : "collapsed")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -455,6 +455,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	ADD_TRAIT(src, TRAIT_BLIND_TOOL, INNATE_TRAIT)
 
+/obj/item/cane/equipped(mob/living/user, slot, initial)
+	. = ..()
+	user.update_limbless_movespeed_mod()
+
+/obj/item/cane/dropped(mob/living/user, silent)
+	. = ..()
+	user.update_limbless_movespeed_mod()
+
 /obj/item/cane/white
 	name = "white cane"
 	desc = "A cane traditionally used by the blind to help them see. Folds down to be easier to transport."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2289,14 +2289,18 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			if(!usable_hands)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
+	update_limbless_movespeed_mod()
+
+/mob/living/proc/update_limbless_movespeed_mod()
 	if(usable_legs < default_num_legs)
 		var/limbless_slowdown = (default_num_legs - usable_legs) * 3
 		if(!usable_legs && usable_hands < default_num_hands)
 			limbless_slowdown += (default_num_hands - usable_hands) * 3
+		for(var/obj/item/cane/thing in held_items)
+			limbless_slowdown *= 0.5
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, multiplicative_slowdown = limbless_slowdown)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
-
 
 ///Proc to modify the value of num_hands and hook behavior associated to this event.
 /mob/living/proc/set_num_hands(new_value)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2291,13 +2291,17 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 	update_limbless_movespeed_mod()
 
+/// Updates the mob's movespeed based on how many limbs they have or are missing.
 /mob/living/proc/update_limbless_movespeed_mod()
 	if(usable_legs < default_num_legs)
 		var/limbless_slowdown = (default_num_legs - usable_legs) * 3
 		if(!usable_legs && usable_hands < default_num_hands)
 			limbless_slowdown += (default_num_hands - usable_hands) * 3
-		for(var/obj/item/cane/thing in held_items)
-			limbless_slowdown *= 0.5
+
+		var/list/slowdown_mods = list()
+		SEND_SIGNAL(src, COMSIG_LIVING_LIMBLESS_MOVESPEED_UPDATE, slowdown_mods)
+		for(var/num in slowdown_mods)
+			limbless_slowdown *= slowdown_mods
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, multiplicative_slowdown = limbless_slowdown)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6090,6 +6090,7 @@
 #include "maplestation_modules\code\controllers\subsystem\pain_subsystem.dm"
 #include "maplestation_modules\code\datums\shuttles.dm"
 #include "maplestation_modules\code\datums\components\easy_ignite.dm"
+#include "maplestation_modules\code\datums\components\limbless_aid.dm"
 #include "maplestation_modules\code\datums\components\make_item_slow.dm"
 #include "maplestation_modules\code\datums\components\remote_materials.dm"
 #include "maplestation_modules\code\datums\components\stackable_item.dm"

--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -1,0 +1,46 @@
+/// Attach to items that help mobs missing limbs move faster when held.
+/datum/component/limbless_aid
+	/// What slot flags must the parent item have to provide the bonus?
+	var/required_slot = ITEM_SLOT_HANDS
+	/// How much should the movespeed be modified?
+	var/movespeed_mod = 0.5
+
+/datum/component/limbless_aid/Initialize(required_slot = ITEM_SLOT_HANDS, movespeed_mod = 0.5)
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.required_slot = required_slot
+	src.movespeed_mod = movespeed_mod
+
+/datum/component/limbless_aid/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
+	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
+
+/datum/component/limbless_aid/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
+
+	var/obj/item/item_parent = parent
+	if(isliving(item_parent.loc))
+		var/mob/living/wearer = item_parent.loc
+		UnregisterSignal(wearer, COMSIG_LIVING_LIMBLESS_MOVESPEED_UPDATE)
+		wearer.update_limbless_movespeed_mod()
+
+/datum/component/limbless_aid/proc/on_equip(obj/item/source, mob/living/user, slot)
+	SIGNAL_HANDLER
+
+	if(!(slot & required_slot))
+		return
+
+	RegisterSignal(user, COMSIG_LIVING_LIMBLESS_MOVESPEED_UPDATE, PROC_REF(modify_movespeed), override = TRUE)
+	user.update_limbless_movespeed_mod()
+
+/datum/component/limbless_aid/proc/on_drop(obj/item/source, mob/living/user)
+	SIGNAL_HANDLER
+
+	UnregisterSignal(user, COMSIG_LIVING_LIMBLESS_MOVESPEED_UPDATE)
+	user.update_limbless_movespeed_mod()
+
+/datum/component/limbless_aid/proc/modify_movespeed(mob/living/source, list/modifiers)
+	SIGNAL_HANDLER
+
+	modifiers += movespeed_mod

--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -16,6 +16,11 @@
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 
+	var/obj/item/item_parent = parent
+	if(isliving(item_parent.loc))
+		var/mob/living/wearer = item_parent.loc
+		on_equip(parent, wearer, wearer.get_slot_by_item(parent))
+
 /datum/component/limbless_aid/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 


### PR DESCRIPTION
Holding a cane reduces the movespeed penalty for missing limbs by 50%. Per cane, so you can have two canes for 75%. If you want