### PR TITLE
Reverts station trait costs, adds general budget

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -431,17 +431,17 @@
 
 /datum/config_entry/string/new_player_alert_role_id
 
-/datum/config_entry/keyed_list/positive_station_traits
-	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
-	key_mode = KEY_MODE_TEXT
-	value_mode = VALUE_MODE_NUM
-
-/datum/config_entry/keyed_list/negative_station_traits
-	default = list("0" = 8, "1" = 4, "2" = 2, "3" = 1)
-	key_mode = KEY_MODE_TEXT
-	value_mode = VALUE_MODE_NUM
-
-/datum/config_entry/keyed_list/neutral_station_traits
-	default = list("0" = 10, "1" = 10, "2" = 3, "2.5" = 1)
+/datum/config_entry/keyed_list/station_traits
+	default = list(
+		"0" = 12,
+		"1" = 40,
+		"2" = 24,
+		"3" = 12,
+		"4" = 6,
+		"5" = 3,
+		"6" = 2,
+		"7" = 1,
+		"8" = 0,
+	)
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -73,12 +73,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 
-	var/trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/station_traits)))
+	var/trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/station_traits))) || 0
 	var/list/selectable_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE)
-	while(trait_budget > 0)
-		if(!length(selectable_types))
-			break
-
+	while(trait_budget > 0 && length(selectable_types))
 		var/picked_cat = pick(selectable_types)
 		var/list/selectable_traits = selectable_traits_by_types[picked_cat]
 		if(!length(selectable_traits))

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -73,48 +73,29 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 
-	var/positive_trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/positive_station_traits)))
-	var/neutral_trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/neutral_station_traits)))
-	var/negative_trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/negative_station_traits)))
+	var/trait_budget = text2num(pick_weight(CONFIG_GET(keyed_list/station_traits)))
+	var/list/selectable_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE)
+	while(trait_budget > 0)
+		if(!length(selectable_types))
+			break
 
-	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_budget)
-	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_budget)
-	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_budget)
-
-/**
- * Picks traits of a specific category (e.g. bad or good), initializes them, adds them to the list of traits,
- * then removes them from possible traits as to not roll twice and subtracts their cost from the budget.
- * All until the whole budget is spent or no more traits can be picked with it.
- */
-/datum/controller/subsystem/processing/station/proc/pick_traits(trait_sign, budget)
-	if(!budget)
-		return
-	///A list of traits of the same trait sign
-	var/list/selectable_traits = selectable_traits_by_types[trait_sign]
-	while(budget)
-		///Remove any station trait with a cost bigger than the budget
-		for(var/datum/station_trait/proto_trait as anything in selectable_traits)
-			if(initial(proto_trait.cost) > budget)
-				selectable_traits -= proto_trait
-		///We have spare budget but no trait that can be bought with what's left of it
+		var/picked_cat = pick(selectable_types)
+		var/list/selectable_traits = selectable_traits_by_types[picked_cat]
 		if(!length(selectable_traits))
-			return
-		//Rolls from the table for the specific trait type
-		var/datum/station_trait/trait_type = pick_weight(selectable_traits)
-		selectable_traits -= trait_type
-		budget -= initial(trait_type.cost)
-		setup_trait(trait_type)
+			selectable_types -= picked_cat
+			continue
+
+		setup_trait(pick_weight(selectable_traits))
+		trait_budget--
 
 ///Creates a given trait of a specific type, while also removing any blacklisted ones from the future pool.
 /datum/controller/subsystem/processing/station/proc/setup_trait(datum/station_trait/trait_type)
 	var/datum/station_trait/trait_instance = new trait_type()
 	station_traits += trait_instance
 	log_game("Station Trait: [trait_instance.name] chosen for this round.")
-	if(!trait_instance.blacklist)
-		return
-	for(var/i in trait_instance.blacklist)
-		var/datum/station_trait/trait_to_remove = i
+	for(var/datum/station_trait/trait_to_remove as anything in trait_instance.blacklist)
 		selectable_traits_by_types[initial(trait_to_remove.trait_type)] -= trait_to_remove
+	selectable_traits_by_types[trait_instance.trait_type] -= trait_type
 
 /// Update station trait lobby buttons for clients who joined before we initialised this subsystem
 /datum/controller/subsystem/processing/station/proc/display_lobby_traits()

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -11,8 +11,6 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	var/trait_processes = FALSE
 	///Chance relative to other traits of its type to be picked
 	var/weight = 10
-	///The cost of the trait, which is removed from the budget.
-	var/cost = STATION_TRAIT_COST_FULL
 	///Whether this trait is always enabled; generally used for debugging
 	var/force = FALSE
 	///Does this trait show in the centcom report?
@@ -22,7 +20,7 @@ GLOBAL_LIST_EMPTY(lobby_station_traits)
 	///What code-trait does this station trait give? gives none if null
 	var/trait_to_give
 	///What traits are incompatible with this one?
-	var/blacklist
+	var/list/blacklist
 	///Extra flags for station traits such as it being abstract, planetary or space only
 	var/trait_flags = STATION_TRAIT_MAP_UNRESTRICTED
 	/// Whether or not this trait can be reverted by an admin

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -123,7 +123,6 @@
 	name = "Cleaned out maintenance"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW //Most of maints is literal trash anyway
 	show_in_report = TRUE
 	report_message = "Our workers cleaned out most of the junk in the maintenace areas."
 	blacklist = list(/datum/station_trait/filled_maint)
@@ -168,7 +167,6 @@
 	name = "Bot Language Matrix Malfunction"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 4
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 	report_message = "Your station's friendly bots have had their language matrix fried due to an event, resulting in some strange and unfamiliar speech patterns."
 	trait_to_give = STATION_TRAIT_BOTS_GLITCHED
@@ -189,7 +187,6 @@
 	name = "Revenge of Pun Pun"
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	cost = STATION_TRAIT_COST_LOW
 
 	// Way too much is done on atoms SS to be reverted, and it'd look
 	// kinda clunky on round start. It's not impossible to make this work,
@@ -322,7 +319,6 @@
 	report_message = "The space around your station is clouded by heavy pockets of space dust. Expect an increased likelyhood of space dust storms damaging the station hull."
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 2
-	cost = STATION_TRAIT_COST_LOW
 	event_control_path = /datum/round_event_control/meteor_wave/dust_storm
 	weight_multiplier = 2
 	max_occurrences_modifier = 3

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -3,7 +3,6 @@
 	name = "Bananium Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	report_message = "Rumors has it that the clown planet has been sending support packages to clowns in this system."
 	trait_to_give = STATION_TRAIT_BANANIUM_SHIPMENTS
 
@@ -11,7 +10,6 @@
 	name = "Unnatural atmospherical properties"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 	report_message = "System's local planet has irregular atmospherical properties."
 	trait_to_give = STATION_TRAIT_UNNATURAL_ATMOSPHERE
@@ -45,7 +43,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 5
 	show_in_report = FALSE
-	cost = STATION_TRAIT_COST_LOW
 	report_message = "Ian has gone exploring somewhere in the station."
 
 /datum/station_trait/ian_adventure/on_round_start()
@@ -105,7 +102,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 10
 	show_in_report = TRUE
-	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "Something seems to be wrong with the PDAs issued to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED
 
@@ -138,7 +134,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 10
 	show_in_report = TRUE
-	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "Due to a shortage in standard issue jumpsuits, we have provided your assistants with one of our backup supplies."
 	blacklist = list(/datum/station_trait/assistant_gimmicks)
 
@@ -283,7 +278,6 @@
 	name = "Scarves"
 	trait_type = STATION_TRAIT_NEUTRAL
 	weight = 10
-	cost = STATION_TRAIT_COST_MINIMAL
 	show_in_report = TRUE
 	var/list/scarves
 
@@ -317,7 +311,6 @@
 	trait_type = STATION_TRAIT_NEUTRAL
 	show_in_report = TRUE
 	weight = 10
-	cost = STATION_TRAIT_COST_MINIMAL
 	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
 
 /datum/station_trait/wallets/New()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -54,7 +54,6 @@
 	name = "Bountiful bounties"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 	report_message = "It seems collectors in this system are extra keen to on bounties, and will pay more to see their completion."
 
@@ -76,7 +75,6 @@
 	name = "Filled up maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 	report_message = "Our workers accidentally forgot more of their personal belongings in the maintenace areas."
 	blacklist = list(/datum/station_trait/empty_maint)
@@ -277,7 +275,6 @@
 	name = "Advanced Medbots"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 	report_message = "Your station's medibots have received a hardware upgrade, enabling expanded healing capabilities."
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
@@ -314,7 +311,6 @@
 	report_message = "A repair technician left their wallet in a locker somewhere. They would greatly appreciate if you could locate and return it to them when the shift has ended."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	cost = STATION_TRAIT_COST_LOW
 	show_in_report = TRUE
 
 /datum/station_trait/missing_wallet/on_round_start()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -508,19 +508,15 @@ DISALLOW_TITLE_MUSIC
 #GIVE_TUTORIALS_WITHOUT_DB
 
 ## Configuration for station traits of each type.
-## The first value (key) is the budget, or the space available to use for station traits of that type. Some take more space than others.
+## The first value (key) is the budget, or how many traits to spawn.
 ## The second value (assoc) is the weight associated with said budget compared to the rest for that type.
-POSITIVE_STATION_TRAITS 0 8
-POSITIVE_STATION_TRAITS 1 4
-POSITIVE_STATION_TRAITS 2 2
-POSITIVE_STATION_TRAITS 3 1
-
-NEUTRAL_STATION_TRAITS 0 10
-NEUTRAL_STATION_TRAITS 1 10
-NEUTRAL_STATION_TRAITS 2 3
-NEUTRAL_STATION_TRAITS 2.5 1
-
-NEGATIVE_STATION_TRAITS 0 8
-NEGATIVE_STATION_TRAITS 1 4
-NEGATIVE_STATION_TRAITS 2 2
-NEGATIVE_STATION_TRAITS 3 1
+## Adds up to 100 for easy math: The weight = the % chance of being picked.
+STATION_TRAITS 0 12
+STATION_TRAITS 1 40
+STATION_TRAITS 2 24
+STATION_TRAITS 3 12
+STATION_TRAITS 4 6
+STATION_TRAITS 5 3
+STATION_TRAITS 6 2
+STATION_TRAITS 7 1
+STATION_TRAITS 8 0


### PR DESCRIPTION
Strait trait costs: Good in theory, but fails in practice. 

While in theory this allows for more rare traits to shine by leaving behind some "budget" to purchase more impactful traits along side smaller ones, in practice this means the less impactful traits (already regulated by higher weights) become soft-guaranteed to roll: as they effectively combine their weights into one. 

When you have a budget of `1`, and you roll a trait that costs `0.3`, you are left with `0.7`. Now you can't buy any traits that cost `1`, but we still want to spend the rest of the budget, so we are now guaranteed to buy a bunch of things that cost `0.5` or `0.3`. This sucks in practice. 

So I reverted it. All traits are `1` cost. 

But I didn't revert it to how the system used to be. In the past, it would roll 3 numbers for `num positive`, `num neutral` and `num negative`. 
Instead, we just roll 1 big pool and then randomly pick from either positive, neutral, or negative, as we attempt to fill out or budget. 

Why am I doing this? I think it will result in more "dynamic" rounds than when it used to be. While in the past most rounds felt rather standard: You get something positive, something negative, and something neutral. Instead now, in some rounds you will feel blessed, and be given many positives, and in some rounds you will feel cursed, and be given many negatives. Or you will get the standard balanced result. Or who knows!


`Also remember this is config so it can be easily easily tweaked`
