### PR TITLE
Add Sansufentanyl prescription to Cargo, fix Psicodine prescription (after 3 years)

### DIFF
--- a/maplestation_modules/code/modules/cargo/packs.dm
+++ b/maplestation_modules/code/modules/cargo/packs.dm
@@ -173,6 +173,15 @@
 		/obj/item/storage/pill_bottle/prescription/psicodine,
 	)
 
+/datum/supply_pack/goody/experimental
+	name = "Experimental Medicine Prescription"
+	desc = "Contains a pill bottle of Experimental Medicine required for living with Hereditary Manifold Sickness."
+	group = GROUP_DRUGS
+	cost = PAYCHECK_CREW * 4
+	contains = list(
+		/obj/item/storage/pill_bottle/sansufentanyl,
+	)
+
 /datum/supply_pack/medical/painkiller_syringes
 	name = "Painkiller Syringe Shipment"
 	desc = "Contains six syringes of general medicinal painkillers - Ibuprofen, Paracetamol, and Aspirin."

--- a/maplestation_modules/code/modules/cargo/packs.dm
+++ b/maplestation_modules/code/modules/cargo/packs.dm
@@ -164,7 +164,7 @@
 	pill_type = /obj/item/reagent_containers/pill/psicodine
 	num_pills = 3
 
-/datum/supply_pack/goody/happiness
+/datum/supply_pack/goody/psicodine
 	name = "Psicodine Prescription"
 	desc = "Contains a pill bottle of Psicodine."
 	group = GROUP_DRUGS


### PR DESCRIPTION
- Adds Sansufentanyl (1 count) to cargo, so you can order some without buying a big ass crate
- Fix Psicodine prescription being wrong for 3 years