### PR TITLE
Adjusts spell Flares Lifetime and Lesser Cooldown

### DIFF
--- a/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_item_lumenomancy.dm
+++ b/maplestation_modules/code/modules/client/preferences/spellbook/items/spellbook_item_lumenomancy.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(spellbook_lumenomancy_items, generate_spellbook_items(SPELLBOOK
 // Customization to allow lesser flare
 /datum/spellbook_item/spell/conjure_item/flare/generate_customization_params()
 	. = list()
-	.["lesser"] = new /datum/spellbook_customization_entry/boolean("lesser", "Lesser, weaker, somewhat cheaper version", "A cheap less lasting flare that fizzles out faster than expected, for those just learning magic or unable to grasp the full concept of luminosity.")
+	.["lesser"] = new /datum/spellbook_customization_entry/boolean("lesser", "Lesser, weaker, somewhat cheaper version", "A cheap less lasting flare that fizzles out faster than normally, along with a considerable cooldown between casts, for those just learning magic or unable to grasp the full concept of luminosity.")
 
 /datum/spellbook_item/spell/illusion
 	name = "Illusion"

--- a/maplestation_modules/code/modules/magic/story_spells/flare.dm
+++ b/maplestation_modules/code/modules/magic/story_spells/flare.dm
@@ -31,8 +31,9 @@
 	if (lesser)
 		our_spell.item_type = /obj/item/flashlight/glowstick/magic/lesser
 		our_spell.flare_cost = 10
+		our_spell.cooldown_time = 2 MINUTES
 		our_spell.name = "Lesser Flare"
-		our_spell.desc = "Conjure lumens into a glob to be held or thrown to light an area. Right-click the spell icon to set the light color. This weaker version burns up quicker and may fizzle out after casting."
+		our_spell.desc = "Conjure lumens into a glob to be held or thrown to light an area. Right-click the spell icon to set the light color. This weaker version burns up quicker and has a considerable cooldown between conjures."
 	return
 
 /datum/action/cooldown/spell/conjure_item/flare/make_item()
@@ -59,6 +60,7 @@
 
 /obj/item/flashlight/glowstick/magic/Initialize(mapload)
 	. = ..()
+	fuel = rand(5 MINUTES, 10 MINUTES)
 	set_light_on(TRUE)
 
 /obj/item/flashlight/glowstick/magic/lesser
@@ -68,7 +70,7 @@
 
 /obj/item/flashlight/glowstick/magic/lesser/Initialize(mapload)
 	. = ..()
-	fuel = rand(2, 100)
+	fuel = rand(1 MINUTES, 5 MINUTES)
 
 //Will have the flare start on and slowly burn through its fuel, when it runs out it will fizzle, fade out and delete itself. Similar to magic lockers from the staff.
 /obj/item/flashlight/glowstick/magic/Initialize(mapload)


### PR DESCRIPTION
Magical flares now randomly stay alight between 5-10 minutes with lesser flares 1-5 minutes. Lesser flares now have a cooldown alongside their cheaper cost.
