### PR TITLE
Adds sneak mode to replicate the old "no footstep" behavior of walking

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -9,6 +9,7 @@
 //movement intent defines for the move_intent var
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN "run"
+#define MOVE_INTENT_SNEAK "sneak" // NON-MODULE CHANGE
 
 //Blood levels
 #define BLOOD_VOLUME_MAX_LETHAL 2150

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -78,7 +78,7 @@
 
 	using = new /atom/movable/screen/mov_intent(null, src)
 	using.icon = ui_style
-	using.icon_state = (owner.move_intent == MOVE_INTENT_RUN ? "running" : "walking")
+	using.update_appearance(UPDATE_ICON_STATE) // NON-MODULE CHANGE
 	using.screen_loc = ui_movi
 	static_inventory += using
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -78,7 +78,7 @@
 
 	using = new /atom/movable/screen/mov_intent(null, src)
 	using.icon = ui_style
-	using.update_appearance(UPDATE_ICON_STATE) // NON-MODULE CHANGE
+	using.update_appearance() // NON-MODULE CHANGE
 	using.screen_loc = ui_movi
 	static_inventory += using
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -346,7 +346,7 @@
 /atom/movable/screen/mov_intent/proc/toggle(mob/living/user)
 	if(!istype(user))
 		return
-	user.toggle_move_intent(user)
+	user.toggle_move_intent()
 
 /atom/movable/screen/pull
 	name = "stop pulling"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -336,10 +336,11 @@
 		return
 	var/mob/living/living_hud_owner = hud.mymob
 	switch(living_hud_owner.move_intent)
-		if(MOVE_INTENT_WALK)
+		if(MOVE_INTENT_WALK, MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
 			icon_state = "walking"
 		if(MOVE_INTENT_RUN)
 			icon_state = "running"
+	maptext = "<span style='[maptext_style]'>[capitalize(living_hud_owner.move_intent)]</span>" // NON-MODULE CHANGE
 	return ..()
 
 /atom/movable/screen/mov_intent/proc/toggle(mob/living/user)

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -78,8 +78,8 @@
 		var/mob/living/carbon/carbon_source = source
 		if(!carbon_source.get_bodypart(BODY_ZONE_L_LEG) && !carbon_source.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		// if(carbon_source.m_intent == MOVE_INTENT_WALK) // NON-MODULE CHANGE
-		// 	return// stealth // NON-MODULE CHANGE
+		if(carbon_source.move_intent == MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
+			return// stealth
 	steps_for_living[source] += 1
 	var/steps = steps_for_living[source]
 

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -121,8 +121,8 @@
 /datum/keybinding/living/toggle_move_intent
 	hotkey_keys = list("C")
 	name = "toggle_move_intent"
-	full_name = "Hold to toggle move intent"
-	description = "Held down to cycle to the other move intent, release to cycle back"
+	full_name = "Hold to toggle sprint" // NON-MODULE CHANGE
+	description = "Hold down to enable sprinting. Releasing will return you to walk." // NON-MODULE CHANGE
 	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENT_DOWN
 
 /datum/keybinding/living/toggle_move_intent/down(client/user)
@@ -130,19 +130,19 @@
 	if(.)
 		return
 	var/mob/living/M = user.mob
-	M.toggle_move_intent()
+	M.set_move_intent(MOVE_INTENT_RUN) // NON-MODULE CHANGE
 	return TRUE
 
 /datum/keybinding/living/toggle_move_intent/up(client/user)
 	var/mob/living/M = user.mob
-	M.toggle_move_intent()
+	M.set_move_intent(MOVE_INTENT_WALK) // NON-MODULE CHANGE
 	return TRUE
 
 /datum/keybinding/living/toggle_move_intent_alternative
 	hotkey_keys = list("Unbound")
 	name = "toggle_move_intent_alt"
 	full_name = "press to cycle move intent"
-	description = "Pressing this cycle to the opposite move intent, does not cycle back"
+	description = "Pressing this will cycle to the next move intent." // NON-MODULE CHANGE
 	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN
 
 /datum/keybinding/living/toggle_move_intent_alternative/down(client/user)

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -141,7 +141,7 @@
 /datum/keybinding/living/toggle_move_intent_alternative
 	hotkey_keys = list("Unbound")
 	name = "toggle_move_intent_alt"
-	full_name = "press to cycle move intent"
+	full_name = "Press to cycle move intent"
 	description = "Pressing this will cycle to the next move intent." // NON-MODULE CHANGE
 	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN
 

--- a/code/datums/quirks/negative_quirks/nyctophobia.dm
+++ b/code/datums/quirks/negative_quirks/nyctophobia.dm
@@ -40,7 +40,7 @@
 		quirk_holder.clear_mood_event("nyctophobia")
 		return
 
-	if(quirk_holder.move_intent == MOVE_INTENT_RUN)
+	if(quirk_holder.move_intent != MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
 		to_chat(quirk_holder, span_warning("Easy, easy, take it slow... you're in the dark..."))
-		quirk_holder.toggle_move_intent()
+		quirk_holder.set_move_intent(MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
 	quirk_holder.add_mood_event("nyctophobia", /datum/mood_event/nyctophobia)

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -348,18 +348,16 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 /datum/voice_of_god_command/walk/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	for(var/mob/living/target as anything in listeners)
-		if(target.move_intent != MOVE_INTENT_WALK)
-			target.toggle_move_intent()
+		target.set_move_intent(MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
 
 /// This command forces the listeners to switch to run intent.
 /datum/voice_of_god_command/run
 	trigger = "run"
 	is_regex = FALSE
 
-/datum/voice_of_god_command/walk/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
+/datum/voice_of_god_command/run/execute(list/listeners, mob/living/user, power_multiplier = 1, message) // NON-MODULE CHANGE
 	for(var/mob/living/target as anything in listeners)
-		if(target.move_intent != MOVE_INTENT_RUN)
-			target.toggle_move_intent()
+		target.set_move_intent(MOVE_INTENT_RUN) // NON-MODULE CHANGE
 
 /// This command turns the listeners' throw mode on.
 /datum/voice_of_god_command/throw_catch

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -179,7 +179,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/flasher, 26)
 
 	if(iscarbon(proximity_check_mob))
 		var/mob/living/carbon/proximity_carbon = proximity_check_mob
-		if (proximity_carbon.move_intent != MOVE_INTENT_WALK && anchored)
+		if (proximity_carbon.move_intent != MOVE_INTENT_SNEAK && anchored) // NON-MODULE CHANGE
 			flash()
 
 /obj/machinery/flasher/portable/vv_edit_var(vname, vval)

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -37,7 +37,7 @@
 
 	if(iscarbon(tomb_raider))
 		var/mob/living/carbon/nearby_carbon = tomb_raider
-		if (nearby_carbon.move_intent != MOVE_INTENT_WALK || prob(15))
+		if (nearby_carbon.move_intent != MOVE_INTENT_SNEAK || prob(15)) // NON-MODULE CHANGE
 			release_smoke(nearby_carbon)
 			COOLDOWN_START(src, gas_cooldown, rand(20 SECONDS, 2 MINUTES))
 

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -310,7 +310,7 @@
 	else
 		if(!(lube & SLIP_WHEN_CRAWLING) && (slipper.body_position == LYING_DOWN || !(slipper.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
 			return FALSE
-		if(slipper.move_intent == MOVE_INTENT_WALK && (lube & NO_SLIP_WHEN_WALKING))
+		if(slipper.move_intent != MOVE_INTENT_RUN && (lube & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
 			return FALSE
 
 	if(!(lube & SLIDE_ICE))

--- a/code/modules/admin/smites/ghost_control.dm
+++ b/code/modules/admin/smites/ghost_control.dm
@@ -16,8 +16,11 @@
 		"throw" = CALLBACK(target, TYPE_PROC_REF(/mob, throw_item), get_edge_target_turf(target, pick(GLOB.alldirs))),
 		"shove" = CALLBACK(src, PROC_REF(ghost_shove), target),
 		"sit" = CALLBACK(src, PROC_REF(ghost_sit), target),
-		"run" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_RUN),
-		"walk" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_WALK),
+		"run" = CALLBACK(target, TYPE_PROC_REF(/mob/living, set_move_intent), MOVE_INTENT_RUN), // NON-MODULE CHANGE
+		"walk" = CALLBACK(target, TYPE_PROC_REF(/mob/living, set_move_intent), MOVE_INTENT_WALK), // NON-MODULE CHANGE
+		"sneak" = CALLBACK(target, TYPE_PROC_REF(/mob/living, set_move_intent), MOVE_INTENT_SNEAK), // NON-MODULE CHANGE
+		"crawl" = CALLBACK(target, TYPE_PROC_REF(/mob/living, set_resting), TRUE), // NON-MODULE CHANGE
+		"stand" = CALLBACK(target, TYPE_PROC_REF(/mob/living, set_resting), FALSE), // NON-MODULE CHANGE
 		), 7 SECONDS)
 
 	to_chat(target, span_revenwarning("You feel a ghastly presence!!!"))
@@ -45,7 +48,4 @@
 	var/obj/structure/chair/sitting_chair = pick(chairs)
 	sitting_chair.buckle_mob(target, check_loc = FALSE)
 
-/datum/smite/ghost_control/proc/ghost_speed(mob/living/target, new_speed)
-	if(target.move_intent == new_speed)
-		return
-	target.toggle_move_intent()
+ // NON-MODULE CHANGE: this proc is gone we don't need it any more

--- a/code/modules/admin/smites/ghost_control.dm
+++ b/code/modules/admin/smites/ghost_control.dm
@@ -48,4 +48,4 @@
 	var/obj/structure/chair/sitting_chair = pick(chairs)
 	sitting_chair.buckle_mob(target, check_loc = FALSE)
 
- // NON-MODULE CHANGE: this proc is gone we don't need it any more
+// NON-MODULE CHANGE: this proc is gone we don't need it any more

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -289,7 +289,7 @@
 		return
 	if(isliving(movable))
 		var/mob/living/crusher = movable
-		if(crusher.move_intent != MOVE_INTENT_WALK && (!(crusher.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crusher.buckled))
+		if(crusher.move_intent != MOVE_INTENT_SNEAK && (!(crusher.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || crusher.buckled)) // NON-MODULE CHANGE
 			playsound(src, 'sound/effects/footstep/glass_step.ogg', 30, TRUE)
 			visible_message(span_warning("[crusher] steps on [src], damaging it!"))
 			take_damage(100, sound_effect = FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -141,7 +141,7 @@
 //Called when we bump onto a mob
 /mob/living/proc/MobBump(mob/M)
 	//No bumping/swapping/pushing others if you are on walk intent
-	if(move_intent == MOVE_INTENT_WALK)
+	if(move_intent != MOVE_INTENT_RUN)  // NON-MODULE CHANGE
 		return TRUE
 
 	if(SEND_SIGNAL(M, COMSIG_LIVING_PRE_MOB_BUMP, src) & COMPONENT_LIVING_BLOCK_PRE_MOB_BUMP)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -481,14 +481,14 @@
 	set instant = TRUE
 	if(isliving(mob))
 		var/mob/living/user_mob = mob
-		user_mob.toggle_move_intent(usr)
+		user_mob.toggle_move_intent()
 
 /**
  * Toggle the move intent of the mob
  *
  * triggers an update the move intent hud as well
  */
-/mob/living/proc/toggle_move_intent(mob/user)
+/mob/living/proc/toggle_move_intent()
 	if(move_intent == MOVE_INTENT_RUN)
 		move_intent = MOVE_INTENT_WALK
 	else

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6381,6 +6381,7 @@
 #include "maplestation_modules\code\modules\mob\living\impede_speech_verb.dm"
 #include "maplestation_modules\code\modules\mob\living\living.dm"
 #include "maplestation_modules\code\modules\mob\living\living_movement.dm"
+#include "maplestation_modules\code\modules\mob\living\sneak.dm"
 #include "maplestation_modules\code\modules\mob\living\speech_and_radio_sounds.dm"
 #include "maplestation_modules\code\modules\mob\living\sprint.dm"
 #include "maplestation_modules\code\modules\mob\living\carbon\human\human.dm"

--- a/maplestation_modules/code/modules/mob/living/sneak.dm
+++ b/maplestation_modules/code/modules/mob/living/sneak.dm
@@ -45,7 +45,8 @@
 
 // Movespeed modifier for sneaking. It's just 1.5x the slowness of walking.
 /datum/movespeed_modifier/config_walk_run/walk/sneak/sync()
-	return ..() * 1.5
+	var/mod = CONFIG_GET(number/movedelay/walk_delay)
+	multiplicative_slowdown = (isnum(mod) ? mod : initial(multiplicative_slowdown)) * 1.5
 
 // Syncs the sneak movespeed modifier with the walk movespeed modifier
 /datum/config_entry/number/movedelay/walk_delay/ValidateAndSet()
@@ -72,4 +73,40 @@
 /datum/keybinding/living/opposite_toggle_move_intent/up(client/user)
 	var/mob/living/M = user.mob
 	M.set_move_intent(MOVE_INTENT_WALK)
+	return TRUE
+
+/datum/keybinding/living/set_move_intent
+	hotkey_keys = list("Unbound")
+	name = "set_move_intent"
+	full_name = "Toggle Run"
+	description = "Press to start sprinting. Press again to stop."
+	keybind_signal = "keybinding_mob_setmoveintent"
+
+/datum/keybinding/living/set_move_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/M = user.mob
+	if(M.move_intent == MOVE_INTENT_RUN)
+		M.set_move_intent(MOVE_INTENT_WALK)
+	else
+		M.set_move_intent(MOVE_INTENT_RUN)
+	return TRUE
+
+/datum/keybinding/living/opposite_set_move_intent
+	hotkey_keys = list("Unbound")
+	name = "opposite_set_move_intent"
+	full_name = "Toggle Sneak"
+	description = "Press to start sneaking. Press again to stop."
+	keybind_signal = "keybinding_mob_oppositesetmoveintent"
+
+/datum/keybinding/living/opposite_set_move_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/M = user.mob
+	if(M.move_intent == MOVE_INTENT_SNEAK)
+		M.set_move_intent(MOVE_INTENT_WALK)
+	else
+		M.set_move_intent(MOVE_INTENT_SNEAK)
 	return TRUE

--- a/maplestation_modules/code/modules/mob/living/sneak.dm
+++ b/maplestation_modules/code/modules/mob/living/sneak.dm
@@ -1,16 +1,26 @@
 // Reworks toggle_move_intent to cycle rather than go back and forth
-/mob/living/toggle_move_intent()
-	switch(move_intent)
-		if(MOVE_INTENT_RUN)
-			move_intent = MOVE_INTENT_SNEAK
-		if(MOVE_INTENT_SNEAK)
-			move_intent = MOVE_INTENT_WALK
-		if(MOVE_INTENT_WALK)
-			move_intent = MOVE_INTENT_RUN
+/mob/living/toggle_move_intent(mob/user, backwards)
 
-	if(hud_used?.static_inventory)
-		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
-			selector.update_appearance()
+	if(backwards)
+		switch(move_intent)
+			if(MOVE_INTENT_RUN)
+				move_intent = MOVE_INTENT_WALK
+			if(MOVE_INTENT_WALK)
+				move_intent = MOVE_INTENT_SNEAK
+			if(MOVE_INTENT_SNEAK)
+				move_intent = MOVE_INTENT_RUN
+
+	else
+		switch(move_intent)
+			if(MOVE_INTENT_RUN)
+				move_intent = MOVE_INTENT_SNEAK
+			if(MOVE_INTENT_SNEAK)
+				move_intent = MOVE_INTENT_WALK
+			if(MOVE_INTENT_WALK)
+				move_intent = MOVE_INTENT_RUN
+
+	for(var/atom/movable/screen/mov_intent/selector in hud_used?.static_inventory)
+		selector.update_appearance()
 	update_move_intent_slowdown()
 
 /// Sets the mob's move intent to the passed intent

--- a/maplestation_modules/code/modules/mob/living/sneak.dm
+++ b/maplestation_modules/code/modules/mob/living/sneak.dm
@@ -1,0 +1,65 @@
+// Reworks toggle_move_intent to cycle rather than go back and forth
+/mob/living/toggle_move_intent()
+	switch(move_intent)
+		if(MOVE_INTENT_RUN)
+			move_intent = MOVE_INTENT_SNEAK
+		if(MOVE_INTENT_SNEAK)
+			move_intent = MOVE_INTENT_WALK
+		if(MOVE_INTENT_WALK)
+			move_intent = MOVE_INTENT_RUN
+
+	if(hud_used?.static_inventory)
+		for(var/atom/movable/screen/mov_intent/selector in hud_used.static_inventory)
+			selector.update_appearance()
+	update_move_intent_slowdown()
+
+/// Sets the mob's move intent to the passed intent
+/mob/living/proc/set_move_intent(new_intent)
+	if(move_intent == new_intent)
+		return
+
+	move_intent = new_intent
+	for(var/atom/movable/screen/mov_intent/selector in hud_used?.static_inventory)
+		selector.update_appearance()
+	update_move_intent_slowdown()
+
+// Adds sneak movespeed modifier as an option
+/mob/living/update_move_intent_slowdown()
+	switch(move_intent)
+		if(MOVE_INTENT_WALK)
+			add_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/walk)
+		if(MOVE_INTENT_RUN)
+			add_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/run)
+		if(MOVE_INTENT_SNEAK)
+			add_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/walk/sneak)
+
+// Movespeed modifier for sneaking. It's just 1.5x the slowness of walking.
+/datum/movespeed_modifier/config_walk_run/walk/sneak/sync()
+	return ..() * 1.5
+
+// Syncs the sneak movespeed modifier with the walk movespeed modifier
+/datum/config_entry/number/movedelay/walk_delay/ValidateAndSet()
+	. = ..()
+	var/datum/movespeed_modifier/config_walk_run/sneak = get_cached_movespeed_modifier(/datum/movespeed_modifier/config_walk_run/walk/sneak)
+	sneak.sync()
+
+// Keybind for sneak intent
+/datum/keybinding/living/opposite_toggle_move_intent
+	hotkey_keys = list("Unbound")
+	name = "opposite_toggle_move_intent"
+	full_name = "Hold to toggle sneak"
+	description = "Hold down to enable sneaking. Releasing will return you to walk."
+	keybind_signal = "keybinding_mob_oppositetogglemoveintent_down"
+
+/datum/keybinding/living/opposite_toggle_move_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/M = user.mob
+	M.set_move_intent(MOVE_INTENT_SNEAK)
+	return TRUE
+
+/datum/keybinding/living/opposite_toggle_move_intent/up(client/user)
+	var/mob/living/M = user.mob
+	M.set_move_intent(MOVE_INTENT_WALK)
+	return TRUE

--- a/maplestation_modules/code/modules/mob/living/sneak.dm
+++ b/maplestation_modules/code/modules/mob/living/sneak.dm
@@ -1,5 +1,5 @@
 // Reworks toggle_move_intent to cycle rather than go back and forth
-/mob/living/toggle_move_intent(mob/user, backwards)
+/mob/living/toggle_move_intent(backwards)
 
 	if(backwards)
 		switch(move_intent)

--- a/maplestation_modules/code/modules/mob/living/sprint.dm
+++ b/maplestation_modules/code/modules/mob/living/sprint.dm
@@ -1,5 +1,15 @@
 /atom/movable/screen/mov_intent
+	name = "run/walk/sneak cycle"
+	maptext_width = 64
+	maptext_x = 3
+	maptext_y = 20
+	/// Style applied to the maptext used on the selector
+	var/maptext_style = "text-align:center; -dm-text-outline: 1px black"
+	/// The sprint bar that appears over the bottom of our move selector
 	var/mutable_appearance/sprint_bar
+
+/atom/movable/screen/mov_intent/Click()
+	toggle(usr)
 
 /atom/movable/screen/mov_intent/update_overlays()
 	. = ..()
@@ -7,10 +17,7 @@
 		return
 
 	if(isnull(sprint_bar))
-		sprint_bar = mutable_appearance(
-			icon = 'icons/effects/progressbar.dmi',
-			icon_state = "prog_bar_100",
-		)
+		sprint_bar = mutable_appearance('icons/effects/progressbar.dmi')
 		sprint_bar.pixel_y -= 2
 
 	var/mob/living/carbon/human/runner = hud.mymob
@@ -76,7 +83,7 @@
 
 	// Okay you're gonna stamcrit yourself, slow your roll
 	if(getStaminaLoss() >= maxHealth * 0.9)
-		toggle_move_intent()
+		set_move_intent(MOVE_INTENT_WALK)
 		return
 
 	adjustStaminaLoss(1)

--- a/maplestation_modules/code/modules/mob/living/sprint.dm
+++ b/maplestation_modules/code/modules/mob/living/sprint.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/mov_intent
 	name = "run/walk/sneak cycle"
+	desc = "Cycles between move intents. Right click to cycle backwards."
 	maptext_width = 64
 	maptext_x = 3
 	maptext_y = 20
@@ -8,8 +9,9 @@
 	/// The sprint bar that appears over the bottom of our move selector
 	var/mutable_appearance/sprint_bar
 
-/atom/movable/screen/mov_intent/Click()
-	toggle(usr)
+/atom/movable/screen/mov_intent/Click(location, control, params)
+	var/list/modifiers = params2list(params)
+	cycle_intent(usr, backwards = LAZYACCESS(modifiers, RIGHT_CLICK))
 
 /atom/movable/screen/mov_intent/update_overlays()
 	. = ..()
@@ -23,6 +25,12 @@
 	var/mob/living/carbon/human/runner = hud.mymob
 	sprint_bar.icon_state = "prog_bar_[round(((runner.sprint_length / runner.sprint_length_max) * 100), 5)]"
 	. += sprint_bar
+
+/atom/movable/screen/mov_intent/proc/cycle_intent(mob/living/cycler, backwards = FALSE)
+	if(!istype(cycler))
+		return
+
+	cycler.toggle_move_intent(cycler, backwards)
 
 /datum/movespeed_modifier/momentum
 	movetypes = GROUND

--- a/maplestation_modules/code/modules/mob/living/sprint.dm
+++ b/maplestation_modules/code/modules/mob/living/sprint.dm
@@ -2,7 +2,7 @@
 	name = "run/walk/sneak cycle"
 	desc = "Cycles between move intents. Right click to cycle backwards."
 	maptext_width = 64
-	maptext_x = 3
+	maptext_x = -15
 	maptext_y = 20
 	/// Style applied to the maptext used on the selector
 	var/maptext_style = "text-align:center; -dm-text-outline: 1px black"
@@ -11,7 +11,7 @@
 
 /atom/movable/screen/mov_intent/Click(location, control, params)
 	var/list/modifiers = params2list(params)
-	cycle_intent(usr, backwards = LAZYACCESS(modifiers, RIGHT_CLICK))
+	cycle_intent(backwards = LAZYACCESS(modifiers, RIGHT_CLICK))
 
 /atom/movable/screen/mov_intent/update_overlays()
 	. = ..()
@@ -26,11 +26,12 @@
 	sprint_bar.icon_state = "prog_bar_[round(((runner.sprint_length / runner.sprint_length_max) * 100), 5)]"
 	. += sprint_bar
 
-/atom/movable/screen/mov_intent/proc/cycle_intent(mob/living/cycler, backwards = FALSE)
+/atom/movable/screen/mov_intent/proc/cycle_intent(backwards = FALSE)
+	var/mob/living/cycler = hud?.mymob
 	if(!istype(cycler))
 		return
 
-	cycler.toggle_move_intent(cycler, backwards)
+	cycler.toggle_move_intent(backwards)
 
 /datum/movespeed_modifier/momentum
 	movetypes = GROUND
@@ -56,12 +57,24 @@
 
 /mob/living/carbon/human/toggle_move_intent()
 	. = ..()
+	play_movespeed_sound()
+
+/mob/living/carbon/human/set_move_intent(new_intent)
+	. = ..()
+	play_movespeed_sound()
+
+/mob/living/carbon/human/proc/play_movespeed_sound()
 	if(!client?.prefs.read_preference(/datum/preference/toggle/sound_combatmode))
 		return
-	if(move_intent == MOVE_INTENT_RUN)
-		playsound_local(get_turf(src), 'maplestation_modules/sound/sprintactivate.ogg', 75, vary = FALSE, pressure_affected = FALSE)
-	else
-		playsound_local(get_turf(src), 'maplestation_modules/sound/sprintdeactivate.ogg', 75, vary = FALSE, pressure_affected = FALSE)
+	switch(move_intent)
+		if(MOVE_INTENT_RUN)
+			playsound_local(get_turf(src), 'maplestation_modules/sound/sprintactivate.ogg', 75, vary = FALSE, pressure_affected = FALSE)
+		if(MOVE_INTENT_WALK)
+			playsound_local(get_turf(src), 'maplestation_modules/sound/sprintdeactivate.ogg', 75, vary = FALSE, pressure_affected = FALSE)
+		if(MOVE_INTENT_SNEAK)
+			var/sound/sound_pitched = sound('maplestation_modules/sound/sprintdeactivate.ogg')
+			sound_pitched.pitch = 0.5
+			playsound_local(get_turf(src), sound_to_use = sound_pitched, vol = 75, vary = FALSE, pressure_affected = FALSE)
 
 /mob/living/carbon/human/Life(seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
Changes

- Walk is the default move mode. 
- Sneak mode 1.5x slower than walk mode. 
- `"Hold to toggle move intent"` hotkey has been repurposed to `"Hold to toggle sprint"`, IE, holding the hotkey will put you on run mode while you hold it
- `"Press to cycle move intent"` hotkey will now cycle in a circle, walk -> run -> sneak -> walk, etc
- `"Hold to toggle sneak" hotkey is a thing which is `"Hold to toggle sprint"` but for sneak, obviously. 
- Clicking on the movement selector on your hud will cycle walk -> run -> sneak -> walk, right clicking will go in reverse walk -> sneak -> run -> walk

Todo

- An `"Inverted press to cycle move intent"` hotkey which cycles backwards
- Sprites. I have no sneak mode sprites and no desire to sprite a sneak mode button for like 12 huds, so I just slapped maptext on all the buttons, which stick out greatly but ostensibly "works" 