### PR TITLE
Adds borg sprinting

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -143,6 +143,12 @@
 	action_intent.screen_loc = ui_combat_toggle
 	static_inventory += action_intent
 
+	using = new /atom/movable/screen/mov_intent(null, src)
+	using.screen_loc = ui_combat_toggle
+	using.icon = 'icons/hud/screen_slimecore.dmi'
+	using.update_appearance()
+	static_inventory += using
+
 //Health
 	healths = new /atom/movable/screen/healths/robot(null, src)
 	infodisplay += healths

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -5,3 +5,19 @@
 	if(ionpulse())
 		return TRUE
 	return FALSE
+
+/mob/living/silicon/robot
+	move_intent = MOVE_INTENT_WALK
+
+/mob/living/silicon/robot/Move(NewLoc, direct)
+	. = ..()
+	if(!.)
+		return
+	if(move_intent != MOVE_INTENT_RUN || stat == DEAD || pulledby)
+		return
+	if((movement_type & (FLOATING|FLYING)) || !(mobility_flags & (MOBILITY_MOVE|MOBILITY_STAND)))
+		return
+	if(low_power_mode || cell?.charge <= STANDARD_CELL_CHARGE * 0.005)
+		set_move_intent(MOVE_INTENT_WALK)
+		return
+	cell.use(STANDARD_CELL_CHARGE * 0.005)


### PR DESCRIPTION
I forgot cyborgs exist. 

Now they have a move selector on their hud. 
Sprinting as a borg uses energy per tile sprinted, a very small amount but eventually noticeable without an upgraded cell. 