### PR TITLE
Lets Lizards Customize Hiss Length

### DIFF
--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -184,6 +184,15 @@
 	liked_foodtypes = GORE | MEAT | SEAFOOD | NUTS | BUGS
 	disliked_foodtypes = GRAIN | DAIRY | CLOTH | GROSS
 	voice_filter = @{"[0:a] asplit [out0][out2]; [out0] asetrate=%SAMPLE_RATE%*0.9,aresample=%SAMPLE_RATE%,atempo=1/0.9,aformat=channel_layouts=mono,volume=0.2 [p0]; [out2] asetrate=%SAMPLE_RATE%*1.1,aresample=%SAMPLE_RATE%,atempo=1/1.1,aformat=channel_layouts=mono,volume=0.2[p2]; [p0][0][p2] amix=inputs=3"}
+	/// How long is our hissssssss?
+	var/draw_length = 3
+
+/obj/item/organ/internal/tongue/lizard/Initialize(mapload)
+	. = ..()
+	draw_length = rand(2, 6)
+	if(prob(10))
+		draw_length += 2
+
 /obj/item/organ/internal/tongue/lizard/modify_speech(datum/source, list/speech_args)
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
@@ -193,12 +202,12 @@
 	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = lizard_hiss.Replace(message, "sss")
-		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_kss.Replace(message, "$1kss")
-		message = lizard_kSS.Replace(message, "$1KSS")
-		message = lizard_ecks.Replace(message, "ecks$1")
-		message = lizard_eckS.Replace(message, "ECKS$1")
+		message = lizard_hiss.Replace(message, repeat_string(draw_length, "s"))
+		message = lizard_hiSS.Replace(message, repeat_string(draw_length, "S"))
+		message = lizard_kss.Replace(message, "$1k[repeat_string(max(draw_length - 1, 1), "s")]")
+		message = lizard_kSS.Replace(message, "$1K[repeat_string(max(draw_length - 1, 1), "S")]")
+		message = lizard_ecks.Replace(message, "eck[repeat_string(max(draw_length - 2, 1), "s")]$1")
+		message = lizard_eckS.Replace(message, "ECK[repeat_string(max(draw_length - 2, 1), "S")]$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/internal/tongue/lizard/silver

--- a/maplestation_modules/code/modules/client/preferences/species/lizard.dm
+++ b/maplestation_modules/code/modules/client/preferences/species/lizard.dm
@@ -7,10 +7,7 @@
 	default_value = FALSE
 
 /datum/preference/toggle/hair_lizard/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
-		return FALSE
-
-	return ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/lizard)
+	return ..() && ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/lizard)
 
 /datum/preference/toggle/hair_lizard/apply_to_human(mob/living/carbon/human/target, value)
 	if(!islizard(target))
@@ -40,3 +37,24 @@
 		"facial_hair_gradient",
 		"facial_hair_gradient_color",
 	)
+
+/datum/preference/numeric/hiss_length
+	savefile_key = "hiss_length"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	priority = PREFERENCE_PRIORITY_NAMES
+	can_randomize = FALSE
+	minimum = 2
+	maximum = 6
+
+/datum/preference/numeric/hiss_length/create_default_value()
+	return 3
+
+/datum/preference/numeric/hiss_length/is_accessible(datum/preferences/preferences)
+	return ..() && ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/lizard)
+
+/datum/preference/numeric/hiss_length/apply_to_human(mob/living/carbon/human/target, value)
+	var/obj/item/organ/internal/tongue/lizard/tongue = target.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue))
+		return
+	tongue.draw_length = value

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/_modular_species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/_modular_species_features.tsx
@@ -20,6 +20,12 @@ export const hair_lizard: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const hiss_length: FeatureNumeric = {
+  name: 'Hiss Length',
+  description: 'How long do you hissssss for?',
+  component: FeatureNumberInput,
+};
+
 export const feature_synth_species: FeatureChoiced = {
   name: 'Synth Species',
   description: 'Determines what species you spawn disguised as.',


### PR DESCRIPTION
Adds a preference allowing lizards to have (slightly) shorter or (much) longer hisses, to represent different drawls. 