### PR TITLE
Polite Split Personality (non-random Split Personality Variant)

### DIFF
--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6089,6 +6089,7 @@
 #include "maplestation_modules\code\controllers\subsystem\economy.dm"
 #include "maplestation_modules\code\controllers\subsystem\pain_subsystem.dm"
 #include "maplestation_modules\code\datums\shuttles.dm"
+#include "maplestation_modules\code\datums\brain_damage\split_personality.dm"
 #include "maplestation_modules\code\datums\components\easy_ignite.dm"
 #include "maplestation_modules\code\datums\components\knockoff_move.dm"
 #include "maplestation_modules\code\datums\components\limbless_aid.dm"

--- a/maplestation_modules/code/datums/brain_damage/split_personality.dm
+++ b/maplestation_modules/code/datums/brain_damage/split_personality.dm
@@ -34,8 +34,6 @@
 	var/datum/action/request_switch/twin_action
 	var/mob/living/split_personality/non_controller
 
-	var/switch_msg = span_boldnotice("You switch with your other personality.")
-
 /datum/action/request_switch/owner
 
 /datum/action/request_switch/stranger

--- a/maplestation_modules/code/datums/brain_damage/split_personality.dm
+++ b/maplestation_modules/code/datums/brain_damage/split_personality.dm
@@ -30,10 +30,6 @@
 
 	var/requested = FALSE
 
-	var/datum/brain_trauma/severe/split_personality/trauma
-	var/datum/action/request_switch/twin_action
-	var/mob/living/split_personality/non_controller
-
 /datum/action/request_switch/owner
 
 /datum/action/request_switch/stranger
@@ -50,11 +46,9 @@
 	if(!.)
 		return FALSE
 
-	trauma = target
-
 	requested = !requested
 
-/datum/action/request_switch/proc/handle_switch()
+/datum/action/request_switch/proc/handle_switch(datum/brain_trauma/severe/split_personality/trauma, datum/action/request_switch/twin_action)
 	trauma.switch_personalities()
 	requested = FALSE
 	twin_action.requested = FALSE
@@ -62,7 +56,11 @@
 
 /datum/action/request_switch/owner/Trigger(trigger_flags)
 	. = ..()
-	var/non_controller
+	if(!.)
+		return
+	var/datum/brain_trauma/severe/split_personality/trauma = target
+	var/datum/action/request_switch/twin_action
+	var/mob/living/split_personality/non_controller
 
 	if(trauma.current_controller == /*OWNER*/0)
 		twin_action = locate(/datum/action/request_switch) in trauma.stranger_backseat.actions
@@ -72,12 +70,18 @@
 		non_controller = trauma.owner_backseat
 
 	if(twin_action.requested)
-		handle_switch()
+		handle_switch(trauma, twin_action)
 	else
 		request(trauma.owner, non_controller)
 
 /datum/action/request_switch/stranger/Trigger(trigger_flags)
 	. = ..()
+	if(!.)
+		return
+
+	var/datum/brain_trauma/severe/split_personality/trauma = target
+	var/datum/action/request_switch/twin_action
+	var/mob/living/split_personality/non_controller
 
 	twin_action = locate(/datum/action/request_switch)  in trauma.owner.actions
 	if(trauma.current_controller == /*OWNER*/0)
@@ -86,7 +90,7 @@
 		non_controller = trauma.owner_backseat
 
 	if(twin_action.requested)
-		handle_switch()
+		handle_switch(trauma, twin_action)
 	else
 		request(trauma.owner, non_controller)
 

--- a/maplestation_modules/code/datums/brain_damage/split_personality.dm
+++ b/maplestation_modules/code/datums/brain_damage/split_personality.dm
@@ -102,7 +102,7 @@
 	var/str_cancelled_msg = span_boldnotice("You feel your other side giving up on taking direct control over your body.")
 
 	controller.balloon_alert(controller, "your brain tickles")
-	non_controller.balloon_alert(controller, "your brain tickles")
+	controller.balloon_alert(non_controller, "your brain tickles")
 	if(requested)
 		to_chat(non_controller, "[str_request_msg]")
 		to_chat(controller, "[str_requested_msg]")
@@ -119,7 +119,7 @@
 	var/own_cancelled_msg = span_boldnotice("You feel your other side giving up on giving you control.")
 
 	controller.balloon_alert(controller, "your brain tickles")
-	non_controller.balloon_alert(controller, "your brain tickles")
+	controller.balloon_alert(non_controller, "your brain tickles")
 	if(requested)
 		to_chat(non_controller, "[own_requested_msg]")
 		to_chat(controller, "[own_request_msg]")

--- a/maplestation_modules/code/datums/brain_damage/split_personality.dm
+++ b/maplestation_modules/code/datums/brain_damage/split_personality.dm
@@ -1,0 +1,105 @@
+/datum/brain_trauma/severe/split_personality/orderly/
+	name = "Orderly Split Personality"
+	desc = "Patient's brain is split into two personalities, which switch control of the body occasionally."
+
+
+/datum/brain_trauma/severe/split_personality/orderly/on_life(seconds_per_tick, times_fired)
+	return //no random switching
+
+/datum/brain_trauma/severe/split_personality/orderly/on_gain()
+	. = ..()
+	var/datum/action/request_switch/stranger/stranger_spell = new(src)
+	stranger_spell.Grant(stranger_backseat)
+
+	var/datum/action/request_switch/owner/owner_spell = new(src)
+	owner_spell.Grant(owner)
+
+
+// Action to request switch between bodies
+
+/datum/action/request_switch
+	name = "Request Switch"
+	desc = "Request to switch control over the shared body."
+	background_icon_state = "bg_spell"
+	button_icon = 'icons/mob/actions/actions_spells.dmi'
+	button_icon_state = "swap"
+	overlay_icon_state = "bg_spell_border"
+	var/requested = FALSE
+
+
+/datum/action/request_switch/owner
+
+/datum/action/request_switch/stranger
+
+/datum/action/request_switch/New(Target)
+	. = ..()
+
+	if(!istype(target, /datum/brain_trauma/severe/split_personality))
+		stack_trace("[type] was created on a target that isn't a /datum/brain_trauma/severe/split_personality, this doesn't work.")
+		qdel(src)
+
+/datum/action/request_switch/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	requested = !requested
+
+	if (requested)
+		to_chat(target, "REQUESTED")
+	else
+		to_chat(target, "NOT REQUESTED")
+
+/datum/action/request_switch/owner/Trigger(trigger_flags)
+	. = ..()
+
+	var/datum/brain_trauma/severe/split_personality/trauma = target
+	var/mob/living/carbon/human/personality_body = trauma.owner
+	var/mob/living/split_personality/non_controller = target.stranger_backseat
+
+	request(personality_body, non_controller)
+
+/datum/action/request_switch/stranger/Trigger(trigger_flags)
+	. = ..()
+
+	var/datum/brain_trauma/severe/split_personality/trauma = target
+	var/mob/living/carbon/human/personality_body = trauma.owner
+	var/mob/living/split_personality/non_controller = trauma.stranger_backseat
+
+	request(personality_body, non_controller)
+
+/datum/action/request_switch/stranger/proc/request(mob/controller, mob/non_controller)
+	var/str_request_msg = span_boldnotice("You concentrate on attempting to take direct control over your body.")
+	var/str_requested_msg = span_boldnotice("You feel your other side attempting to take direct control over your body.")
+
+	var/str_cancel_msg = span_boldnotice("You give up on attempting to take direct control over your body.")
+	var/str_cancelled_msg = span_boldnotice("You feel your other side giving up on taking direct control over your body.")
+
+	if(requested)
+		to_chat(non_controller, "STRANGER MSG [str_request_msg]")
+
+		controller.balloon_alert(controller, "your brain tickles")
+		to_chat(controller, "STRANGER MSG [str_requested_msg]")
+	else
+		to_chat(non_controller, "STRANGER MSG [str_cancel_msg]")
+
+		controller.balloon_alert(controller, "str your brain tickles")
+		to_chat(controller, "STRANGER MSG [str_cancelled_msg]")
+
+/datum/action/request_switch/owner/proc/request(mob/controller, mob/non_controller)
+	var/own_request_msg = span_boldnotice("You start to give up control over your body.")
+	var/own_requested_msg = span_boldnotice("You feel your body allowing your control over them.")
+
+	var/own_cancel_msg = span_boldnotice("You take back full control of your body.")
+	var/own_cancelled_msg = span_boldnotice("You feel your body taking back full control over them.")
+
+	if(requested)
+		to_chat(non_controller, "OWNER MSG [own_request_msg]")
+
+		controller.balloon_alert(controller, "your brain tickles")
+		to_chat(controller, "OWNER MSG [own_requested_msg]")
+	else
+		to_chat(non_controller, "OWNER MSG [own_cancel_msg]")
+
+		controller.balloon_alert(controller, "your brain tickles")
+		to_chat(controller, "OWNER MSG [own_cancelled_msg]")

--- a/maplestation_modules/code/datums/brain_damage/split_personality.dm
+++ b/maplestation_modules/code/datums/brain_damage/split_personality.dm
@@ -8,8 +8,11 @@
 
 /datum/brain_trauma/severe/split_personality/orderly/on_gain()
 	. = ..()
-	var/datum/action/request_switch/stranger/stranger_spell = new(src)
-	stranger_spell.Grant(stranger_backseat)
+	var/datum/action/request_switch/stranger/strangerseat_spell = new(src)
+	strangerseat_spell.Grant(stranger_backseat)
+
+	var/datum/action/request_switch/stranger/ownerseat_spell = new(src)
+	ownerseat_spell.Grant(owner_backseat)
 
 	var/datum/action/request_switch/owner/owner_spell = new(src)
 	owner_spell.Grant(owner)
@@ -24,8 +27,14 @@
 	button_icon = 'icons/mob/actions/actions_spells.dmi'
 	button_icon_state = "swap"
 	overlay_icon_state = "bg_spell_border"
+
 	var/requested = FALSE
 
+	var/datum/brain_trauma/severe/split_personality/trauma
+	var/datum/action/request_switch/twin_action
+	var/mob/living/split_personality/non_controller
+
+	var/switch_msg = span_boldnotice("You switch with your other personality.")
 
 /datum/action/request_switch/owner
 
@@ -43,30 +52,45 @@
 	if(!.)
 		return FALSE
 
+	trauma = target
+
 	requested = !requested
 
-	if (requested)
-		to_chat(target, "REQUESTED")
-	else
-		to_chat(target, "NOT REQUESTED")
+/datum/action/request_switch/proc/handle_switch()
+	trauma.switch_personalities()
+	requested = FALSE
+	twin_action.requested = FALSE
+	return
 
 /datum/action/request_switch/owner/Trigger(trigger_flags)
 	. = ..()
+	var/non_controller
 
-	var/datum/brain_trauma/severe/split_personality/trauma = target
-	var/mob/living/carbon/human/personality_body = trauma.owner
-	var/mob/living/split_personality/non_controller = target.stranger_backseat
+	if(trauma.current_controller == /*OWNER*/0)
+		twin_action = locate(/datum/action/request_switch) in trauma.stranger_backseat.actions
+		non_controller = trauma.stranger_backseat
+	else if(trauma.current_controller == /*STRANGER*/1)
+		twin_action = locate(/datum/action/request_switch) in trauma.owner_backseat.actions
+		non_controller = trauma.owner_backseat
 
-	request(personality_body, non_controller)
+	if(twin_action.requested)
+		handle_switch()
+	else
+		request(trauma.owner, non_controller)
 
 /datum/action/request_switch/stranger/Trigger(trigger_flags)
 	. = ..()
 
-	var/datum/brain_trauma/severe/split_personality/trauma = target
-	var/mob/living/carbon/human/personality_body = trauma.owner
-	var/mob/living/split_personality/non_controller = trauma.stranger_backseat
+	twin_action = locate(/datum/action/request_switch)  in trauma.owner.actions
+	if(trauma.current_controller == /*OWNER*/0)
+		non_controller = trauma.stranger_backseat
+	else if(trauma.current_controller == /*STRANGER*/1)
+		non_controller = trauma.owner_backseat
 
-	request(personality_body, non_controller)
+	if(twin_action.requested)
+		handle_switch()
+	else
+		request(trauma.owner, non_controller)
 
 /datum/action/request_switch/stranger/proc/request(mob/controller, mob/non_controller)
 	var/str_request_msg = span_boldnotice("You concentrate on attempting to take direct control over your body.")
@@ -75,31 +99,28 @@
 	var/str_cancel_msg = span_boldnotice("You give up on attempting to take direct control over your body.")
 	var/str_cancelled_msg = span_boldnotice("You feel your other side giving up on taking direct control over your body.")
 
+	controller.balloon_alert(controller, "your brain tickles")
+	non_controller.balloon_alert(controller, "your brain tickles")
 	if(requested)
-		to_chat(non_controller, "STRANGER MSG [str_request_msg]")
-
-		controller.balloon_alert(controller, "your brain tickles")
-		to_chat(controller, "STRANGER MSG [str_requested_msg]")
+		to_chat(non_controller, "[str_request_msg]")
+		to_chat(controller, "[str_requested_msg]")
 	else
-		to_chat(non_controller, "STRANGER MSG [str_cancel_msg]")
+		to_chat(non_controller, "[str_cancel_msg]")
+		to_chat(controller, "[str_cancelled_msg]")
 
-		controller.balloon_alert(controller, "str your brain tickles")
-		to_chat(controller, "STRANGER MSG [str_cancelled_msg]")
 
 /datum/action/request_switch/owner/proc/request(mob/controller, mob/non_controller)
-	var/own_request_msg = span_boldnotice("You start to give up control over your body.")
-	var/own_requested_msg = span_boldnotice("You feel your body allowing your control over them.")
+	var/own_request_msg = span_boldnotice("You concentrate on giving your other side control to your body.")
+	var/own_requested_msg = span_boldnotice("You feel your other side attempting to let you take over their body.")
 
-	var/own_cancel_msg = span_boldnotice("You take back full control of your body.")
-	var/own_cancelled_msg = span_boldnotice("You feel your body taking back full control over them.")
+	var/own_cancel_msg = span_boldnotice("You give up on attempting to give your other side control to your body.")
+	var/own_cancelled_msg = span_boldnotice("You feel your other side giving up on giving you control.")
 
+	controller.balloon_alert(controller, "your brain tickles")
+	non_controller.balloon_alert(controller, "your brain tickles")
 	if(requested)
-		to_chat(non_controller, "OWNER MSG [own_request_msg]")
-
-		controller.balloon_alert(controller, "your brain tickles")
-		to_chat(controller, "OWNER MSG [own_requested_msg]")
+		to_chat(non_controller, "[own_requested_msg]")
+		to_chat(controller, "[own_request_msg]")
 	else
-		to_chat(non_controller, "OWNER MSG [own_cancel_msg]")
-
-		controller.balloon_alert(controller, "your brain tickles")
-		to_chat(controller, "OWNER MSG [own_cancelled_msg]")
+		to_chat(non_controller, "[own_cancelled_msg]")
+		to_chat(controller, "[own_cancel_msg]")


### PR DESCRIPTION
This version of Split Personality, instead of randomly changing, adds a new action shared between the two players which can be turned on or off.

If both of them are on, the players switch control on mutual demand instead.

Don't ask me why.