### PR TITLE
Fixes borked VSC settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,5 @@
 		"*.dmi": "dmiEditor.dmiEditor"
 	},
 	"Lua.diagnostics.enable": false,
-	"editor.insertSpaces": false,
+	"editor.insertSpaces": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
 	"workbench.editorAssociations": {
 		"*.dmi": "dmiEditor.dmiEditor"
 	},
-	"Lua.diagnostics.enable": false
+	"Lua.diagnostics.enable": false,
+	"editor.insertSpaces": false,
 }


### PR DESCRIPTION
Sets default indentation to tabs instead of spaces, no idea why it broke for the repo but this forces VSC to use correct indents regardless of .dm settings