### PR TITLE
Adds defenestration and bullet penetrating glass

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -78,7 +78,7 @@
 	if((flags & CALTROP_IGNORE_WALKERS) && digitigrade_fan.move_intent == MOVE_INTENT_WALK)
 		return
 
-	if(digitigrade_fan.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) //check if they are able to pass over us
+	if((digitigrade_fan.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) || !QDELETED(digitigrade_fan.throwing)) //check if they are able to pass over us
 		//gravity checking only our parent would prevent us from triggering they're using magboots / other gravity assisting items that would cause them to still touch us.
 		return
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,6 +1,8 @@
 
 /obj/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	. = ..()
+	if(QDELETED(src))
+		return
 	hit_by_damage(AM, throwingdatum)
 
 /obj/proc/hit_by_damage(atom/movable/hitting_us, datum/thrownthing/throwingdatum)
@@ -52,8 +54,8 @@
 		if(has_grille && prob(66))
 			continue
 
-		defenestrated.apply_damage(10, BRUTE, part, blocked = min(90, defenestrated.getarmor(part, MELEE)), sharpness = SHARP_POINTY, bare_wound_bonus = 12, attacking_item = (length(shards) ? shards[1] : "glass"))
-		if(prob(25 * length(shards)) && shards[1].tryEmbed(part, zone))
+		defenestrated.apply_damage(10, BRUTE, part, blocked = min(90, defenestrated.getarmor(part, MELEE)), sharpness = SHARP_POINTY, wound_bonus = 4, bare_wound_bonus = 8, attacking_item = (length(shards) ? shards[1] : "glass"))
+		if(prob(25 * length(shards)) && shards[1].tryEmbed(part, TRUE))
 			shards -= shards[1]
 
 	if(has_grille)
@@ -79,7 +81,7 @@
 		return ..()
 
 	// take a lot of damage from being hit with a mob - so we can defenestrate
-	take_damage(min(max_integrity * 0.75, max_integrity * 0.5 * (100 / get_armor_rating(MELEE))), BRUTE, MELEE, TRUE, get_dir(src, hitting_us), 0)
+	take_damage(max_integrity * min(0.75, (get_armor_rating(MELEE) / 100)), BRUTE, MELEE, TRUE, get_dir(src, hitting_us), 0)
 
 /obj/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,7 +1,85 @@
 
 /obj/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	..()
-	take_damage(AM.throwforce, BRUTE, MELEE, 1, get_dir(src, AM))
+	. = ..()
+	hit_by_damage(AM, throwingdatum)
+
+/obj/proc/hit_by_damage(atom/movable/hitting_us, datum/thrownthing/throwingdatum)
+	var/base_dam = hitting_us.throwforce
+	if(isliving(hitting_us))
+		var/mob/living/living_mob = hitting_us
+		var/speed_bonus = throwingdatum.speed - living_mob.throw_speed
+		if(speed_bonus > 0)
+			base_dam += (5 * speed_bonus)
+		base_dam += (5 * max(0, living_mob.mob_size - 1))
+	if(isitem(hitting_us))
+		var/obj/item/hit_item = hitting_us
+		base_dam += (5 * max(0, hit_item.w_class - 2))
+
+	// no armor penetration
+	take_damage(base_dam, BRUTE, MELEE, TRUE, get_dir(src, hitting_us), 0)
+
+/obj/structure/window/Initialize(mapload, direct)
+	. = ..()
+	// glass will buckle before being pushed around
+	ADD_TRAIT(src, TRAIT_NO_THROW_HITPUSH, INNATE_TRAIT)
+
+/obj/structure/window/Cross(atom/movable/crossed_atom)
+	. = ..()
+	if(.)
+		return .
+	if(!isliving(crossed_atom) || QDELETED(crossed_atom.throwing))
+		return .
+	if(anchored && get_integrity_percentage() > 0.5)
+		return .
+
+	var/turf/old_loc = loc
+
+	take_damage(INFINITY, BRUTE, MELEE, TRUE, get_dir(src, crossed_atom), 0)
+
+	if(!QDELETED(src))
+		return .
+
+	var/mob/living/defenestrated = crossed_atom
+	var/has_grille = locate(/obj/structure/grille) in old_loc
+	var/list/obj/item/shards = list()
+	for(var/obj/item/shard/shard in old_loc)
+		shards += shard
+
+	for(var/zone in shuffle(BODY_ZONES_ALL))
+		var/obj/item/bodypart/part = defenestrated.get_bodypart(zone)
+		if(!part)
+			continue
+		if(has_grille && prob(66))
+			continue
+
+		defenestrated.apply_damage(10, BRUTE, part, blocked = min(90, defenestrated.getarmor(part, MELEE)), sharpness = SHARP_POINTY, bare_wound_bonus = 12, attacking_item = (length(shards) ? shards[1] : "glass"))
+		if(prob(25 * length(shards)) && shards[1].tryEmbed(part, zone))
+			shards -= shards[1]
+
+	if(has_grille)
+		defenestrated.Paralyze(1 SECONDS)
+		defenestrated.Knockdown(2 SECONDS)
+		defenestrated.visible_message(
+			span_danger("[defenestrated] is thrown against [src], shattering it!"),
+			span_userdanger("You are thrown against [src], shattering it!"),
+		)
+
+	else
+		defenestrated.Paralyze(3 SECONDS)
+		defenestrated.Knockdown(6 SECONDS)
+		defenestrated.visible_message(
+			span_danger("[defenestrated] is thrown clean through [src]!"),
+			span_userdanger("You are thrown clean through [src]!"),
+		)
+
+	return TRUE
+
+/obj/structure/window/hit_by_damage(atom/movable/hitting_us, datum/thrownthing/throwingdatum)
+	if(reinf || !isliving(hitting_us))
+		return ..()
+
+	// take a lot of damage from being hit with a mob - so we can defenestrate
+	take_damage(min(max_integrity * 0.75, max_integrity * 0.5 * (100 / get_armor_rating(MELEE))), BRUTE, MELEE, TRUE, get_dir(src, hitting_us), 0)
 
 /obj/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)
@@ -46,6 +124,19 @@
 		)
 
 	return damage_sustained > 0 ? BULLET_ACT_HIT : BULLET_ACT_BLOCK
+
+/obj/structure/window/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
+	// don't smack the window and its grille same turf, ever
+	for(var/obj/structure/grille/grille in loc)
+		hitting_projectile.impacted[grille] = TRUE
+
+	. = ..()
+	if(QDELETED(hitting_projectile) || . != BULLET_ACT_HIT)
+		return .
+	if(QDELETED(src) && prob(80))
+		// right through the window!
+		return BULLET_ACT_FORCE_PIERCE
+	return .
 
 /obj/attack_hulk(mob/living/carbon/human/user)
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -60,8 +60,10 @@
 			take_bodypart_damage(5 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 		else if(!iscarbon(hit_atom) && extra_speed)
 			take_bodypart_damage(5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
-		visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? " really hard" : ""]"),\
-			span_userdanger("You violently crash into [hit_atom][extra_speed ? " extra hard" : ""]!"))
+		visible_message(
+			span_danger("[src] crashes into [hit_atom][extra_speed ? " really hard" : ""]!"),
+			span_userdanger("You [extra_speed ? "violently" : ""] crash into [hit_atom][extra_speed ? " extra hard" : ""]!"),
+		)
 		log_combat(hit_atom, src, "crashes ")
 		oof_noise = TRUE
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -62,7 +62,7 @@
 			take_bodypart_damage(5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 		visible_message(
 			span_danger("[src] crashes into [hit_atom][extra_speed ? " really hard" : ""]!"),
-			span_userdanger("You [extra_speed ? "violently" : ""] crash into [hit_atom][extra_speed ? " extra hard" : ""]!"),
+			span_userdanger("You[extra_speed ? " violently" : ""] crash into [hit_atom][extra_speed ? " extra hard" : ""]!"),
 		)
 		log_combat(hit_atom, src, "crashes ")
 		oof_noise = TRUE


### PR DESCRIPTION
1.

If a bullet would fully shatter a window, there's an 80% chance the shot will continue.

2.

Being tossed against a (non-reinforced) window now does considerably more damage (to the window)
By default, normal windows require a human to be chucked at it twice to break.

If the toss would shatter the window, you would instead fly _through_ the window, assuming it has no grille. 
This does additional damage (to you) and may cause the shards to embed.

(Demo, has since been tweaked)

https://github.com/user-attachments/assets/0d6156f0-ecba-4799-9eea-805d8272a197
