### PR TITLE
Fix canes in pockets

### DIFF
--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -41,6 +41,7 @@
 	SIGNAL_HANDLER
 
 	if(!(slot & required_slot))
+		lose_support(user)
 		return
 
 	add_support(user)


### PR DESCRIPTION
Canes no longer count as assisting you while pocketed.