### PR TITLE
Adds Limping Quirk

### DIFF
--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -52,8 +52,8 @@
 	update_limp()
 	if(QDELETED(src)) // update limp might have removed us
 		return FALSE
-	RegisterSignal(C, COMSIG_MOVABLE_MOVED, PROC_REF(check_step))
-	RegisterSignals(C, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB), PROC_REF(update_limp))
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_step))
+	RegisterSignals(owner, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB), PROC_REF(update_limp))
 	return TRUE
 
 /datum/status_effect/limp/on_remove()

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -30,7 +30,6 @@
 	status_type = STATUS_EFFECT_REPLACE
 	tick_interval = -1
 	alert_type = /atom/movable/screen/alert/status_effect/limp
-	var/msg_stage = 0//so you dont get the most intense messages immediately
 	/// The left leg of the limping person
 	var/obj/item/bodypart/leg/left/left
 	/// The right leg of the limping person
@@ -59,6 +58,9 @@
 
 /datum/status_effect/limp/on_remove()
 	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB))
+	next_leg = null
+	left = null
+	right = null
 
 /atom/movable/screen/alert/status_effect/limp
 	name = "Limping"
@@ -71,6 +73,7 @@
 		return
 
 	if(SEND_SIGNAL(owner, COMSIG_CARBON_LIMPING, (next_leg || right || left)) & COMPONENT_CANCEL_LIMP)
+		next_leg = (next_leg == left ? right : left)
 		return
 
 	// less limping while we have determination still
@@ -91,9 +94,10 @@
 	var/mob/living/carbon/C = owner
 	left = C.get_bodypart(BODY_ZONE_L_LEG)
 	right = C.get_bodypart(BODY_ZONE_R_LEG)
+	next_leg = null
 
 	if(!left && !right)
-		C.remove_status_effect(src)
+		qdel(src)
 		return
 
 	slowdown_left = 0
@@ -116,7 +120,7 @@
 
 	// this handles losing your leg with the limp and the other one being in good shape as well
 	if(!slowdown_left && !slowdown_right)
-		C.remove_status_effect(src)
+		qdel(src)
 		return
 
 

--- a/code/datums/status_effects/wound_effects.dm
+++ b/code/datums/status_effects/wound_effects.dm
@@ -30,6 +30,7 @@
 	status_type = STATUS_EFFECT_REPLACE
 	tick_interval = -1
 	alert_type = /atom/movable/screen/alert/status_effect/limp
+	on_remove_on_mob_delete = TRUE
 	/// The left leg of the limping person
 	var/obj/item/bodypart/leg/left/left
 	/// The right leg of the limping person
@@ -48,10 +49,9 @@
 /datum/status_effect/limp/on_apply()
 	if(!iscarbon(owner))
 		return FALSE
-	var/mob/living/carbon/C = owner
-	left = C.get_bodypart(BODY_ZONE_L_LEG)
-	right = C.get_bodypart(BODY_ZONE_R_LEG)
 	update_limp()
+	if(QDELETED(src)) // update limp might have removed us
+		return FALSE
 	RegisterSignal(C, COMSIG_MOVABLE_MOVED, PROC_REF(check_step))
 	RegisterSignals(C, list(COMSIG_CARBON_GAIN_WOUND, COMSIG_CARBON_POST_LOSE_WOUND, COMSIG_CARBON_ATTACH_LIMB, COMSIG_CARBON_REMOVE_LIMB), PROC_REF(update_limp))
 	return TRUE
@@ -91,9 +91,8 @@
 /datum/status_effect/limp/proc/update_limp()
 	SIGNAL_HANDLER
 
-	var/mob/living/carbon/C = owner
-	left = C.get_bodypart(BODY_ZONE_L_LEG)
-	right = C.get_bodypart(BODY_ZONE_R_LEG)
+	left = owner.get_bodypart(BODY_ZONE_L_LEG)
+	right = owner.get_bodypart(BODY_ZONE_R_LEG)
 	next_leg = null
 
 	if(!left && !right)
@@ -107,14 +106,12 @@
 
 	// technically you can have multiple wounds causing limps on the same limb, even if practically only bone wounds cause it in normal gameplay
 	if(left)
-		for(var/thing in left.wounds)
-			var/datum/wound/W = thing
+		for(var/datum/wound/W as anything in left.wounds)
 			slowdown_left += W.limp_slowdown
 			limp_chance_left = max(limp_chance_left, W.limp_chance)
 
 	if(right)
-		for(var/thing in right.wounds)
-			var/datum/wound/W = thing
+		for(var/datum/wound/W as anything in right.wounds)
 			slowdown_right += W.limp_slowdown
 			limp_chance_right = max(limp_chance_right, W.limp_chance)
 

--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -87,9 +87,7 @@
 /// Checks what side the item is equipped on
 /datum/component/limbless_aid/proc/get_braced_leg(mob/living/who)
 	if(required_slot & ITEM_SLOT_HANDS)
-		// note this is backwards intentionally:
-		// right arm braces the left leg, and left arm braces right leg
-		var/side = IS_RIGHT_ARM(who.get_held_index_of_item(parent)) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG
+		var/side = IS_RIGHT_ARM(who.get_held_index_of_item(parent)) ? BODY_ZONE_R_LEG : BODY_ZONE_L_LEG
 		return who.get_bodypart(side)
 
 	return null // unimplemented

--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -68,31 +68,33 @@
 	user.update_limbless_locomotion()
 	user.update_limbless_movespeed_mod()
 
+#define IS_RIGHT_ARM(index) (index % 2 == 0)
+
 /datum/component/limbless_aid/proc/modify_movespeed(mob/living/source, list/modifiers)
 	SIGNAL_HANDLER
 
-	var/obj/item/bodypart/leg = get_braced_leg(source)
+	var/obj/item/bodypart/leg
+	if(required_slot & ITEM_SLOT_HANDS)
+		// this is not backwards intentionally:
+		// if you're missing the left leg, you need the left leg braced
+		var/side = IS_RIGHT_ARM(source.get_held_index_of_item(parent)) ? BODY_ZONE_R_LEG : BODY_ZONE_L_LEG
+		leg = source.get_bodypart(side)
+
 	if(isnull(leg) || leg.bodypart_disabled)
 		modifiers += movespeed_mod
 
 /datum/component/limbless_aid/proc/limp_check(mob/living/source, obj/item/bodypart/next_leg)
 	SIGNAL_HANDLER
 
-	var/obj/item/bodypart/leg = get_braced_leg(source)
-	if(isnull(leg) || leg == next_leg)
-		return COMPONENT_CANCEL_LIMP
-
-#define IS_RIGHT_ARM(index) (index % 2 == 0)
-
-/// Checks what side the item is equipped on
-/datum/component/limbless_aid/proc/get_braced_leg(mob/living/who)
+	var/obj/item/bodypart/leg
 	if(required_slot & ITEM_SLOT_HANDS)
 		// note this is backwards intentionally:
-		// right arm braces the left leg, and left arm braces right leg
-		var/side = IS_RIGHT_ARM(who.get_held_index_of_item(parent)) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG
-		return who.get_bodypart(side)
+		// you use your right arm to brace your left leg, and vice versa
+		var/side = IS_RIGHT_ARM(source.get_held_index_of_item(parent)) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG
+		leg = source.get_bodypart(side)
 
-	return null // unimplemented
+	if(isnull(leg) || leg == next_leg)
+		return COMPONENT_CANCEL_LIMP
 
 #undef IS_RIGHT_ARM
 

--- a/maplestation_modules/code/datums/components/limbless_aid.dm
+++ b/maplestation_modules/code/datums/components/limbless_aid.dm
@@ -87,7 +87,9 @@
 /// Checks what side the item is equipped on
 /datum/component/limbless_aid/proc/get_braced_leg(mob/living/who)
 	if(required_slot & ITEM_SLOT_HANDS)
-		var/side = IS_RIGHT_ARM(who.get_held_index_of_item(parent)) ? BODY_ZONE_R_LEG : BODY_ZONE_L_LEG
+		// note this is backwards intentionally:
+		// right arm braces the left leg, and left arm braces right leg
+		var/side = IS_RIGHT_ARM(who.get_held_index_of_item(parent)) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG
 		return who.get_bodypart(side)
 
 	return null // unimplemented

--- a/maplestation_modules/code/datums/quirks/negative.dm
+++ b/maplestation_modules/code/datums/quirks/negative.dm
@@ -146,9 +146,9 @@
 
 	var/obj/item/given = new cane_type()
 	if(side == SIDE_LEFT)
-		. = quirk_holder.put_in_l_hand(given)
+		. = quirk_holder.put_in_r_hand(given) // reversed
 	if(side == SIDE_RIGHT)
-		. = quirk_holder.put_in_r_hand(given)
+		. = quirk_holder.put_in_l_hand(given) // reversed
 	if(!.)
 		. = quirk_holder.put_in_hands(given)
 

--- a/maplestation_modules/code/datums/quirks/negative.dm
+++ b/maplestation_modules/code/datums/quirks/negative.dm
@@ -136,8 +136,11 @@
 		if(NO_CANE)
 			mail_goodies |= /obj/item/reagent_containers/pill/morphine/diluted
 
-	if(intensity == INTENSITY_HIGH)
-		mail_goodies |= /obj/item/reagent_containers/pill/morphine/diluted
+	switch(intensity)
+		if(INTENSITY_MEDIUM)
+			mail_goodies |= /obj/item/reagent_containers/pill/paracetamol
+		if(INTENSITY_HIGH)
+			mail_goodies |= /obj/item/reagent_containers/pill/morphine/diluted
 
 	quirk_holder.apply_status_effect(/datum/status_effect/limp/permanent, side, intensity)
 

--- a/maplestation_modules/code/datums/quirks/negative.dm
+++ b/maplestation_modules/code/datums/quirks/negative.dm
@@ -93,3 +93,191 @@
 	INVOKE_ASYNC(quirk_holder, TYPE_PROC_REF(/mob/living, pain_emote))
 	quirk_holder.add_mood_event("bad_touch", /datum/mood_event/very_bad_touch)
 	COOLDOWN_START(src, time_since_last_touch, 30 SECONDS)
+
+#define CANE_BASIC "Cane (Black)"
+#define CANE_MEDICAL "Cane (Medical)"
+#define CANE_WOODEN "Cane (Wooden)"
+#define NO_CANE "None"
+
+#define INTENSITY_LOW "Low (1/5th of a second)"
+#define INTENSITY_MEDIUM "Medium (2/5ths of a second)"
+#define INTENSITY_HIGH "High (3/5ths of a second)"
+
+#define SIDE_LEFT "Left"
+#define SIDE_RIGHT "Right"
+#define SIDE_RANDOM "Random"
+
+/datum/quirk/limp
+	name = "Limp"
+	desc = "You have a limp, making you slower and less agile."
+	icon = FA_ICON_WALKING
+	value = -4
+	gain_text = span_danger("You feel a limp.")
+	lose_text = span_notice("You feel less of a limp.")
+	medical_record_text = "Patient has a limp in one of their legs."
+
+/datum/quirk/limp/add_unique(client/client_source)
+	var/cane = client_source?.prefs?.read_preference(/datum/preference/choiced/limp_cane) || NO_CANE
+	var/intensity = client_source?.prefs?.read_preference(/datum/preference/choiced/limp_intensity) || INTENSITY_LOW
+	var/side = client_source?.prefs?.read_preference(/datum/preference/choiced/limp_side) || SIDE_RANDOM
+	if(side == SIDE_RANDOM)
+		side = pick(SIDE_LEFT, SIDE_RIGHT)
+
+	switch(cane)
+		if(CANE_BASIC)
+			give_cane(/obj/item/cane, side)
+			mail_goodies |= /obj/item/cane
+		if(CANE_MEDICAL)
+			give_cane(/obj/item/cane/crutch, side)
+			mail_goodies |= /obj/item/cane/crutch
+		if(CANE_WOODEN)
+			give_cane(/obj/item/cane/crutch/wood, side)
+			mail_goodies |= /obj/item/cane/crutch/wood
+		if(NO_CANE)
+			mail_goodies |= /obj/item/reagent_containers/pill/morphine/diluted
+
+	if(intensity == INTENSITY_HIGH)
+		mail_goodies |= /obj/item/reagent_containers/pill/morphine/diluted
+
+	quirk_holder.apply_status_effect(/datum/status_effect/limp/permanent, side, intensity)
+
+/datum/quirk/limp/proc/give_cane(cane_type, side)
+	. = FALSE
+
+	var/obj/item/given = new cane_type()
+	if(side == SIDE_LEFT)
+		. = quirk_holder.put_in_l_hand(given)
+	if(side == SIDE_RIGHT)
+		. = quirk_holder.put_in_r_hand(given)
+	if(!.)
+		. = quirk_holder.put_in_hands(given)
+
+/datum/quirk/limp/remove()
+	quirk_holder.remove_status_effect(/datum/status_effect/limp/permanent)
+
+/datum/status_effect/limp/permanent
+	id = "perma_limp"
+	alert_type = null
+
+/datum/status_effect/limp/permanent/on_creation(mob/living/new_owner, side = pick(SIDE_LEFT, SIDE_RIGHT), intensity = INTENSITY_LOW)
+	// setting to 150, because adrenaline halves limp chance
+	switch(side)
+		if(SIDE_LEFT)
+			limp_chance_left = 150
+		if(SIDE_RIGHT)
+			limp_chance_right = 150
+
+	// we can set both since it'll have a 0% chance for the unused side anyways
+	switch(intensity)
+		if(INTENSITY_LOW)
+			slowdown_left = slowdown_right = 0.2 SECONDS
+		if(INTENSITY_MEDIUM)
+			slowdown_left = slowdown_right = 0.4 SECONDS
+		if(INTENSITY_HIGH)
+			slowdown_left = slowdown_right = 0.6 SECONDS
+
+	return ..()
+
+/datum/status_effect/limp/permanent/update_limp()
+	left = owner.get_bodypart(BODY_ZONE_L_LEG)
+	right = owner.get_bodypart(BODY_ZONE_R_LEG)
+	next_leg = null
+
+
+/datum/quirk_constant_data/limp
+	associated_typepath = /datum/quirk/limp
+	customization_options = list(
+		/datum/preference/choiced/limp_cane,
+		/datum/preference/choiced/limp_intensity,
+		/datum/preference/choiced/limp_side,
+	)
+
+/datum/preference/choiced/limp_cane
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "limp_cane"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	should_generate_icons = TRUE
+
+/datum/preference/choiced/limp_cane/create_default_value()
+	return CANE_BASIC
+
+/datum/preference/choiced/limp_cane/init_possible_values()
+	return list(CANE_BASIC, CANE_MEDICAL, CANE_WOODEN, NO_CANE)
+
+/datum/preference/choiced/limp_cane/icon_for(value)
+	switch(value)
+		if(CANE_BASIC)
+			return icon(/obj/item/cane::icon, /obj/item/cane::icon_state)
+		if(CANE_MEDICAL)
+			return icon(/obj/item/cane/crutch::icon, /obj/item/cane/crutch::icon_state)
+		if(CANE_WOODEN)
+			return icon(/obj/item/cane/crutch/wood::icon, /obj/item/cane/crutch/wood::icon_state)
+		if(NO_CANE)
+			return icon('icons/hud/screen_gen.dmi', "x")
+
+	return icon('icons/effects/random_spawners.dmi', "questionmark")
+
+/datum/preference/choiced/limp_cane/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+
+	return /datum/quirk/limp::name in preferences.all_quirks
+
+/datum/preference/choiced/limp_cane/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/choiced/limp_intensity
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "limp_intensity"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/limp_intensity/create_default_value()
+	return INTENSITY_LOW
+
+/datum/preference/choiced/limp_intensity/init_possible_values()
+	return list(INTENSITY_LOW, INTENSITY_MEDIUM, INTENSITY_HIGH)
+
+/datum/preference/choiced/limp_intensity/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+
+	return /datum/quirk/limp::name in preferences.all_quirks
+
+/datum/preference/choiced/limp_intensity/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/choiced/limp_side
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "limp_side"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/limp_side/create_default_value()
+	return SIDE_RANDOM
+
+/datum/preference/choiced/limp_side/init_possible_values()
+	return list(SIDE_LEFT, SIDE_RIGHT, SIDE_RANDOM)
+
+/datum/preference/choiced/limp_side/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+
+	return /datum/quirk/limp::name in preferences.all_quirks
+
+/datum/preference/choiced/limp_side/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+#undef CANE_BASIC
+#undef CANE_MEDICAL
+#undef CANE_WOODEN
+#undef NO_CANE
+
+#undef INTENSITY_LOW
+#undef INTENSITY_MEDIUM
+#undef INTENSITY_HIGH
+
+#undef SIDE_LEFT
+#undef SIDE_RIGHT
+#undef SIDE_RANDOM

--- a/maplestation_modules/code/datums/quirks/negative.dm
+++ b/maplestation_modules/code/datums/quirks/negative.dm
@@ -146,11 +146,13 @@
 
 	var/obj/item/given = new cane_type()
 	if(side == SIDE_LEFT)
-		. = quirk_holder.put_in_r_hand(given) // reversed
+		. = quirk_holder.put_in_r_hand(given) // reversed (it makes sense just think about it)
 	if(side == SIDE_RIGHT)
-		. = quirk_holder.put_in_l_hand(given) // reversed
+		. = quirk_holder.put_in_l_hand(given) // reversed (same)
 	if(!.)
-		. = quirk_holder.put_in_hands(given)
+		. = quirk_holder.put_in_hands(given) // if it fails now, it will dump the ground. acceptable
+
+	return .
 
 /datum/quirk/limp/remove()
 	quirk_holder.remove_status_effect(/datum/status_effect/limp/permanent)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/limp.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/limp.tsx
@@ -1,0 +1,21 @@
+import {
+  FeatureChoiced,
+  FeatureDropdownInput,
+  FeatureIconnedDropdownInput,
+  FeatureWithIcons,
+} from '../base';
+
+export const limp_cane: FeatureWithIcons<string> = {
+  name: 'Limp Aid',
+  component: FeatureIconnedDropdownInput,
+};
+
+export const limp_intensity: FeatureChoiced = {
+  name: 'Limp Intensity',
+  component: FeatureDropdownInput,
+};
+
+export const limp_side: FeatureChoiced = {
+  name: 'Limp Side',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
Very simple quirk. It makes you limp every other step, as if your leg was wounded. Using a cane prevents the limp. 

You can choose which side you want limping, as well as if you spawn with a cane (and what type of cane), and how intense the limp is. 

Important to note, this is a guaranteed* limp every other step, where normally wounds are an RNG chance to limp.
*While under the effects of adrenaline from combat, you have a 25% chance to not limp. I left that in.
