### PR TITLE
Adds some anti-addiction chemicals, also finally adds a reagent tag for pain for sorting

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -183,8 +183,10 @@
 #define REACTION_TAG_CHEMICAL (1<<18)
 /// This reaction is produces a product that affects plants
 #define REACTION_TAG_PLANT (1<<19)
-/// This reaction is produces a product that affects plants
+/// This reaction competes with another reaction in specific circumstances, like hot vs cold
 #define REACTION_TAG_COMPETITIVE (1<<20)
+/// This reaction is produces a product which assuages (or causes) pain
+#define REACTION_TAG_PAIN (1<<21)
 
 //flags used by holder.dm to locate an reagent
 ///Direct type

--- a/code/modules/reagents/chemistry/holder/ui_data.dm
+++ b/code/modules/reagents/chemistry/holder/ui_data.dm
@@ -278,6 +278,7 @@
 	data["bitflags"]["CHEMICAL"] = REACTION_TAG_CHEMICAL
 	data["bitflags"]["PLANT"] = REACTION_TAG_PLANT
 	data["bitflags"]["COMPETITIVE"] = REACTION_TAG_COMPETITIVE
+	data["bitflags"]["PAIN"] = REACTION_TAG_PAIN
 
 	return data
 
@@ -406,6 +407,9 @@
 			return TRUE
 		if("toggle_tag_competitive")
 			ui_tags_selected = ui_tags_selected ^ REACTION_TAG_COMPETITIVE
+			return TRUE
+		if("toggle_tag_pain")
+			ui_tags_selected = ui_tags_selected ^ REACTION_TAG_PAIN
 			return TRUE
 		if("update_ui")
 			return TRUE

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -96,12 +96,12 @@
 /datum/chemical_reaction/medicine/mine_salve
 	results = list(/datum/reagent/medicine/mine_salve = 3)
 	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/water = 1, /datum/reagent/iron = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/mine_salve2
 	results = list(/datum/reagent/medicine/mine_salve = 15)
 	required_reagents = list(/datum/reagent/toxin/plasma = 5, /datum/reagent/iron = 5, /datum/reagent/consumable/sugar = 1) // A sheet of plasma, a twinkie and a sheet of metal makes four of these
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/synthflesh
 	results = list(/datum/reagent/medicine/c2/synthflesh = 3)
@@ -119,7 +119,7 @@
 	rate_up_lim = 20 //affected by pH too
 	purity_min = 0.3
 	reaction_flags = REACTION_PH_VOL_CONSTANT
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE | REACTION_TAG_BURN | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/medicine/calomel
 	results = list(/datum/reagent/medicine/calomel = 2)
@@ -130,17 +130,17 @@
 /datum/chemical_reaction/medicine/ammoniated_mercury
 	results = list(/datum/reagent/medicine/ammoniated_mercury = 3)
 	required_reagents = list(/datum/reagent/medicine/calomel = 1, /datum/reagent/ammonia = 2)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_TOXIN | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/medicine/potass_iodide
 	results = list(/datum/reagent/medicine/potass_iodide = 2)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/iodine = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_TOXIN | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/medicine/pen_acid
 	results = list(/datum/reagent/medicine/pen_acid = 5)
 	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/ammonia = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/consumable/salt = 1, /datum/reagent/toxin/cyanide = 1)
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_TOXIN | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/medicine/sal_acid
 	results = list(/datum/reagent/medicine/sal_acid = 5)
@@ -318,15 +318,6 @@
 	required_reagents = list(/datum/reagent/phenol = 2, /datum/reagent/lithium = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_ORGAN
 
-/*
-// Non-module change
-/datum/chemical_reaction/medicine/morphine
-	results = list(/datum/reagent/medicine/morphine = 2)
-	required_reagents = list(/datum/reagent/carbon = 2, /datum/reagent/hydrogen = 2, /datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
-	required_temp = 480
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
-*/
-
 /datum/chemical_reaction/medicine/modafinil
 	results = list(/datum/reagent/medicine/modafinil = 5)
 	required_reagents = list(/datum/reagent/diethylamine = 1, /datum/reagent/ammonia = 1, /datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/toxin/acid = 1)
@@ -383,4 +374,4 @@
 	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 1)
 	required_catalysts = list(/datum/reagent/consumable/ethanol = 3)
 	optimal_ph_max = 11
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -17,7 +17,7 @@
 	rate_up_lim = 15
 	purity_min = 0.5
 	reaction_flags = REACTION_PH_VOL_CONSTANT
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_CHEMICAL | REACTION_TAG_BRUTE | REACTION_TAG_TOXIN
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_CHEMICAL | REACTION_TAG_BRUTE | REACTION_TAG_TOXIN | REACTION_TAG_ORGAN | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/fentanyl
 	results = list(/datum/reagent/toxin/fentanyl = 1)
@@ -37,7 +37,7 @@
 	rate_up_lim = 5
 	purity_min = 0.5
 	reaction_flags = REACTION_PH_VOL_CONSTANT
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_ORGAN | REACTION_TAG_TOXIN
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_ORGAN | REACTION_TAG_TOXIN | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/cyanide
 	results = list(/datum/reagent/toxin/cyanide = 3)

--- a/maplestation_modules/code/datums/pain/pain_implements.dm
+++ b/maplestation_modules/code/datums/pain/pain_implements.dm
@@ -165,6 +165,18 @@
 	list_reagents = list(/datum/reagent/medicine/painkiller/paracetamol = 10) // Lasts ~4 minutes, heals ~15 pain per bodypart
 	rename_with_volume = TRUE
 
+/obj/item/reagent_containers/pill/naloxone
+	name = "naloxone pill"
+	desc = "Used to treat opioid overdoses and addiction."
+	icon_state = "pill13"
+	list_reagents = list(/datum/reagent/medicine/naloxone = 10)
+
+/obj/item/reagent_containers/pill/buproprion
+	name = "buproprion pill"
+	desc = "Used to treat stimulant and nicotine addiction."
+	icon_state = "pill14"
+	list_reagents = list(/datum/reagent/medicine/naloxone = 10)
+
 /obj/item/reagent_containers/syringe/paracetamol
 	name = "syringe (paracetamol)"
 	desc = "Contains fiteen units of Paracetamol. Used to treat general pain. Metabolizes slowly."

--- a/maplestation_modules/code/datums/pain/pain_reagents/painkiller_reactions.dm
+++ b/maplestation_modules/code/datums/pain/pain_reagents/painkiller_reactions.dm
@@ -1,34 +1,26 @@
-
-/datum/chemical_reaction/medicine/ondansetron
-	results = list(/datum/reagent/medicine/ondansetron = 3)
-	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 1)
-	required_catalysts = list(/datum/reagent/consumable/ethanol = 3)
-	optimal_ph_max = 11
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
-
 // move these melbert todo
 /datum/chemical_reaction/medicine/morphine
-	results = list(/datum/reagent/medicine/painkiller/morphine = 2)
+	results = list(/datum/reagent/medicine/painkiller/morphine = 3)
 	required_reagents = list(/datum/reagent/carbon = 2, /datum/reagent/hydrogen = 2, /datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
 	required_temp = 480
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/aspirin
 	results = list(/datum/reagent/medicine/painkiller/aspirin = 3)
 	required_reagents = list(/datum/reagent/medicine/sal_acid = 1, /datum/reagent/acetone = 1, /datum/reagent/oxygen = 1)
 	required_catalysts = list(/datum/reagent/toxin/acid = 1)
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/paracetamol
 	results = list(/datum/reagent/medicine/painkiller/paracetamol = 5)
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/acid/nitracid = 1)
 	optimal_temp = 480
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/ibuprofen
 	results = list(/datum/reagent/medicine/painkiller/ibuprofen = 5)
-	required_reagents = list(/datum/reagent/propionic_acid = 1, /datum/reagent/phenol = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	required_reagents = list(/datum/reagent/propionic_acid = 1, /datum/reagent/phenol = 2, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/propionic_acid
 	results = list(/datum/reagent/propionic_acid = 3)
@@ -45,20 +37,20 @@
 	required_reagents = list(/datum/reagent/medicine/painkiller/aspirin = 1, /datum/reagent/medicine/painkiller/paracetamol = 1, /datum/reagent/consumable/coffee = 1)
 	optimal_ph_min = 2
 	optimal_ph_max = 12
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 	reaction_flags = REACTION_INSTANT
 
 /datum/chemical_reaction/medicine/ibaltifen
 	results = list(/datum/reagent/medicine/painkiller/specialized/ibaltifen = 3)
 	required_reagents = list(/datum/reagent/propionic_acid = 1, /datum/reagent/chlorine = 1, /datum/reagent/copper = 1)
 	required_catalysts = list(/datum/reagent/medicine/c2/libital = 1)
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 /datum/chemical_reaction/medicine/anurifen
 	results = list(/datum/reagent/medicine/painkiller/specialized/anurifen = 3)
-	required_reagents = list(/datum/reagent/propionic_acid= 1, /datum/reagent/fluorine = 1, /datum/reagent/phosphorus = 1)
+	required_reagents = list(/datum/reagent/propionic_acid = 1, /datum/reagent/fluorine = 1, /datum/reagent/phosphorus = 1)
 	required_catalysts = list(/datum/reagent/medicine/c2/aiuri = 1)
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG | REACTION_TAG_PAIN
 
 // Not really reactions, but I'm leaving these here
 // Gain oxycodone from juicing poppies
@@ -70,3 +62,19 @@
 
 /obj/item/food/grown/poppy/lily
 	juice_typepath = null
+
+/datum/chemical_reaction/medicine/dimenhydrinate
+	results = list(/datum/reagent/medicine/dimenhydrinate = 3)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/nitrogen = 1, /datum/reagent/chlorine = 1)
+	optimal_ph_max = 12.5
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/medicine/naloxone
+	results = list(/datum/reagent/medicine/naloxone = 3)
+	required_reagents = list(/datum/reagent/medicine/painkiller/morphine = 1, /datum/reagent/hydrogen = 1, /datum/reagent/chlorine = 1)
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
+
+/datum/chemical_reaction/medicine/buproprion
+	results = list(/datum/reagent/medicine/buproprion = 3)
+	required_reagents = list(/datum/reagent/propionic_acid = 1, /datum/reagent/hydrogen = 1, /datum/reagent/chlorine = 1)
+	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG

--- a/maplestation_modules/code/datums/pain/pain_reagents/painkiller_related_chems.dm
+++ b/maplestation_modules/code/datums/pain/pain_reagents/painkiller_related_chems.dm
@@ -25,26 +25,66 @@
 	if(M.nutrition > NUTRITION_LEVEL_FULL - 25) // Boosts hunger to a bit, assuming you've been vomiting
 		M.adjust_nutrition(2 * HUNGER_FACTOR * REM * seconds_per_tick)
 
-/datum/chemical_reaction/medicine/dimenhydrinate
-	results = list(/datum/reagent/medicine/dimenhydrinate = 3)
-	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/nitrogen = 1, /datum/reagent/chlorine = 1)
-	optimal_ph_max = 12.5
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_HEALING | REACTION_TAG_OTHER | REACTION_TAG_DRUG
-
-// Good against nausea, easier to make than Dimenhydrinate
-/datum/reagent/medicine/ondansetron
-	name = "Ondansetron"
-	description = "Prevents nausea and vomiting."
+// Naloxone helps with opioid addiction
+/datum/reagent/medicine/naloxone
+	name = "Naloxone"
+	description = "An opioid antagonist which helps opioid overdoses and addiction."
 	reagent_state = LIQUID
-	color = "#74d3ff"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	ph = 10.6
+	color = "#ff9900"
+	ph = 7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/ondansetron/on_mob_life(mob/living/carbon/M, seconds_per_tick, times_fired)
+/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if(SPT_PROB(8, seconds_per_tick))
-		M.adjust_drowsiness(2 SECONDS * REM * seconds_per_tick)
-	if(SPT_PROB(15, seconds_per_tick) && M.get_bodypart_pain(BODY_ZONE_HEAD) <= PAIN_HEAD_MAX / 4)
-		M.cause_pain(BODY_ZONE_HEAD, 4)
-	M.adjust_disgust(-10 * REM * seconds_per_tick)
+	// Purges anything remotely opioid-related
+	for(var/datum/reagent/other_opioid as anything in affected_mob.reagents.reagent_list)
+		if(other_opioid.addiction_types?[/datum/addiction/opioids])
+			affected_mob.reagents.remove_reagent(other_opioid.type, 3 * REM * seconds_per_tick)
+
+	affected_mob.mind?.remove_addiction_points(/datum/addiction/opioids, 5 * normalise_creation_purity() * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(1 * REM * seconds_per_tick)
+
+// Buproprion helps with stimulant and nicotine addiction
+/datum/reagent/medicine/buproprion
+	name = "Buproprion"
+	description = "A medication that can help with stimulant and nicotine addiction."
+	reagent_state = LIQUID
+	color = "#9ff1ff"
+	ph = 7
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/medicine/buproprion/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	// I don't want this to be a major purger of relevant chems, primarily just to stem addiction
+	for(var/datum/reagent/other_opioid as anything in affected_mob.reagents.reagent_list)
+		if(other_opioid.addiction_types?[/datum/addiction/nicotine] || other_opioid.addiction_types?[/datum/addiction/stimulants])
+			affected_mob.reagents.remove_reagent(other_opioid.type, 1 * REM * seconds_per_tick)
+
+	affected_mob.mind?.remove_addiction_points(/datum/addiction/nicotine, 5 * normalise_creation_purity() * REM * seconds_per_tick)
+	affected_mob.mind?.remove_addiction_points(/datum/addiction/stimulants, 5 * normalise_creation_purity() * REM * seconds_per_tick)
+	affected_mob.adjust_disgust(1 * REM * seconds_per_tick)
+
+/datum/reagent/medicine/buproprion/on_mob_metabolize(mob/living/carbon/user)
+	. = ..()
+	user.add_mood_event(type, /datum/mood_event/buproprion)
+
+/datum/reagent/medicine/buproprion/on_mob_end_metabolize(mob/living/carbon/user)
+	. = ..()
+	user.clear_mood_event(type)
+	user.add_mood_event(type, /datum/mood_event/buproprion/timeout, current_cycle)
+
+/datum/mood_event/buproprion
+	description = "I feel a bit better than usual."
+	mood_change = 4
+
+/datum/mood_event/buproprion/timeout
+	mood_change = 2
+	timeout = 20 SECONDS
+
+/datum/mood_event/buproprion/timeout/add_effects(cycles_metabolized = 10)
+	timeout = max(cycles_metabolized * 0.5 SECONDS, 1 SECONDS)
+
+// Antihol also helps alcohol addiction
+/datum/reagent/medicine/antihol/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	affected_mob.mind?.remove_addiction_points(/datum/addiction/alcohol, 5 * normalise_creation_purity() * REM * seconds_per_tick)

--- a/maplestation_modules/code/datums/pain/pain_reagents/painkiller_related_chems.dm
+++ b/maplestation_modules/code/datums/pain/pain_reagents/painkiller_related_chems.dm
@@ -43,6 +43,7 @@
 
 	affected_mob.mind?.remove_addiction_points(/datum/addiction/opioids, 5 * normalise_creation_purity() * REM * seconds_per_tick)
 	affected_mob.adjust_disgust(1 * REM * seconds_per_tick)
+	affected_mob.adjust_drugginess(-2.5 SECONDS * REM * seconds_per_tick)
 
 // Buproprion helps with stimulant and nicotine addiction
 /datum/reagent/medicine/buproprion

--- a/maplestation_modules/code/modules/cargo/packs.dm
+++ b/maplestation_modules/code/modules/cargo/packs.dm
@@ -182,6 +182,32 @@
 		/obj/item/storage/pill_bottle/sansufentanyl,
 	)
 
+/obj/item/storage/pill_bottle/prescription/naloxone
+	pill_type = /obj/item/reagent_containers/pill/naloxone
+	num_pills = 3
+
+/datum/supply_pack/goody/naloxone
+	name = "Naloxone Prescription"
+	desc = "Contains a pill bottle of Naloxone, which helps with opioid overdoses and addiction."
+	group = GROUP_DRUGS
+	cost = PAYCHECK_CREW * 5
+	contains = list(
+		/obj/item/storage/pill_bottle/prescription/naloxone,
+	)
+
+/obj/item/storage/pill_bottle/prescription/buproprion
+	pill_type = /obj/item/reagent_containers/pill/buproprion
+	num_pills = 3
+
+/datum/supply_pack/goody/buproprion
+	name = "Buproprion Prescription"
+	desc = "Contains a pill bottle of Buproprion, which helps with stimulant and nicotine addiction."
+	group = GROUP_DRUGS
+	cost = PAYCHECK_CREW * 5
+	contains = list(
+		/obj/item/storage/pill_bottle/prescription/buproprion,
+	)
+
 /datum/supply_pack/medical/painkiller_syringes
 	name = "Painkiller Syringe Shipment"
 	desc = "Contains six syringes of general medicinal painkillers - Ibuprofen, Paracetamol, and Aspirin."

--- a/maplestation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
+++ b/maplestation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
@@ -238,7 +238,7 @@
 /datum/chemical_reaction/gojuice
 	results = list(/datum/reagent/drug/gojuice = 3)
 	required_reagents = list(/datum/reagent/neutroamine = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/drug/methamphetamine, /datum/reagent/fuel/oil = 1, /datum/reagent/consumable/sugar = 1)
-	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
+	reaction_tags = REACTION_TAG_HARD | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING | REACTION_TAG_PAIN
 
 /obj/item/reagent_containers/cup/glass/bottle/gojuice
 	name = "go-juice bottle"

--- a/tgui/packages/tgui/interfaces/Reagents.jsx
+++ b/tgui/packages/tgui/interfaces/Reagents.jsx
@@ -49,6 +49,7 @@ export const Reagents = (props) => {
     { flag: bitflags.CHEMICAL, icon: 'flask' },
     { flag: bitflags.PLANT, icon: 'seedling' },
     { flag: bitflags.COMPETITIVE, icon: 'recycle' },
+    { flag: bitflags.PAIN, icon: 'syringe' },
   ];
 
   const [page, setPage] = useLocalState('page', 1);
@@ -200,6 +201,16 @@ const TagBox = (props) => {
           }}
         >
           Organ
+        </Button>
+        <Button
+          icon="syringe"
+          color={selectedBitflags & bitflags.PAIN ? 'green' : 'red'}
+          onClick={() => {
+            act('toggle_tag_pain');
+            setPage(1);
+          }}
+        >
+          Pain
         </Button>
         <Button
           icon="flask"


### PR DESCRIPTION
Getting stuck with in addiction for like 20 minutes for messing around with chems (or accidentally getting someone else stuck with an addiction for like 20 minutes because of a mistake) is lame and boring. So here's some chemicals to help with that. 

- Naloxone (1 part morphine, 1 part hydrogen, 1 part chlorine). Purges opiates (oxycodone, morphine, etc) and helps cure opiate addiction. Causes minor disgust.

- Buproprion (1 part propionic acid, 1 part hydrogen, 1 part chlorine). Very slightly purges stimulants and nicotine and helps cure stimuland and nicotine addiction. Causes minor disgust, also gives you a minor positive moodlet.

Both can be ordered as a cargo prescription. 

Other:

- Adds a tag for pain so you can sort by it. Sorts a few reagent tags. 
- Fix Ondansetron having double the effect.