### PR TITLE
Adds Combat Gloves Single-Pack.

### DIFF
--- a/maplestation_modules/code/modules/cargo/goodies.dm
+++ b/maplestation_modules/code/modules/cargo/goodies.dm
@@ -5,3 +5,9 @@
 	cost = PAYCHECK_CREW * 4
 	crate_type = /obj/structure/closet/crate/critter
 	contains = list(/obj/item/toy/plush/peepy)
+
+/datum/supply_pack/goody/combat_gloves
+	name = "Combat Gloves Single-Pack"
+	desc = "Contains one set of advanced military-grade combat gloves. Totally not under a massive mark-up for black gloves with insulating fiber, honest!"
+	cost = PAYCHECK_COMMAND * 8
+	contains = list(/obj/item/clothing/gloves/combat)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c04f6644-8950-4f08-8819-9ec3321182c5)

This just allows you to buy combat gloves as a goodie for a decently large price. Probably too large of a price, but that's what you get for wanting DRIP (that looks exactly the same as black gloves)

These USED to be sold in cargo, but the options for buying them withered away until they were no longer available.