### PR TITLE
Expands Synth temp range, EVA coat fix

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -87,7 +87,7 @@
 	equip_delay_other = 6 SECONDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT // Protects very cold.
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT // Protects a little hot.
-	flags_inv = HIDEJUMPSUIT
+	transparent_protection = HIDEJUMPSUIT
 	clothing_flags = THICKMATERIAL
 	resistance_flags = NONE
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/synth.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/synth.dm
@@ -33,6 +33,9 @@ GLOBAL_LIST_EMPTY(synth_head_cover_list)
 	changesource_flags = MIRROR_BADMIN|MIRROR_PRIDE|MIRROR_MAGIC
 	species_language_holder = /datum/language_holder/synthetic
 
+	bodytemp_heat_damage_limit = BODYTEMP_HEAT_LAVALAND_SAFE
+	bodytemp_cold_damage_limit = BODYTEMP_COLD_ICEBOX_SAFE
+
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/synth,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/synth,


### PR DESCRIPTION
- Synths have a more "comfortable" range of temperatures, from extremely-cold to rather-hot
- EVA Winter Coats no longer hides jumpsuit sprite