### PR TITLE
Adds more languages to the AI.

### DIFF
--- a/maplestation_modules/code/modules/language/language_holder.dm
+++ b/maplestation_modules/code/modules/language/language_holder.dm
@@ -1,5 +1,15 @@
 // -- Overrides and extensions for language holders. --
 /datum/language_holder/synthetic/New(atom/_owner)
-	understood_languages |= list(/datum/language/skrell = list(LANGUAGE_ATOM), /datum/language/impdraconic = list(LANGUAGE_ATOM))
-	spoken_languages |= list(/datum/language/skrell = list(LANGUAGE_ATOM), /datum/language/impdraconic = list(LANGUAGE_ATOM))
+	understood_languages |= list(
+		/datum/language/skrell = list(LANGUAGE_ATOM),
+		/datum/language/impdraconic = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/yangyu = list(LANGUAGE_ATOM),
+		)
+	spoken_languages |= list(
+		/datum/language/skrell = list(LANGUAGE_ATOM),
+		/datum/language/impdraconic = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/yangyu = list(LANGUAGE_ATOM),
+		)
 	return ..()


### PR DESCRIPTION

# What is this?
This code adds more languages to the AI. 


## Why?
I made this so CaLE can understand and speak more languages, it was missing quite a few.

The languages I chose were ones that CaLE would know IC at this current point of time. If adding yangyu is a bit much, tell me and I will remove it.

Languages added:
1. Draconic
2. Yangyu
