### PR TITLE
Small and tiny mobs cannot bump open doors (when AI controlled)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -269,7 +269,7 @@
 
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
-	else if(requiresID() && allowed(user))
+	else if(requiresID() && (!user || user.mind || user.mob_size >= MOB_SIZE_HUMAN) && allowed(user))
 		open()
 	else
 		do_animate("deny")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -267,9 +267,14 @@
 	if(!density || (obj_flags & EMAGGED))
 		return
 
+	if(isliving(user) && isnull(user.mind))
+		var/mob/living/living_user = user
+		if(living_user.mob_size < MOB_SIZE_HUMAN)
+			return
+
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
-	else if(requiresID() && (!user || user.mind || user.mob_size >= MOB_SIZE_HUMAN) && allowed(user))
+	else if(requiresID() && allowed(user))
 		open()
 	else
 		do_animate("deny")

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -154,7 +154,7 @@
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
 
-	else if(allowed(user))
+	else if((!user || user.mind || user.mob_size >= MOB_SIZE_HUMAN) && allowed(user))
 		open_and_close()
 
 	else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -148,13 +148,15 @@
 		return
 
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
+	if(isliving(user) && isnull(user.mind))
+		var/mob/living/living_user = user
+		if(living_user.mob_size < MOB_SIZE_HUMAN)
+			return
 
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
 
-	else if((!user || user.mind || user.mob_size >= MOB_SIZE_HUMAN) && allowed(user))
+	else if(requiresID() && allowed(user))
 		open_and_close()
 
 	else

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -25,7 +25,7 @@
 	response_harm_continuous = "squashes"
 	response_harm_simple = "squash"
 
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_SMALL
 	pixel_x = -16
 	base_pixel_x = -16
 

--- a/code/modules/mob/living/basic/jungle/leaper/leaper.dm
+++ b/code/modules/mob/living/basic/jungle/leaper/leaper.dm
@@ -29,7 +29,7 @@
 	lighting_cutoff_red = 5
 	lighting_cutoff_green = 20
 	lighting_cutoff_blue = 25
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	ai_controller = /datum/ai_controller/basic_controller/leaper
 	move_resist = MOVE_FORCE_VERY_STRONG
 	pull_force = MOVE_FORCE_VERY_STRONG

--- a/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
+++ b/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
@@ -26,7 +26,7 @@
 	lighting_cutoff_red = 5
 	lighting_cutoff_green = 20
 	lighting_cutoff_blue = 25
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 
 	speak_emote = list("chitters")
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -36,7 +36,7 @@
 	melee_damage_upper = 35
 	melee_damage_lower = 35
 	melee_attack_cooldown = CLICK_CD_MELEE
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	armour_penetration = 30
 	pixel_x = -16
 	base_pixel_x = -16

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -7,7 +7,7 @@
 	maptext_height = 64
 	maptext_width = 64
 	bubble_icon = "alienroyal"
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles
 	pressure_resistance = 200 //Because big, stompy xenos should not be blown around like paper.
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3)

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -139,7 +139,7 @@
 	health = 400
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 10,
 							/obj/item/stack/sheet/animalhide/xeno = 2)
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/alien/maid


### PR DESCRIPTION
Cockroaches, butterflies, chickens, and similarly small mobs can't bump open (public access) airlocks unless they are controlled by a player.

Basically no more butterflies escaping captivity and spreading across the station and no more cockroaches jumpscaring you in maint



I also went through and tweaked some mobsizes which made little sense to me (why are bees large?) 