### PR TITLE
Examine tweaks + Pronouns in bio

### DIFF
--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -145,9 +145,10 @@
 			return
 
 		var/mob/viewer = usr
+		var/mob/wearer = get(src, /mob/living) || loc
 		if(viewer.incapacitated(IGNORE_STASIS|IGNORE_RESTRAINTS|IGNORE_GRAB))
 			return
-		if(HAS_TRAIT(loc, TRAIT_UNKNOWN) || !(viewer in viewers(loc)))
+		if(HAS_TRAIT(wearer, TRAIT_UNKNOWN) || !can_examine_when_worn(viewer))
 			to_chat(viewer, span_notice("You can't make out that item anymore."))
 			return
 
@@ -155,6 +156,26 @@
 			viewer._pointed(src, skip_view = TRUE)
 		else
 			viewer.examinate(src)
+
+/// Checks if this item, when examined / pointed at while being worn, can actually be examined by the given mob
+/atom/movable/proc/can_examine_when_worn(mob/examiner)
+	return (examiner in viewers(loc))
+
+/obj/item/can_examine_when_worn(mob/examiner)
+	if(!slot_flags)
+		return ..()
+	var/mob/living/carbon/wearer = loc
+	if(!istype(wearer))
+		return ..()
+	if(wearer.check_obscured_slots() & slot_flags)
+		return FALSE
+	return ..()
+
+/obj/item/clothing/accessory/can_examine_when_worn(mob/examiner)
+	if(isclothing(loc))
+		var/obj/item/clothing/shirt = loc
+		return shirt.can_examine_when_worn(examiner)
+	return ..()
 
 /obj/item/card/id/Topic(href, list/href_list)
 	. = ..()

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -3,7 +3,7 @@
 
 /mob/living/carbon/human/get_examine_name(mob/user)
 	if(!HAS_TRAIT(user, TRAIT_PROSOPAGNOSIA))
-		return ..()
+		return "[..()] ([p_they()]/[p_them()])"
 
 	return "Unknown"
 
@@ -495,7 +495,7 @@
 	var/list/cybers = list()
 	for(var/obj/item/organ/internal/cyberimp/cyberimp in organs)
 		if(IS_ROBOTIC_ORGAN(cyberimp) && !(cyberimp.organ_flags & ORGAN_HIDDEN))
-			cybers += cyberimp.examine_title(user, href = TRUE)
+			cybers += cyberimp.examine_title(user, href = FALSE)
 	if(length(cybers))
 		. += "<span class='notice ml-1'>Detected cybernetic modifications:</span>"
 		. += "<span class='notice ml-2'>[english_list(cybers, and_text = ", and")]</span>"


### PR DESCRIPTION
1. You can examine accessories, as intended
2. You can't examine cybernetic implants
3. Adds pronouns to the examine title of humans

This is something Goon does which I thought was "Yeah sure why not". 

![image](https://github.com/user-attachments/assets/912d9866-5112-4915-88ac-5a4d39714e71)

The examine bar for humans has a lot of blank space because they don't have an icon associated, so might as well fill it

![image](https://github.com/user-attachments/assets/19a7394e-ea87-472d-a1e4-1a4da4b6fc04)
