### PR TITLE
Temporary fix for prothetic users being crit in two hits

### DIFF
--- a/code/__DEFINES/bodyparts.dm
+++ b/code/__DEFINES/bodyparts.dm
@@ -19,10 +19,10 @@
 /// A mutiplication of the burn and brute damage that the limb's stored damage contributes to its attached mob's overall wellbeing.
 /// For instance, if a limb has 50 damage, and has a coefficient of 50%, the human is considered to have suffered 25 damage to their total health.
 
-#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.5 //Used by advanced robotic limbs.
+#define LIMB_BODY_DAMAGE_COEFFICIENT_ADVANCED 0.66 //Used by advanced robotic limbs.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_DEFAULT 0.75 //Used by all limbs by default.
 #define LIMB_BODY_DAMAGE_COEFFICIENT_TOTAL 1 //Used by heads and torsos
-#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 2.5 //Used by surplus prosthesis limbs
+#define LIMB_BODY_DAMAGE_COEFFICIENT_PROSTHESIS 1.5 //Used by surplus prosthesis limbs
 
 // EMP
 // Note most of these values are doubled on heavy EMP


### PR DESCRIPTION
Prosthetics have this modifier on them to make their effective hp equivalent to that of normal limbs, however this results in rather unfun gameplay of literally being crit in two hits

So I'm just tweaking the numbers to be closer to default across the board. This is solved in the medrework so that's what makes it temporary 
