### PR TITLE
Silverscale blood runtime fixes and tweaks

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -83,7 +83,7 @@
 		clamp(starting_color_rgb[1] - red_offset, 0, 255),
 		clamp(starting_color_rgb[2] - green_offset, 0, 255),
 		clamp(starting_color_rgb[3] - blue_offset, 0, 255),
-		length(starting_color_rgb) >= 4 ? starting_color_rgb[4] : 255, // maintain alpha! (if it has it)
+		length(starting_color_rgb) >= 4 ? starting_color_rgb[4] : alpha, // maintain alpha! (if it has it)
 	)
 	// if it's dried (or about to dry) we can just set color directly
 	if(dried || drying_progress >= drying_time)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -64,7 +64,7 @@
 	// (at any given moment, there may be like... 200 blood decals on your screen at once
 	// byond is, apparently, pretty bad at handling that many color matrix operations,
 	// especially in a filter or while animating)
-	var/list/starting_color_rgb = ReadRGB(color)
+	var/list/starting_color_rgb = ReadRGB(color) || list(255, 255, 255, alpha)
 	// we want a fixed offset for a fixed drop in color intensity, plus a scaling offset based on our strongest color
 	// the scaling offset helps keep dark colors from turning black, while also ensurse bright colors don't stay super bright
 	var/max_color = max(starting_color_rgb[1], starting_color_rgb[2], starting_color_rgb[3])

--- a/maplestation_modules/code/modules/mob/living/blood.dm
+++ b/maplestation_modules/code/modules/mob/living/blood.dm
@@ -279,15 +279,20 @@ PROCESSING_SUBSYSTEM_DEF(blood_drying)
 /datum/blood_type/crew/lizard
 	name = "L"
 	color = "#047200" // Some species of lizards have mutated green blood due to biliverdin build up
-	compatible_types = list(/datum/blood_type/crew/lizard/silver)
+	compatible_types = list(/datum/blood_type/silver/lizard)
 
-/datum/blood_type/crew/lizard/silver
-	color = "#ffffff9c"
-	compatible_types = list(/datum/blood_type/crew/lizard)
+/datum/blood_type/silver
+	name = "Ag"
+	color = "#c9c9c99c"
+	reagent_type = /datum/reagent/silver
 
-/datum/blood_type/crew/lizard/silver/set_up_blood(obj/effect/decal/cleanable/blood/blood, new_splat)
-	blood.add_filter("silver_glint", 3, list("type" = "outline", "color" = "#c9c9c99c", "size" = 1.5))
+/datum/blood_type/silver/set_up_blood(obj/effect/decal/cleanable/blood/blood, new_splat)
+	blood.can_dry = FALSE
 	blood.emissive_alpha = max(blood.emissive_alpha, new_splat ? 125 : 63)
+
+/datum/blood_type/silver/lizard
+	name = "sL"
+	compatible_types = list(/datum/blood_type/crew/lizard)
 
 /datum/blood_type/crew/skrell
 	name = "S"

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/silverscale.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/silverscale.dm
@@ -82,7 +82,7 @@
 	he_who_was_blessed_with_silver.add_filter("silver_glint", 2, list("type" = "outline", "color" = "#ffffff63", "size" = 2))
 
 	he_who_was_blessed_with_silver.physiology?.damage_resistance += 10
-	he_who_was_blessed_with_silver.dna.species.exotic_bloodtype = /datum/blood_type/crew/lizard/silver
+	he_who_was_blessed_with_silver.dna.species.exotic_bloodtype = /datum/blood_type/silver/lizard
 	organ_owner.update_body(TRUE)
 
 /obj/item/organ/internal/tongue/lizard/silver/on_mob_remove(mob/living/carbon/organ_owner, special)


### PR DESCRIPTION
Follow up to blood optimization, this fixes runtimes from Silverscale blood (which is full white, which is `null` color in byond) 

But I need to revisit Silverscale blood anyway because - while it's working As Intended with the new effect - I think it's kinda ugly