### PR TITLE
Adds partial language understanding

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -307,3 +307,12 @@ GLOBAL_LIST_INIT(status_display_state_pictures, list(
 	"blank",
 	"shuttle",
 ))
+
+GLOBAL_LIST_INIT(most_common_words, init_common_words())
+
+/proc/init_common_words()
+	. = list()
+	var/i = 1
+	for(var/word in world.file2list("strings/1000_most_common.txt"))
+		.[word] = i
+		i += 1

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -43,9 +43,6 @@ SUBSYSTEM_DEF(discord)
 	/// People who have tried to verify this round already
 	var/list/reverify_cache
 
-	/// Common words list, used to generate one time tokens
-	var/list/common_words
-
 	/// The file where notification status is saved
 	var/notify_file = file("data/notify.json")
 
@@ -53,7 +50,6 @@ SUBSYSTEM_DEF(discord)
 	var/enabled = FALSE
 
 /datum/controller/subsystem/discord/Initialize()
-	common_words = world.file2list("strings/1000_most_common.txt")
 	reverify_cache = list()
 	// Check for if we are using TGS, otherwise return and disables firing
 	if(world.TgsAvailable())
@@ -156,7 +152,7 @@ SUBSYSTEM_DEF(discord)
 	// While there's a collision in the token, generate a new one (should rarely happen)
 	while(not_unique)
 		//Column is varchar 100, so we trim just in case someone does us the dirty later
-		one_time_token = trim("[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]", 100)
+		one_time_token = trim("[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]", 100)
 
 		not_unique = find_discord_link_by_token(one_time_token, timebound = TRUE)
 
@@ -298,4 +294,3 @@ SUBSYSTEM_DEF(discord)
 	if (length(discord_mention_extraction_regex.group) == 1)
 		return discord_mention_extraction_regex.group[1]
 	return null
-

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -191,8 +191,6 @@
 	gain_text = span_warning("You lose your grasp on complex words.")
 	lose_text = span_notice("You feel your vocabulary returning to normal again.")
 
-	var/static/list/common_words = world.file2list("strings/1000_most_common.txt")
-
 /datum/brain_trauma/mild/expressive_aphasia/handle_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message)
@@ -212,7 +210,7 @@
 				word = copytext(word, 1, suffix_foundon)
 			word = html_decode(word)
 
-			if(lowertext(word) in common_words)
+			if(GLOB.most_common_words[lowertext(word)])
 				new_message += word + suffix
 			else
 				if(prob(30) && message_split.len > 2)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1521,6 +1521,10 @@
 /atom/movable/proc/get_random_understood_language()
 	return get_language_holder().get_random_understood_language()
 
+/// Gets a list of all mutually understood languages.
+/atom/movable/proc/get_mutually_understood_languages()
+	return get_language_holder().get_mutually_understood_languages()
+
 /// Gets a random spoken language, useful for forced speech and such.
 /atom/movable/proc/get_random_spoken_language()
 	return get_language_holder().get_random_spoken_language()

--- a/code/game/machinery/telecomms/computers/logbrowser.dm
+++ b/code/game/machinery/telecomms/computers/logbrowser.dm
@@ -59,7 +59,7 @@
 					message_out = "\"[message_in]\""
 				else if(!user.has_language(language))
 					// Language unknown: scramble
-					message_out = "\"[language_instance.scramble(message_in)]\""
+					message_out = "\"[language_instance.scramble_sentence(message_in, user.get_mutually_understood_languages())]\""
 				else
 					message_out = "(Unintelligible)"
 				packet_out["message"] = message_out

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	if(!has_language(language))
 		var/datum/language/dialect = GLOB.language_datum_instances[language]
-		raw_message = dialect.scramble(raw_message)
+		raw_message = dialect.scramble_sentence(raw_message, get_mutually_understood_languages())
 
 	return raw_message
 

--- a/code/modules/language/_language.dm
+++ b/code/modules/language/_language.dm
@@ -133,7 +133,7 @@
 		return most_common_cache[input]
 
 	. = scramble_cache[input]
-	if(.)
+	if(. && scramble_cache[1] != input)
 		// bumps it to the top of the cache
 		scramble_cache -= input
 		scramble_cache[input] = .
@@ -154,7 +154,7 @@
 /datum/language/proc/read_sentence_cache(input)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	. = last_sentence_cache[input]
-	if(.)
+	if(. && last_sentence_cache[1] != input)
 		// bumps it to the top of the cache (don't anticipate this happening often)
 		last_sentence_cache -= input
 		last_sentence_cache[input] = .

--- a/code/modules/language/_language_holder.dm
+++ b/code/modules/language/_language_holder.dm
@@ -176,6 +176,18 @@ Key procs
 /datum/language_holder/proc/get_random_understood_language()
 	return pick(understood_languages)
 
+/// Gets a list of all mutually understood languages.
+/datum/language_holder/proc/get_mutually_understood_languages()
+	var/list/mutual_languages = list()
+	for(var/language_type in understood_languages)
+		var/datum/language/language_instance = GLOB.language_datum_instances[language_type]
+		for(var/mutual_language_type in language_instance.mutual_understanding)
+			// add it to the list OR override it if it's a stronger mutual understanding
+			if(!mutual_languages[mutual_language_type] || mutual_languages[mutual_language_type] < language_instance.mutual_understanding[mutual_language_type])
+				mutual_languages[mutual_language_type] = language_instance.mutual_understanding[mutual_language_type]
+
+	return mutual_languages
+
 /// Gets a random spoken language, useful for forced speech and such.
 /datum/language_holder/proc/get_random_spoken_language()
 	return pick(spoken_languages)

--- a/code/modules/language/beachbum.dm
+++ b/code/modules/language/beachbum.dm
@@ -19,3 +19,8 @@
 	)
 	icon_state = "beach"
 	always_use_default_namelist = TRUE
+
+	mutual_understanding = list(
+		/datum/language/common = 50,
+		/datum/language/uncommon = 30,
+	)

--- a/code/modules/language/codespeak.dm
+++ b/code/modules/language/codespeak.dm
@@ -7,7 +7,7 @@
 	icon_state = "codespeak"
 	always_use_default_namelist = TRUE // No syllables anyways
 
-/datum/language/codespeak/scramble(input)
+/datum/language/codespeak/scramble_sentence(input, list/mutual_languages)
 	var/lookup = check_cache(input)
 	if(lookup)
 		return lookup

--- a/code/modules/language/codespeak.dm
+++ b/code/modules/language/codespeak.dm
@@ -8,9 +8,9 @@
 	always_use_default_namelist = TRUE // No syllables anyways
 
 /datum/language/codespeak/scramble_sentence(input, list/mutual_languages)
-	var/lookup = check_cache(input)
-	if(lookup)
-		return lookup
+	. = read_word_cache(input)
+	if(.)
+		return .
 
 	. = ""
 	var/list/words = list()
@@ -29,4 +29,4 @@
 	if(input_ending in endings)
 		. += input_ending
 
-	add_to_cache(input, .)
+	write_word_cache(input, .)

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -57,5 +57,6 @@
 	)
 
 	mutual_understanding = list(
+		/datum/language/beachbum = 33,
 		/datum/language/uncommon = 20,
 	)

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -55,3 +55,7 @@
 			"his", "ing", "ion", "ith", "not", "ome", "oul", "our", "sho", "ted", "ter", "tha", "the", "thi",
 		),
 	)
+
+	mutual_understanding = list(
+		/datum/language/uncommon = 20,
+	)

--- a/code/modules/language/uncommon.dm
+++ b/code/modules/language/uncommon.dm
@@ -14,3 +14,8 @@
 	)
 	icon_state = "galuncom"
 	default_priority = 90
+
+	mutual_understanding = list(
+		/datum/language/common = 33,
+		/datum/language/beachbum = 20,
+	)

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
@@ -11,7 +11,7 @@
 	spans = list(SPAN_ROBOT)
 	icon_state = "ratvar"
 
-/datum/language/ratvarian/scramble(input)
+/datum/language/ratvarian/scramble_sentence(input, list/mutual_languages)
 	return text2ratvar(input)
 
 /// Regexes used to add ratvarian styling to rot13 english

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -26,6 +26,9 @@
 		/datum/language/impdraconic = 66,
 	)
 
+// TG unit test compliance (out of laziness)
+#ifndef UNIT_TESTS
+
 // Edit to the silverscale language holder - silverscales can speak high draconic.
 /datum/language_holder/lizard/silver
 	understood_languages = list(
@@ -49,3 +52,5 @@
 	spoken_languages = list(
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
+
+#endif

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -17,16 +17,13 @@
 	icon_state = "lizardred"
 	default_priority = 85
 
-// So I wrote a few unit tests for /tg/ that rely on Lizards not knowing what high draconic is.
-// And since rewriting them is out of the questions, Lizards don't know high draconic in unit tests.
-#ifndef UNIT_TESTS
+	mutual_understanding = list(
+		/datum/language/draconic = 66,
+	)
 
-// Edit to the base lizard language holder - lizards can understand high draconic.
-/datum/language_holder/lizard
-	understood_languages = list(
-		/datum/language/common = list(LANGUAGE_ATOM),
-		/datum/language/draconic = list(LANGUAGE_ATOM),
-		/datum/language/impdraconic = list(LANGUAGE_ATOM),
+/datum/language/draconic
+	mutual_understanding = list(
+		/datum/language/impdraconic = 66,
 	)
 
 // Edit to the silverscale language holder - silverscales can speak high draconic.
@@ -43,8 +40,6 @@
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
 	selected_language = /datum/language/uncommon
-
-#endif
 
 /datum/language_holder/lizard/ash/primative
 	selected_language = /datum/language/impdraconic

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -44,6 +44,8 @@
 	)
 	selected_language = /datum/language/uncommon
 
+#endif
+
 /datum/language_holder/lizard/ash/primative
 	selected_language = /datum/language/impdraconic
 	understood_languages = list(
@@ -52,5 +54,3 @@
 	spoken_languages = list(
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
-
-#endif


### PR DESCRIPTION
Some languages can only partially understand another language, rather than it being a binary thing

For example, if you know Draconic, you can (now) only understand 66% of words spoken by someone in Tiziran Draconic

This percentage change is not flat, though: It scales depending on how common the word is (...in the english dictionary). Words in the top 500 most common words are easier to understand (meaning more likely to translate), while words beyond the top 500 most common words are harder to understand (meaning less likely to translate)

As a bonus: The top 1000 most common words are now static when translated into a new language - while they still random from round to round, they will now be the same through the *entire* round, rather than (occasionally) being re-randomized. This means you can, kind of, teach people words of a language they don't know, and partial-understanders may be able to pick up what someone is saying over time.

Example (Can you guess what message it used to be?) 

![image](https://github.com/user-attachments/assets/b3fe6571-f9fa-492c-822c-ebfdf6938466)
