### PR TITLE
Language Menu (like the one in the preferences) Rework

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -307,3 +307,12 @@ GLOBAL_LIST_INIT(status_display_state_pictures, list(
 	"blank",
 	"shuttle",
 ))
+
+GLOBAL_LIST_INIT(most_common_words, init_common_words())
+
+/proc/init_common_words()
+	. = list()
+	var/i = 1
+	for(var/word in world.file2list("strings/1000_most_common.txt"))
+		.[word] = i
+		i += 1

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT_TYPED(language_datum_instances, /datum/language, init_language_
 /// List if all language typepaths learnable, IE, those with keys
 GLOBAL_LIST_INIT(all_languages, init_all_languages())
 // /List of language prototypes to reference, assoc "name" = typepath
-GLOBAL_LIST_INIT(language_types_by_name, init_language_types_by_name())
+GLOBAL_LIST_INIT_TYPED(language_types_by_name, /datum/language, init_language_types_by_name())
 
 /proc/init_language_prototypes()
 	var/list/lang_list = list()

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -43,9 +43,6 @@ SUBSYSTEM_DEF(discord)
 	/// People who have tried to verify this round already
 	var/list/reverify_cache
 
-	/// Common words list, used to generate one time tokens
-	var/list/common_words
-
 	/// The file where notification status is saved
 	var/notify_file = file("data/notify.json")
 
@@ -53,7 +50,6 @@ SUBSYSTEM_DEF(discord)
 	var/enabled = FALSE
 
 /datum/controller/subsystem/discord/Initialize()
-	common_words = world.file2list("strings/1000_most_common.txt")
 	reverify_cache = list()
 	// Check for if we are using TGS, otherwise return and disables firing
 	if(world.TgsAvailable())
@@ -156,7 +152,7 @@ SUBSYSTEM_DEF(discord)
 	// While there's a collision in the token, generate a new one (should rarely happen)
 	while(not_unique)
 		//Column is varchar 100, so we trim just in case someone does us the dirty later
-		one_time_token = trim("[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]-[pick(common_words)]", 100)
+		one_time_token = trim("[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]-[pick(GLOB.most_common_words)]", 100)
 
 		not_unique = find_discord_link_by_token(one_time_token, timebound = TRUE)
 
@@ -298,4 +294,3 @@ SUBSYSTEM_DEF(discord)
 	if (length(discord_mention_extraction_regex.group) == 1)
 		return discord_mention_extraction_regex.group[1]
 	return null
-

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/social_anxiety, /datum/quirk/mute),
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
-	list(/datum/quirk/bilingual, /datum/quirk/foreigner),
+	// list(/datum/quirk/bilingual, /datum/quirk/foreigner),
 	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -191,8 +191,6 @@
 	gain_text = span_warning("You lose your grasp on complex words.")
 	lose_text = span_notice("You feel your vocabulary returning to normal again.")
 
-	var/static/list/common_words = world.file2list("strings/1000_most_common.txt")
-
 /datum/brain_trauma/mild/expressive_aphasia/handle_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message)
@@ -212,7 +210,7 @@
 				word = copytext(word, 1, suffix_foundon)
 			word = html_decode(word)
 
-			if(lowertext(word) in common_words)
+			if(GLOB.most_common_words[lowertext(word)])
 				new_message += word + suffix
 			else
 				if(prob(30) && message_split.len > 2)

--- a/code/datums/quirks/neutral_quirks/foreigner.dm
+++ b/code/datums/quirks/neutral_quirks/foreigner.dm
@@ -1,3 +1,4 @@
+/*
 /datum/quirk/foreigner
 	name = "Foreigner"
 	desc = "You're not from around here. You don't know Galactic Common!"
@@ -19,3 +20,4 @@
 	human_holder.remove_blocked_language(/datum/language/common)
 	if(ishumanbasic(human_holder))
 		human_holder.remove_language(/datum/language/uncommon)
+*/

--- a/code/datums/quirks/positive_quirks/bilingual.dm
+++ b/code/datums/quirks/positive_quirks/bilingual.dm
@@ -1,3 +1,4 @@
+/*
 /datum/quirk/bilingual
 	name = "Bilingual"
 	desc = "Over the years you've picked up an extra language!"
@@ -26,3 +27,4 @@
 			return
 		to_chat(quirk_holder, span_boldnotice("You are already familiar with the quirk in your preferences, so you learned Galactic Uncommon instead."))
 	quirk_holder.grant_language(language_type, source = LANGUAGE_QUIRK)
+*/

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1521,6 +1521,10 @@
 /atom/movable/proc/get_random_understood_language()
 	return get_language_holder().get_random_understood_language()
 
+/// Gets a list of all mutually understood languages.
+/atom/movable/proc/get_mutually_understood_languages()
+	return get_language_holder().get_mutually_understood_languages()
+
 /// Gets a random spoken language, useful for forced speech and such.
 /atom/movable/proc/get_random_spoken_language()
 	return get_language_holder().get_random_spoken_language()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1467,7 +1467,7 @@
 */
 
 /// Gets or creates the relevant language holder. For mindless atoms, gets the local one. For atom with mind, gets the mind one.
-/atom/movable/proc/get_language_holder()
+/atom/movable/proc/get_language_holder() as /datum/language_holder
 	RETURN_TYPE(/datum/language_holder)
 	if(QDELING(src))
 		CRASH("get_language_holder() called on a QDELing atom, \

--- a/code/game/machinery/telecomms/computers/logbrowser.dm
+++ b/code/game/machinery/telecomms/computers/logbrowser.dm
@@ -59,7 +59,7 @@
 					message_out = "\"[message_in]\""
 				else if(!user.has_language(language))
 					// Language unknown: scramble
-					message_out = "\"[language_instance.scramble(message_in)]\""
+					message_out = "\"[language_instance.scramble_sentence(message_in, user.get_mutually_understood_languages())]\""
 				else
 					message_out = "(Unintelligible)"
 				packet_out["message"] = message_out

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	if(!has_language(language))
 		var/datum/language/dialect = GLOB.language_datum_instances[language]
-		raw_message = dialect.scramble(raw_message)
+		raw_message = dialect.scramble_sentence(raw_message, get_mutually_understood_languages())
 
 	return raw_message
 

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -1,3 +1,4 @@
+/*
 /datum/preference/choiced/language
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "language"
@@ -33,3 +34,4 @@
 
 /datum/preference/choiced/language/apply_to_human(mob/living/carbon/human/target, value)
 	return
+*/

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 // You do not need to raise this if you are adding new values that have sane defaults.
 // Only raise this value when changing the meaning/format/name/layout of an existing value
 // where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 45
+#define SAVEFILE_VERSION_MAX 45.1
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -110,6 +110,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			new_typepath = /obj/item/clothing/accessory/pride,
 			data_to_migrate = list(INFO_RESKIN = save_data?["pride_pin"]),
 		)
+
+	if (current_version < 45.1)
+		migrate_quirks_to_language_menu(save_data)
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()

--- a/code/modules/language/_language.dm
+++ b/code/modules/language/_language.dm
@@ -133,7 +133,7 @@
 		return most_common_cache[input]
 
 	. = scramble_cache[input]
-	if(.)
+	if(. && scramble_cache[1] != input)
 		// bumps it to the top of the cache
 		scramble_cache -= input
 		scramble_cache[input] = .
@@ -154,7 +154,7 @@
 /datum/language/proc/read_sentence_cache(input)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	. = last_sentence_cache[input]
-	if(.)
+	if(. && last_sentence_cache[1] != input)
 		// bumps it to the top of the cache (don't anticipate this happening often)
 		last_sentence_cache -= input
 		last_sentence_cache[input] = .

--- a/code/modules/language/_language_holder.dm
+++ b/code/modules/language/_language_holder.dm
@@ -176,6 +176,18 @@ Key procs
 /datum/language_holder/proc/get_random_understood_language()
 	return pick(understood_languages)
 
+/// Gets a list of all mutually understood languages.
+/datum/language_holder/proc/get_mutually_understood_languages()
+	var/list/mutual_languages = list()
+	for(var/language_type in understood_languages)
+		var/datum/language/language_instance = GLOB.language_datum_instances[language_type]
+		for(var/mutual_language_type in language_instance.mutual_understanding)
+			// add it to the list OR override it if it's a stronger mutual understanding
+			if(!mutual_languages[mutual_language_type] || mutual_languages[mutual_language_type] < language_instance.mutual_understanding[mutual_language_type])
+				mutual_languages[mutual_language_type] = language_instance.mutual_understanding[mutual_language_type]
+
+	return mutual_languages
+
 /// Gets a random spoken language, useful for forced speech and such.
 /datum/language_holder/proc/get_random_spoken_language()
 	return pick(spoken_languages)

--- a/code/modules/language/beachbum.dm
+++ b/code/modules/language/beachbum.dm
@@ -19,3 +19,8 @@
 	)
 	icon_state = "beach"
 	always_use_default_namelist = TRUE
+
+	mutual_understanding = list(
+		/datum/language/common = 50,
+		/datum/language/uncommon = 30,
+	)

--- a/code/modules/language/codespeak.dm
+++ b/code/modules/language/codespeak.dm
@@ -7,7 +7,7 @@
 	icon_state = "codespeak"
 	always_use_default_namelist = TRUE // No syllables anyways
 
-/datum/language/codespeak/scramble(input)
+/datum/language/codespeak/scramble_sentence(input, list/mutual_languages)
 	var/lookup = check_cache(input)
 	if(lookup)
 		return lookup

--- a/code/modules/language/codespeak.dm
+++ b/code/modules/language/codespeak.dm
@@ -8,9 +8,9 @@
 	always_use_default_namelist = TRUE // No syllables anyways
 
 /datum/language/codespeak/scramble_sentence(input, list/mutual_languages)
-	var/lookup = check_cache(input)
-	if(lookup)
-		return lookup
+	. = read_word_cache(input)
+	if(.)
+		return .
 
 	. = ""
 	var/list/words = list()
@@ -29,4 +29,4 @@
 	if(input_ending in endings)
 		. += input_ending
 
-	add_to_cache(input, .)
+	write_word_cache(input, .)

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -57,5 +57,6 @@
 	)
 
 	mutual_understanding = list(
+		/datum/language/beachbum = 33,
 		/datum/language/uncommon = 20,
 	)

--- a/code/modules/language/common.dm
+++ b/code/modules/language/common.dm
@@ -55,3 +55,7 @@
 			"his", "ing", "ion", "ith", "not", "ome", "oul", "our", "sho", "ted", "ter", "tha", "the", "thi",
 		),
 	)
+
+	mutual_understanding = list(
+		/datum/language/uncommon = 20,
+	)

--- a/code/modules/language/uncommon.dm
+++ b/code/modules/language/uncommon.dm
@@ -14,3 +14,8 @@
 	)
 	icon_state = "galuncom"
 	default_priority = 90
+
+	mutual_understanding = list(
+		/datum/language/common = 33,
+		/datum/language/beachbum = 20,
+	)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -158,6 +158,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		return
 
 	language = message_mods[LANGUAGE_EXTENSION] || get_selected_language()
+	if(!language)
+		message_mods[MODE_CUSTOM_SAY_EMOTE] ||= "makes \a [pick("strange", "weird", "bizarre", "peculiar", "odd", "unusual", "curious")] sound"
+		message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
 
 	var/succumbed = FALSE
 

--- a/maplestation_modules/code/datums/quirks/good.dm
+++ b/maplestation_modules/code/datums/quirks/good.dm
@@ -4,14 +4,8 @@
 /datum/quirk/jolly
 	value = 3
 
-/datum/quirk/bilingual
-	icon = FA_ICON_GLOBE_EUROPE
-	value = 0
-	desc = "Over the years you've picked up an extra language! \
-		(Made redundant by the Language Picker - use it instead.)"
-	medical_record_text = "Patient is bilingual speaks multiple languages."
-
 // New quirks
+/*
 /// Trilingual quirk - Gives the owner a language.
 /datum/quirk/trilingual
 	name = "Trilingual"
@@ -59,6 +53,7 @@
 /datum/quirk/trilingual/remove()
 	if(added_language && !QDELETED(quirk_holder))
 		quirk_holder.get_language_holder().remove_language(added_language, ALL, LANGUAGE_QUIRK)
+*/
 
 /datum/quirk/no_appendix
 	name = "Appendicitis Survivor"

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/clock_language.dm
@@ -11,7 +11,7 @@
 	spans = list(SPAN_ROBOT)
 	icon_state = "ratvar"
 
-/datum/language/ratvarian/scramble(input)
+/datum/language/ratvarian/scramble_sentence(input, list/mutual_languages)
 	return text2ratvar(input)
 
 /// Regexes used to add ratvarian styling to rot13 english

--- a/maplestation_modules/code/modules/client/preferences/languages.dm
+++ b/maplestation_modules/code/modules/client/preferences/languages.dm
@@ -6,6 +6,32 @@
 #define REMOVE_SPOKEN_LANGUAGE "Remove spoken language"
 #define REMOVE_UNDERSTOOD_LANGUAGE "Remove understood language"
 
+/datum/preferences/proc/migrate_quirks_to_language_menu(list/save_data)
+	var/datum/preference_middleware/language/update = locate() in middleware
+	var/datum/preference/languages/language_pref = GLOB.preference_entries[/datum/preference/languages]
+
+	// random quirks
+	if("Bilingual" in all_quirks)
+		var/picked_lang = GLOB.language_types_by_name[save_data["bilingual_language"]]?.type
+		if(picked_lang && (picked_lang in language_pref.selectable_languages))
+			update.add_language_to_user(picked_lang, ADD_SPOKEN_LANGUAGE)
+			update.add_language_to_user(picked_lang, ADD_UNDERSTOOD_LANGUAGE)
+
+	if("Trilingual" in all_quirks)
+		pass() // nothing to do about this
+
+	if("Foreigner" in all_quirks)
+		update.add_language_to_user(/datum/language/uncommon, ADD_SPOKEN_LANGUAGE)
+		update.add_language_to_user(/datum/language/uncommon, ADD_UNDERSTOOD_LANGUAGE)
+		update.add_language_to_user(/datum/language/common, REMOVE_SPOKEN_LANGUAGE)
+		update.add_language_to_user(/datum/language/common, REMOVE_UNDERSTOOD_LANGUAGE)
+
+	// the old prefs
+	var/other_lang = text2path(save_data["language"])
+	if(other_lang && (other_lang in language_pref.selectable_languages))
+		update.add_language_to_user(other_lang, ADD_SPOKEN_LANGUAGE)
+		update.add_language_to_user(other_lang, ADD_UNDERSTOOD_LANGUAGE)
+
 /datum/preference/languages
 	savefile_key = "language"
 	savefile_identifier = PREFERENCE_CHARACTER

--- a/maplestation_modules/code/modules/client/preferences/languages.dm
+++ b/maplestation_modules/code/modules/client/preferences/languages.dm
@@ -1,191 +1,207 @@
 // -- Language preference and UI.
 
-/// Simple define to denote no language.
-#define NO_LANGUAGE "No Language"
+// These defines are used in the UI be careful updating them.
+#define ADD_SPOKEN_LANGUAGE "Add spoken language"
+#define ADD_UNDERSTOOD_LANGUAGE "Add understood language"
+#define REMOVE_SPOKEN_LANGUAGE "Remove spoken language"
+#define REMOVE_UNDERSTOOD_LANGUAGE "Remove understood language"
 
-/datum/preference/choiced/language
-	savefile_key = "bilingual_language"
-
-// Stores a typepath of a language, or "No language" when passed a null / invalid language.
-/datum/preference/additional_language
+/datum/preference/languages
 	savefile_key = "language"
 	savefile_identifier = PREFERENCE_CHARACTER
 	priority = PREFERENCE_PRIORITY_NAMES // needs to happen after species, so name works
 	can_randomize = FALSE
 
-/datum/preference/additional_language/deserialize(input, datum/preferences/preferences)
-	if(input == NO_LANGUAGE)
-		return NO_LANGUAGE
-	if("Trilingual" in preferences.all_quirks)
-		return NO_LANGUAGE
-	if("Bilingual" in preferences.all_quirks)
-		return NO_LANGUAGE
+	/// List of languages you can pick.
+	/// You only need to add languagues here that are not spoken by selectable roundstart species.
+	var/list/selectable_languages = list(
+		/datum/language/common,
+		/datum/language/impdraconic,
+		/datum/language/isatoa,
+		/datum/language/piratespeak,
+		/datum/language/shadowtongue,
+		/datum/language/uncommon,
+		/datum/language/yangyu,
+		// these should be auto filled
+		/datum/language/moffic,
+		/datum/language/nekomimetic,
+		/datum/language/draconic,
+		/datum/language/slime,
+		/datum/language/skrell,
+		// these are iffy
+		/datum/language/voltaic,
+		/datum/language/calcic,
+	)
+	/// Languages not rendered in the UI under any circumstances.
+	var/list/dont_show_languages = list(
+		/datum/language/codespeak,
+		/datum/language/drone,
+		/datum/language/xenocommon,
+	)
 
-	var/datum/language/lang_to_add = check_input_path(input)
-	if(!ispath(lang_to_add, /datum/language))
-		return NO_LANGUAGE
+/datum/preference/languages/create_default_value()
+	return null
 
-	var/datum/species/species = preferences.read_preference(/datum/preference/choiced/species)
-	var/banned = initial(lang_to_add.banned_from_species)
-	var/req = initial(lang_to_add.required_species)
-	if((banned && ispath(species, banned)) || (req && !ispath(species, req)))
-		return NO_LANGUAGE
-
-	return lang_to_add
-
-/datum/preference/additional_language/serialize(input)
-	return check_input_path(input) || NO_LANGUAGE
-
-/datum/preference/additional_language/create_default_value()
-	return NO_LANGUAGE
-
-/datum/preference/additional_language/is_valid(value)
-	return !!check_input_path(value)
-
-/// Checks if our passed input is valid
-/// Returns NO LANGUAGE if passed NO LANGUAGE (truthy value)
-/// Returns null if the input was invalid (falsy value)
-/// Returns a language typepath if the input was a valid path (truthy value)
-/datum/preference/additional_language/proc/check_input_path(input)
-	if(input == NO_LANGUAGE)
-		return NO_LANGUAGE
-
-	var/path_form = istext(input) ? text2path(input) : input
-	// sometimes we deserialize with a text string that is a path, as they're saved as string in our json save
-	// other times we recieve a full typepath, likely from write preference
-	// we need to support either case just to be inclusive, so here we are	var/path_form = istext(input) ? text2path(input) : input
-	if(!ispath(path_form, /datum/language))
+/datum/preference/languages/deserialize(list/input, datum/preferences/preferences)
+	if(!islist(input))
 		return null
 
-	var/datum/language/lang_instance = GLOB.language_datum_instances[path_form]
-	// MAYBE accessed when language datums aren't created so this is just a sanity check
-	if(istype(lang_instance) && !lang_instance.available_as_pref)
-		return null
+	var/datum/species/species = GLOB.species_prototypes[preferences.read_preference(/datum/preference/choiced/species)]
+	var/datum/language_holder/species_holder = GLOB.prototype_language_holders[species.species_language_holder]
+	var/list/sanitized_input = list()
+	for(var/key in input)
+		for(var/lang_text in input[key])
+			var/lang = istext(lang_text) ? text2path(lang_text) : lang_text
+			if(!ispath(lang, /datum/language))
+				continue
+			switch(key)
+				if(ADD_SPOKEN_LANGUAGE)
+					if(!(lang in selectable_languages))
+						continue
+					if(lang in species_holder.spoken_languages)
+						continue
 
-	return path_form
+				if(ADD_UNDERSTOOD_LANGUAGE)
+					if(!(lang in selectable_languages))
+						continue
+					if(lang in species_holder.understood_languages)
+						continue
 
-/datum/preference/additional_language/apply_to_human(mob/living/carbon/human/target, value)
-	if(value == NO_LANGUAGE)
+				if(REMOVE_SPOKEN_LANGUAGE)
+					if(!(lang in species_holder.spoken_languages))
+						continue
+
+				if(REMOVE_UNDERSTOOD_LANGUAGE)
+					if(!(lang in species_holder.understood_languages))
+						continue
+
+			LAZYADD(sanitized_input[key], lang)
+
+	return sanitized_input
+
+/datum/preference/languages/is_valid(value)
+	return islist(value) || isnull(value)
+
+/datum/preference/languages/apply_to_human(mob/living/carbon/human/target, value)
+	if(isdummy(target) || !islist(value))
 		return
 
-	target.grant_language(value, ALL, LANGUAGE_PREF)
+	// this needs to be delayed because it's tied to the mind (and we probably don't have that created yet)
+	if(target.mind)
+		add_mind_languages(target, value)
+	else
+		RegisterSignals(target, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED), PROC_REF(comsig_add_mind_languages), TRUE)
+	// this is fine to do now, though
+	remove_species_languages(target, value)
 
-/datum/language
-	// Vars used in determining valid languages for the language preferences.
-	/// Whether this language is available as a pref.
-	var/available_as_pref = FALSE
-	/// The 'base species' of the language, the lizard to the draconic.
-	/// Players cannot select this language in the preferences menu if they already have this species set.
-	var/datum/species/banned_from_species
-	/// The 'required species' of the language, languages that require you be a certain species to know.
-	/// Players cannot select this language in the preferences menu if they do not have this species set.
-	var/datum/species/required_species
+/datum/preference/languages/proc/comsig_add_mind_languages(mob/living/carbon/human/target)
+	SIGNAL_HANDLER
 
-/datum/language/skrell
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/skrell
+	if(!target.client)
+		return
 
-/datum/language/draconic
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/lizard
+	UnregisterSignal(target, list(COMSIG_MOB_MIND_TRANSFERRED_INTO, COMSIG_MOB_MIND_INITIALIZED))
+	add_mind_languages(target, target.client.prefs.read_preference(/datum/preference/languages))
 
-/datum/language/impdraconic
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/lizard/silverscale // already know it (though this check should be deharcoded)
-	required_species = /datum/species/lizard
+/datum/preference/languages/proc/add_mind_languages(mob/living/carbon/human/target, list/value = list())
+	if(QDELETED(target))
+		return
+	for(var/lang in value[ADD_SPOKEN_LANGUAGE])
+		target.grant_language(lang, SPOKEN_LANGUAGE, LANGUAGE_MIND)
+	for(var/lang in value[ADD_UNDERSTOOD_LANGUAGE])
+		target.grant_language(lang, UNDERSTOOD_LANGUAGE, LANGUAGE_MIND)
 
-/datum/language/nekomimetic
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/human/felinid
-
-/datum/language/moffic
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/moth
-
-/datum/language/uncommon
-	available_as_pref = TRUE
-
-/datum/language/piratespeak
-	available_as_pref = TRUE
-
-/datum/language/yangyu
-	available_as_pref = TRUE
-	banned_from_species = /datum/species/ornithid
-
-/datum/language/shadowtongue
-	available_as_pref = TRUE
+/datum/preference/languages/proc/remove_species_languages(mob/living/carbon/human/target, list/value = list())
+	if(QDELETED(target))
+		return
+	for(var/lang in value[REMOVE_SPOKEN_LANGUAGE])
+		target.remove_language(lang, SPOKEN_LANGUAGE, LANGUAGE_SPECIES)
+	for(var/lang in value[REMOVE_UNDERSTOOD_LANGUAGE])
+		target.remove_language(lang, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
 
 /datum/preference_middleware/language
 	action_delegations = list(
 		"set_language" = PROC_REF(set_language),
 	)
 
+/datum/preference_middleware/language/proc/add_language_to_user(lang_type, lang_key)
+	var/list/existing = preferences.read_preference(/datum/preference/languages) || list()
+
+	LAZYADD(existing[lang_key], lang_type)
+
+	preferences.write_preference(GLOB.preference_entries[/datum/preference/languages], existing)
+
+	return TRUE
+
+/datum/preference_middleware/language/proc/remove_language_from_user(lang_type, lang_key)
+	var/list/existing = preferences.read_preference(/datum/preference/languages) || list()
+
+	LAZYREMOVE(existing[lang_key], lang_type)
+
+	preferences.write_preference(GLOB.preference_entries[/datum/preference/languages], existing)
+
+	return TRUE
+
 /datum/preference_middleware/language/proc/set_language(list/params, mob/user)
-	var/datum/preference/additional_language/language_pref = GLOB.preference_entries[/datum/preference/additional_language]
+	var/datum/preference/languages/language_pref = GLOB.preference_entries[/datum/preference/languages]
 	if(params["deselecting"])
-		preferences.update_preference(language_pref, NO_LANGUAGE)
+		remove_language_from_user(text2path(params["lang_type"]), params["lang_key"])
 		return TRUE
 
 	var/lang_path = text2path(params["lang_type"])
-	var/datum/species/current_species = preferences.read_preference(/datum/preference/choiced/species)
-	var/datum/language/lang_to_add = GLOB.language_datum_instances[lang_path]
-	if(!istype(lang_to_add))
-		to_chat(user, span_warning("Invalid language."))
+	if(!GLOB.language_datum_instances[lang_path])
 		return TRUE
-	if(!lang_to_add.available_as_pref)
-		to_chat(user, span_warning("That language is not available."))
+	if((params["lang_key"] == ADD_SPOKEN_LANGUAGE || params["lang_key"] == ADD_UNDERSTOOD_LANGUAGE) && !(lang_path in language_pref.selectable_languages))
 		return TRUE
-	// Sanity checking - Buttons are disabled in UI but you can never rely on that
-	if(lang_to_add.banned_from_species && ispath(current_species, lang_to_add.banned_from_species))
-		to_chat(user, span_warning("Invalid language for current species."))
-		return TRUE
-	if(lang_to_add.required_species && !ispath(current_species, lang_to_add.required_species))
-		to_chat(user, span_warning("Language requires another species."))
-		return TRUE
-
-	preferences.update_preference(language_pref, lang_path)
+	add_language_to_user(lang_path, params["lang_key"])
 	return TRUE
+
+/datum/preference_middleware/language/on_new_character(mob/user)
+	preferences.update_static_data(user)
+
+/datum/preference_middleware/language/get_ui_static_data(mob/user)
+	var/list/data = list()
+
+	data["pref_name"] = preferences.read_preference(/datum/preference/name/real_name)
+
+	var/datum/species/species = GLOB.species_prototypes[preferences.read_preference(/datum/preference/choiced/species)]
+	var/datum/language_holder/species_holder = GLOB.prototype_language_holders[species.species_language_holder]
+	data["spoken_languages"] = assoc_to_keys(species_holder.spoken_languages)
+	data["understood_languages"] = assoc_to_keys(species_holder.understood_languages)
+	data["partial_languages"] = species_holder.get_mutually_understood_languages()
+
+	return data
 
 /datum/preference_middleware/language/get_ui_data(mob/user)
 	var/list/data = list()
 
-	data["selected_lang"] = preferences.read_preference(/datum/preference/additional_language)
-	data["selected_species"] = preferences.read_preference(/datum/preference/choiced/species)
-	data["pref_name"] = preferences.read_preference(/datum/preference/name/real_name)
-	data["trilingual"] = ("Trilingual" in preferences.all_quirks)
-	data["bilingual"] = ("Bilingual" in preferences.all_quirks)
+	var/list/selected_languages = preferences.read_preference(/datum/preference/languages)
+	data["pref_spoken_languages"] = selected_languages?[ADD_SPOKEN_LANGUAGE] || list()
+	data["pref_understood_languages"] = selected_languages?[ADD_UNDERSTOOD_LANGUAGE] || list()
+	data["pref_unspoken_languages"] = selected_languages?[REMOVE_SPOKEN_LANGUAGE] || list()
+	data["pref_ununderstood_languages"] = selected_languages?[REMOVE_UNDERSTOOD_LANGUAGE] || list()
 
 	return data
 
 /datum/preference_middleware/language/get_constant_data()
 	var/list/data = list()
-	var/list/base_languages = list()
-	var/list/bonus_languages = list()
+
+	var/datum/preference/languages/language_pref = GLOB.preference_entries[/datum/preference/languages]
+
+	data["base_languages"] = list()
 	for(var/found_language in GLOB.language_datum_instances)
-		var/datum/language/found_instance = GLOB.language_datum_instances[found_language]
-		if(!found_instance.available_as_pref)
+		if(found_language in language_pref.dont_show_languages)
 			continue
-
 		var/list/lang_data = list()
-		lang_data["name"] = found_instance.name
 		lang_data["type"] = found_language
+		lang_data["unlocked"] = (found_language in language_pref.selectable_languages)
+		lang_data["name"] = GLOB.language_datum_instances[found_language].name
+		lang_data["desc"] = GLOB.language_datum_instances[found_language].desc
+		UNTYPED_LIST_ADD(data["base_languages"], lang_data)
 
-		var/datum/species/banned_species = found_instance.banned_from_species
-		if(banned_species)
-			lang_data["incompatible_with"] = list("name" = initial(banned_species.name), "type" = banned_species)
-		var/datum/species/required_species = found_instance.required_species
-		if(required_species)
-			lang_data["requires"] = list("name" = initial(required_species.name), "type" = required_species)
-
-		// Having a required species makes it a bonus language, otherwise it's a base language
-		if(found_instance.required_species)
-			UNTYPED_LIST_ADD(bonus_languages, lang_data)
-		else
-			UNTYPED_LIST_ADD(base_languages, lang_data)
-
-	data["base_languages"] = base_languages
-	data["bonus_languages"] = bonus_languages
-	data["blacklisted_species"] = list()
 	return data
 
-#undef NO_LANGUAGE
+#undef ADD_SPOKEN_LANGUAGE
+#undef ADD_UNDERSTOOD_LANGUAGE
+#undef REMOVE_SPOKEN_LANGUAGE
+#undef REMOVE_UNDERSTOOD_LANGUAGE

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -26,6 +26,9 @@
 		/datum/language/impdraconic = 66,
 	)
 
+// TG unit test compliance (out of laziness)
+#ifndef UNIT_TESTS
+
 // Edit to the silverscale language holder - silverscales can speak high draconic.
 /datum/language_holder/lizard/silver
 	understood_languages = list(
@@ -49,3 +52,5 @@
 	spoken_languages = list(
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
+
+#endif

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -17,16 +17,13 @@
 	icon_state = "lizardred"
 	default_priority = 85
 
-// So I wrote a few unit tests for /tg/ that rely on Lizards not knowing what high draconic is.
-// And since rewriting them is out of the questions, Lizards don't know high draconic in unit tests.
-#ifndef UNIT_TESTS
+	mutual_understanding = list(
+		/datum/language/draconic = 66,
+	)
 
-// Edit to the base lizard language holder - lizards can understand high draconic.
-/datum/language_holder/lizard
-	understood_languages = list(
-		/datum/language/common = list(LANGUAGE_ATOM),
-		/datum/language/draconic = list(LANGUAGE_ATOM),
-		/datum/language/impdraconic = list(LANGUAGE_ATOM),
+/datum/language/draconic
+	mutual_understanding = list(
+		/datum/language/impdraconic = 66,
 	)
 
 // Edit to the silverscale language holder - silverscales can speak high draconic.
@@ -43,8 +40,6 @@
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
 	selected_language = /datum/language/uncommon
-
-#endif
 
 /datum/language_holder/lizard/ash/primative
 	selected_language = /datum/language/impdraconic

--- a/maplestation_modules/code/modules/language/highdraconic.dm
+++ b/maplestation_modules/code/modules/language/highdraconic.dm
@@ -44,6 +44,8 @@
 	)
 	selected_language = /datum/language/uncommon
 
+#endif
+
 /datum/language_holder/lizard/ash/primative
 	selected_language = /datum/language/impdraconic
 	understood_languages = list(
@@ -52,5 +54,3 @@
 	spoken_languages = list(
 		/datum/language/impdraconic = list(LANGUAGE_ATOM),
 	)
-
-#endif

--- a/maplestation_modules/code/modules/language/isatoan.dm
+++ b/maplestation_modules/code/modules/language/isatoan.dm
@@ -15,7 +15,6 @@
 	icon_state = "mu"
 	icon = 'maplestation_modules/icons/misc/language.dmi'
 	default_priority = 80
-	available_as_pref = TRUE
 
 /datum/language_holder/isatoa
 	understood_languages = list(

--- a/maplestation_modules/code/modules/language/japanese.dm
+++ b/maplestation_modules/code/modules/language/japanese.dm
@@ -13,7 +13,7 @@
 	)
 	icon_state = "torii"
 	icon = 'maplestation_modules/icons/misc/language.dmi'
-	default_priority = 94
+	default_priority = 90
 
 /datum/language_holder/yangyu
 	understood_languages = list(

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
@@ -252,11 +252,11 @@ const LanguagePageInner = (props: {
 
   return (
     <Flex grow>
-      <Flex.Item width="79%" mr={'1%'}>
+      <Flex.Item width="79%" pr="1%">
         <Section
           scrollable
           title={
-            <Flex align="center">
+            <Flex align="center" pr="4%">
               <Flex.Item width="33%">Language</Flex.Item>
               <Flex.Item grow>Spoken</Flex.Item>
               <Flex.Item grow>Understood</Flex.Item>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
@@ -320,7 +320,7 @@ const LanguagePageInner = (props: {
                 <NoticeBox color="red" mt={0.5} preserveWhitespace>
                   {`You can't speak any languages!
 
-You will be completely unable to communicate verbally, even though sign language.
+You will be completely unable to communicate verbally, even through sign language.
 
 You may want to select at least one language to speak.`}
                 </NoticeBox>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/_LanguagePicker.tsx
@@ -55,11 +55,18 @@ const StateToColor = {
   [LanguageState.NONE]: 'default',
 };
 
-const StateToTooltip = {
-  [LanguageState.DEFAULT]: 'You know this feature due to your species.',
-  [LanguageState.DISABLED]: 'You have disabled this feature of your species.',
-  [LanguageState.ENABLED]: 'You have enabled this feature.',
-  [LanguageState.NONE]: '',
+const StateToTooltipSpeech = {
+  [LanguageState.DEFAULT]: 'You innately speak this.',
+  [LanguageState.DISABLED]: 'You have opted out of speaking this.',
+  [LanguageState.ENABLED]: 'You have chosen to speak this.',
+  [LanguageState.NONE]: 'You do not speak this.',
+};
+
+const StateToTooltipUnderstanding = {
+  [LanguageState.DEFAULT]: 'You innately understand this.',
+  [LanguageState.DISABLED]: 'You have opted out of understanding this.',
+  [LanguageState.ENABLED]: 'You have chosen to understand this.',
+  [LanguageState.NONE]: 'You do not understand this.',
 };
 
 const get_spoken_language_state = (
@@ -176,13 +183,20 @@ const LanguageRow = (props: {
   return (
     <Flex p={0.25} className="candystripe" align="center">
       <Flex.Item width="33%">
-        <Button
-          tooltip={displayed_language.desc}
-          disabled={!displayed_language.desc}
-          icon="question-circle"
-          mr={1}
-        />
-        {displayed_language.name}
+        {displayed_language.desc ? (
+          <Tooltip content={displayed_language.desc} position="bottom-start">
+            <Box
+              inline
+              style={{
+                borderBottom: '2px dotted rgba(255, 255, 255, 0.8)',
+              }}
+            >
+              {displayed_language.name}
+            </Box>
+          </Tooltip>
+        ) : (
+          <Box>{displayed_language.name}</Box>
+        )}
       </Flex.Item>
       <Flex.Item grow>
         <Button
@@ -192,7 +206,8 @@ const LanguageRow = (props: {
           }
           icon={StateToIcon[spoken_state]}
           color={StateToColor[spoken_state]}
-          tooltip={StateToTooltip[spoken_state]}
+          tooltip={StateToTooltipSpeech[spoken_state]}
+          tooltipPosition={'right'}
           onClick={() =>
             act('set_language', {
               lang_type: lang_type,
@@ -210,7 +225,8 @@ const LanguageRow = (props: {
           }
           icon={StateToIcon[understood_state]}
           color={StateToColor[understood_state]}
-          tooltip={StateToTooltip[understood_state]}
+          tooltip={StateToTooltipUnderstanding[understood_state]}
+          tooltipPosition={'right'}
           onClick={() =>
             act('set_language', {
               lang_type: lang_type,
@@ -257,17 +273,54 @@ const LanguagePageInner = (props: {
           scrollable
           title={
             <Flex align="center" pr="4%">
-              <Flex.Item width="33%">Language</Flex.Item>
-              <Flex.Item grow>Spoken</Flex.Item>
-              <Flex.Item grow>Understood</Flex.Item>
+              <Flex.Item width="33%"> Language</Flex.Item>
+              <Flex.Item grow>
+                <Tooltip
+                  content="Speaking a language allows you to
+                    communicate verbally with others who understand it.
+                    It does NOT necessarily mean you can understand the language."
+                >
+                  <Box
+                    inline
+                    style={{
+                      borderBottom: '2px dotted rgba(255, 255, 255, 0.8)',
+                    }}
+                  >
+                    Spoken
+                  </Box>
+                </Tooltip>
+              </Flex.Item>
+              <Flex.Item grow>
+                <Tooltip
+                  content="Understanding a language allows you to
+                    comprehend what others are saying in it.
+                    It does NOT necessarily mean you can speak the language."
+                >
+                  <Box
+                    inline
+                    style={{
+                      borderBottom: '2px dotted rgba(255, 255, 255, 0.8)',
+                    }}
+                  >
+                    Understood
+                  </Box>
+                </Tooltip>
+              </Flex.Item>
               <Flex.Item width="33%">
-                Partial Understanding
-                <Button
-                  icon="info"
-                  tooltip="What percentage of words you are able to understand,
-                    despite not ultimately knowing the language."
-                  ml={1}
-                />
+                <Tooltip
+                  content="Partial understanding indicates what percentage
+                    of words in the language you are able to understand,
+                    if you otherwise are incapable of fully understanding it."
+                >
+                  <Box
+                    inline
+                    style={{
+                      borderBottom: '2px dotted rgba(255, 255, 255, 0.8)',
+                    }}
+                  >
+                    Partial Understanding
+                  </Box>
+                </Tooltip>
               </Flex.Item>
             </Flex>
           }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -207,8 +207,8 @@ export type ServerData = {
   };
   language: {
     base_languages: Language[];
-    bonus_languages: Language[];
-    blacklisted_species: string[];
+    max_spoken_languages: number;
+    max_understood_languages: number;
   };
   // NON-MODULE CHANGE END
   [otheyKey: string]: unknown;


### PR DESCRIPTION
Updates the language menu

Deletes Bilingual, Trilingual, and Foreigner quirks (Bilingual may be readded, giving you more language slots?)

Now you can choose to remove languages your species starts with

Now you can choose to only understand or only speak a language, rather than having both

Languages given to you by the preference are tied to the mind

A few languages are no longer blocked behind being a certain species (may return?) 

Now shows you what languages you have partial understanding of (may be its own preference in the future?) 

![image](https://github.com/user-attachments/assets/0638ac76-ca7c-485d-bafe-c2aca9599243)
