### PR TITLE
Adds in the colorblind quirk.

### DIFF
--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -207,3 +207,78 @@
 	return
 
 #undef RANDOM_INNATE_MUTATION
+
+#define COLORBLINDNESS_PROTANOPIA "Protanopia (Red-Green)"
+#define COLORBLINDNESS_DEUTERANOPIA "Deuteranopia (Red-Green)"
+#define COLORBLINDNESS_TRITANOPIA "Tritanopia (Blue-Yellow)"
+
+// Uses the same values as the colorblind test debug. As always, they're not accurate and if you argue about that or argue like it is accurate i will SLAP YOU
+/datum/quirk/colorblind
+	name = "Colorblind"
+	desc = "You are partially colorblind and are unable to percieve the full color spectrum."
+	icon = FA_ICON_ADJUST
+	value = 0
+	gain_text = span_notice("You suddenly can't see as many colors anymore.")
+	lose_text = span_danger("You can see the world in full color now! It's not that great...")
+	medical_record_text = "Patient is afflicted with color blindness."
+	var/colorblind_type = COLORBLINDNESS_DEUTERANOPIA //cached to prevent on-the-fly prefs switching causing issues
+
+/datum/quirk/colorblind/add(client/client_source)
+	colorblind_type = client_source?.prefs?.read_preference(/datum/preference/choiced/colorblindedness)
+	switch(colorblind_type)
+		if(COLORBLINDNESS_PROTANOPIA)
+			quirk_holder.add_client_colour(/datum/client_colour/colorblind/protanopia)
+		if(COLORBLINDNESS_DEUTERANOPIA)
+			quirk_holder.add_client_colour(/datum/client_colour/colorblind/deuteranopia)
+		if(COLORBLINDNESS_TRITANOPIA)
+			quirk_holder.add_client_colour(/datum/client_colour/colorblind/tritanopia)
+
+/datum/quirk/colorblind/remove()
+	switch(colorblind_type)
+		if(COLORBLINDNESS_PROTANOPIA)
+			quirk_holder.remove_client_colour(/datum/client_colour/colorblind/protanopia)
+		if(COLORBLINDNESS_DEUTERANOPIA)
+			quirk_holder.remove_client_colour(/datum/client_colour/colorblind/deuteranopia)
+		if(COLORBLINDNESS_TRITANOPIA)
+			quirk_holder.remove_client_colour(/datum/client_colour/colorblind/tritanopia)
+
+/datum/quirk_constant_data/colorblind
+	associated_typepath = /datum/quirk/colorblind
+	customization_options = list(/datum/preference/choiced/colorblindedness)
+
+/datum/preference/choiced/colorblindedness
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "colorblindedness"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/colorblindedness/create_default_value()
+	return COLORBLINDNESS_DEUTERANOPIA // most common type
+
+/datum/preference/choiced/colorblindedness/init_possible_values()
+	return list(COLORBLINDNESS_PROTANOPIA, COLORBLINDNESS_DEUTERANOPIA, COLORBLINDNESS_TRITANOPIA)
+
+/datum/preference/choiced/colorblindedness/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+
+	return /datum/quirk/colorblind::name in preferences.all_quirks
+
+/datum/preference/choiced/colorblindedness/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/client_colour/colorblind
+	priority = 10 // PRIORITY_HIGH
+
+/datum/client_colour/colorblind/protanopia
+	colour = list(0.56,0.43,0,0, 0.55,0.44,0,0, 0,0.24,0.75,0, 0,0,0,1, 0,0,0,0)
+
+/datum/client_colour/colorblind/deuteranopia
+	colour = list(0.62,0.37,0,0, 0.70,0.30,0,0, 0,0.30,0.70,0, 0,0,0,1, 0,0,0,0)
+
+/datum/client_colour/colorblind/tritanopia
+	colour = list(0.95,0.5,0,0, 0,0.43,0.56,0, 0,0.47,0.52,0, 0,0,0,1, 0,0,0,0)
+
+#undef COLORBLINDNESS_PROTANOPIA
+#undef COLORBLINDNESS_DEUTERANOPIA
+#undef COLORBLINDNESS_TRITANOPIA

--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -216,7 +216,7 @@
 /datum/quirk/colorblind
 	name = "Colorblind"
 	desc = "You are partially colorblind and are unable to percieve the full color spectrum."
-	icon = FA_ICON_ADJUST
+	icon = FA_ICON_PALETTE
 	value = 0
 	gain_text = span_notice("You suddenly can't see as many colors anymore.")
 	lose_text = span_danger("You can see the world in full color now! It's not that great...")

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/colorblind.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/colorblind.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const colorblindedness: FeatureChoiced = {
+  name: 'Colorblindness',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/60d590f9-f157-4cb9-b67e-118bd0353659)

Example of Deuteranopia:
![image](https://github.com/user-attachments/assets/268a4f56-0675-4170-8609-2819b90e551b)

These are the same colors as used in the colorblindness testing in the debug menu made accessible, and no, Tritanopia is *not* accurate in the slightest.