### PR TITLE
Adds tiered Antimagic, also makes Heretic school its own thing

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -83,7 +83,12 @@
 #define COMSIG_MOB_RESTRICT_MAGIC "mob_cast_magic"
 ///from base of mob/can_block_magic(): (mob/user, casted_magic_flags, charge_cost)
 #define COMSIG_MOB_RECEIVE_MAGIC "mob_receive_magic"
-	#define COMPONENT_MAGIC_BLOCKED (1<<0)
+	/// Magic is blocked, but only surface level effects
+	#define ANTIMAGIC_TIER_WEAK (1<<0)
+	/// Magic is blocked, a majority of effects are blocked but especially powerful things may still get through
+	#define ANTIMAGIC_TIER_STRONG (1<<1)
+	/// Magic is 100% blocked, no magic can get through
+	#define ANTIMAGIC_TIER_IMMUNE (1<<2)
 
 ///from base of mob/create_mob_hud(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"

--- a/code/__DEFINES/magic.dm
+++ b/code/__DEFINES/magic.dm
@@ -26,8 +26,10 @@
 // EVIL SPELLS (instant smite + banishment)
 /// Necromancy spells, usually involves soul / evil / bad stuff
 #define SCHOOL_NECROMANCY "necromancy"
-/// Other forbidden magics, such as heretic spells
+/// Other forbidden magics
 #define SCHOOL_FORBIDDEN "forbidden"
+/// Heretic magics
+#define SCHOOL_ELDRITCH "eldritch"
 /// Blood magic, involves vampirism, draining blood, etc.
 #define SCHOOL_SANGUINE "sanguine"
 

--- a/code/datums/components/chuunibyou.dm
+++ b/code/datums/components/chuunibyou.dm
@@ -38,6 +38,7 @@
 
 			SCHOOL_NECROMANCY = "I am the Lord of the Dead, the Master of Bones, the Ruler of Shadows. I command the legions of the damned to rise from their graves and serve me!",
 			SCHOOL_FORBIDDEN = "I renounce the laws of this world and embrace the chaos of the old gods! Let the forbidden power flow through me and destroy everything in its path!",
+			SCHOOL_ELDRITCH = "I am the harbinger of the end times, the herald of the apocalypse, the bringer of eternal darkness. Bow before me, mortals, and despair!",
 			SCHOOL_SANGUINE = "I cover my eye with an eyepatch to seal my true power, but now I will unleash it upon you. I feast on the life force of my prey and grow stronger with every drop!",
 		)
 

--- a/code/datums/components/smooth_tunes.dm
+++ b/code/datums/components/smooth_tunes.dm
@@ -86,7 +86,7 @@
 	if(viable_for_final_effect)
 		if(finished && linked_songtuner_rite && linked_song)
 			for(var/mob/living/carbon/human/listener in linked_song.hearing_mobs)
-				if(listener == parent || listener.can_block_magic(MAGIC_RESISTANCE_HOLY, charge_cost = 1))
+				if(listener == parent || listener.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 1))
 					continue
 
 				linked_songtuner_rite.finish_effect(listener, parent)
@@ -105,7 +105,7 @@
 /datum/component/smooth_tunes/process(seconds_per_tick = SSOBJ_DT)
 	if(linked_songtuner_rite && linked_song)
 		for(var/mob/living/carbon/human/listener in linked_song.hearing_mobs)
-			if(listener == parent || listener.can_block_magic(MAGIC_RESISTANCE_HOLY, charge_cost = 0))
+			if(listener == parent || listener.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 				continue
 
 			linked_songtuner_rite.song_effect(listener, parent)

--- a/code/datums/mutations/antenna.dm
+++ b/code/datums/mutations/antenna.dm
@@ -77,7 +77,7 @@
 
 /datum/action/cooldown/spell/pointed/mindread/cast(mob/living/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+	if(cast_on.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 		to_chat(owner, span_warning("As you reach into [cast_on]'s mind, \
 			you are stopped by a mental blockage. It seems you've been foiled."))
 		return

--- a/code/datums/proximity_monitor/fields/timestop.dm
+++ b/code/datums/proximity_monitor/fields/timestop.dm
@@ -105,7 +105,7 @@
 		return FALSE
 	if(ismob(A))
 		var/mob/M = A
-		if(M.can_block_magic(antimagic_flags))
+		if(M.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			immune[A] = TRUE
 			return
 	var/frozen = TRUE

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -35,7 +35,7 @@
 		return TRUE
 	if(isliving(mover))
 		var/mob/living/living_mover = mover
-		if(living_mover.can_block_magic(antimagic_flags, charge_cost = 0))
+		if(living_mover.can_block_magic(antimagic_flags, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 			return TRUE
 
 	return ..()
@@ -99,7 +99,7 @@
 	if(!isliving(mover))
 		return ..()
 	var/mob/living/living_mover = mover
-	if(living_mover.can_block_magic(antimagic_flags, charge_cost = 0))
+	if(living_mover.can_block_magic(antimagic_flags, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 		return ..()
 	if(living_mover.has_status_effect(/datum/status_effect/star_mark))
 		return FALSE

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -77,7 +77,7 @@
 		var/mob/mob_victim = victim
 		if(mob_victim.mind in immune_minds)
 			return
-		if(mob_victim.can_block_magic(antimagic_flags))
+		if(mob_victim.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_STRONG)
 			flare()
 			return
 	if(charges <= 0)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -207,7 +207,7 @@
 		if(QDELETED(target_gland))
 			return
 
-		if(carbon_target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+		if(carbon_target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_IMMUNE)
 			user.balloon_alert(user, "foiled!")
 			to_chat(user, span_warning("Your target seems to have some sort of mental blockage, preventing the message from being sent! It seems you've been foiled."))
 			return
@@ -399,7 +399,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/melee/baton/abductor/proc/SleepAttack(mob/living/target, mob/living/user)
 	playsound(src, on_stun_sound, 50, TRUE, -1)
 	if(target.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB))
-		if(target.can_block_magic(MAGIC_RESISTANCE_MIND))
+		if(target.can_block_magic(MAGIC_RESISTANCE_MIND) & ANTIMAGIC_TIER_STRONG)
 			to_chat(user, span_warning("The specimen has some kind of mental protection that is interfering with the sleep inducement! It seems you've been foiled."))
 			target.visible_message(span_danger("[user] tried to induced sleep in [target] with [src], but is unsuccessful!"), \
 			span_userdanger("You feel a strange wave of heavy drowsiness wash over you!"))
@@ -410,7 +410,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		target.Sleeping(sleep_time)
 		log_combat(user, target, "put to sleep")
 	else
-		if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+		if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 			to_chat(user, span_warning("The specimen has some kind of mental protection that is completely blocking our sleep inducement methods! It seems you've been foiled."))
 			target.visible_message(span_danger("[user] tried to induce sleep in [target] with [src], but is unsuccessful!"), \
 			span_userdanger("Any sense of drowsiness is quickly diminished!"))

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -223,7 +223,7 @@
 			c.console = src
 
 /obj/machinery/abductor/console/proc/AddSnapshot(mob/living/carbon/human/target)
-	if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+	if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 		say("Unable to get a proper scan of subject! Something is shielding [target]'s mind!")
 		return
 	var/datum/icon_snapshot/entry = new

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -412,7 +412,7 @@
 			var/old_color = target.color
 			target.color = rgb(0, 128, 0)
 			animate(target, color = old_color, time = 1 SECONDS, easing = EASE_IN)
-		else if(target.can_block_magic())
+		else if(target.can_block_magic(MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 			to_chat(user, span_warning("The spell had no effect!"))
 		else
 			to_chat(user, span_cultitalic("In a brilliant flash of red, [target] falls to the ground!"))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -736,7 +736,7 @@ Striking a noncultist, however, will tear their flesh."}
 			playsound(src, 'sound/weapons/throwtap.ogg', 50)
 			target.visible_message(span_warning("[target] catches [src] out of the air!"))
 			return
-		if(target.can_block_magic() || IS_CULTIST(target))
+		if((target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE) || IS_CULTIST(target))
 			target.visible_message(span_warning("[src] bounces off of [target], as if repelled by an unseen force!"))
 			return
 		if(!..())
@@ -1029,7 +1029,7 @@ Striking a noncultist, however, will tear their flesh."}
 	if(isliving(hit_atom))
 		var/mob/living/target = hit_atom
 
-		if(target.can_block_magic() || IS_CULTIST(target))
+		if((target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE) || IS_CULTIST(target))
 			target.visible_message(span_warning("[src] bounces off of [target], as if repelled by an unseen force!"))
 			return
 		if(IS_CULTIST(target) && target.put_in_active_hand(src))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -271,7 +271,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			to_chat(invoker, span_warning("You need at least two invokers to convert [convertee]!"))
 		return FALSE
 
-	if(convertee.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, charge_cost = 0)) //No charge_cost because it can be spammed
+	if(convertee.can_block_magic(ALL, charge_cost = 0) & ANTIMAGIC_TIER_IMMUNE) //No charge_cost because it can be spammed
 		for(var/invoker in invokers)
 			to_chat(invoker, span_warning("Something is shielding [convertee]'s mind!"))
 		return FALSE
@@ -898,7 +898,7 @@ GLOBAL_VAR_INIT(narsie_summon_count, 0)
 	set_light(6, 1, color)
 	for(var/mob/living/target in viewers(T))
 		if(!IS_CULTIST(target) && !HAS_TRAIT(target, TRAIT_NOBLOOD)) // NON-MODULE CHANGE
-			if(target.can_block_magic(charge_cost = 0))
+			if(target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 				continue
 			to_chat(target, span_cultlarge("Your blood boils in your veins!"))
 	animate(src, color = "#FCB56D", time = 4)
@@ -923,7 +923,7 @@ GLOBAL_VAR_INIT(narsie_summon_count, 0)
 	set_light(6, 1, color)
 	for(var/mob/living/target in viewers(T))
 		if(!IS_CULTIST(target) && !HAS_TRAIT(target, TRAIT_NOBLOOD)) // NON-MODULE CHANGE
-			if(target.can_block_magic(charge_cost = 0))
+			if(target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 				continue
 			target.take_overall_damage(tick_damage*multiplier, tick_damage*multiplier)
 

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -276,7 +276,7 @@
 	SIGNAL_HANDLER
 
 	// Heretic spells are of the forbidden school, otherwise we don't care
-	if(spell.school != SCHOOL_FORBIDDEN)
+	if(spell.school != SCHOOL_ELDRITCH)
 		return
 
 	// If we've got the trait, we don't care

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -476,7 +476,7 @@
 		loc.balloon_alert(user, "ritual failed, too far!")
 		return FALSE
 
-	if(to_curse.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, charge_cost = 0))
+	if(to_curse.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, charge_cost = 0) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(to_curse, span_warning("You feel a ghastly chill, but the feeling passes shortly."))
 		return TRUE
 

--- a/code/modules/antagonists/heretic/items/eldritch_painting.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_painting.dm
@@ -42,7 +42,7 @@
 		return
 	if(IS_HERETIC(viewer))
 		return
-	if(viewer.can_block_magic(MAGIC_RESISTANCE))
+	if(viewer.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND) & ANTIMAGIC_TIER_STRONG)
 		return
 	to_chat(viewer, span_notice(text_to_display))
 	viewer.gain_trauma(applied_trauma, TRAUMA_RESILIENCE_SURGERY)
@@ -50,7 +50,7 @@
 	to_chat(viewer, span_hypnophrase("As you gaze upon the painting, your mind rends to its truth!"))
 
 /obj/structure/sign/painting/eldritch/wirecutter_act(mob/living/user, obj/item/I)
-	if(!user.can_block_magic(MAGIC_RESISTANCE))
+	if(!(user.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND) & ANTIMAGIC_TIER_STRONG))
 		user.add_mood_event("ripped_eldritch_painting", /datum/mood_event/eldritch_painting)
 		to_chat(user, span_hypnophrase("Laughter echoes through your mind...."))
 	qdel(src)

--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -69,7 +69,7 @@
 		user.add_mood_event("Moon Amulette Insanity", /datum/mood_event/amulette_insanity)
 		user.mob_mood.set_sanity(user.mob_mood.sanity - 50)
 		return
-	if(hit.can_block_magic())
+	if(hit.can_block_magic(ALL) & ANTIMAGIC_TIER_STRONG)
 		return
 	if(!hit.mob_mood)
 		return

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -209,11 +209,10 @@
 	ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, REF(src))
 
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
-
+	// How many lunatics we have
+	var/amount_of_lunatics = 0
 	// Roughly 1/5th of the station will rise up as lunatics to the heretic
 	for (var/mob/living/carbon/human/crewmate as anything in GLOB.human_list)
-		// How many lunatics we have
-		var/amount_of_lunatics = 0
 		// Where the crewmate is, used to check their z-level
 		var/turf/crewmate_turf = get_turf(crewmate)
 		var/crewmate_z = crewmate_turf?.z
@@ -228,7 +227,7 @@
 			to_chat(crewmate, span_boldwarning("[user]'s rise is influencing those who are weak willed. Their minds shall rend." ))
 			continue
 		// Mindshielded and anti-magic folks are immune against this effect because this is a magical mind effect
-		if(HAS_TRAIT(crewmate, TRAIT_MINDSHIELD) || crewmate.can_block_magic(MAGIC_RESISTANCE))
+		if(HAS_TRAIT(crewmate, TRAIT_MINDSHIELD) || (crewmate.can_block_magic(ALL) & ANTIMAGIC_TIER_STRONG))
 			to_chat(crewmate, span_boldwarning("You feel shielded from something." ))
 			continue
 		if(amount_of_lunatics > length(GLOB.human_list) * 0.2)

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -7,12 +7,13 @@
 	button_icon_state = "corrode"
 	sound = 'sound/items/welder.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "A'GRSV SPR'D"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	aoe_radius = 3
 

--- a/code/modules/antagonists/heretic/magic/apetravulnera.dm
+++ b/code/modules/antagonists/heretic/magic/apetravulnera.dm
@@ -7,12 +7,13 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "cleave"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 45 SECONDS
 
 	invocation = "AP'TRA VULN'RA!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 4
 	/// What type of wound we apply
@@ -30,7 +31,7 @@
 	if(HAS_TRAIT(cast_on, TRAIT_NOBLOOD)) // NON-MODULE CHANGE
 		return FALSE
 
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		cast_on.visible_message(
 			span_danger("[cast_on]'s bruises briefly glow, but repels the effect!"),
 			span_danger("Your bruises sting a little, but you are protected!")

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -7,12 +7,13 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "fire_ring"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 70 SECONDS
 
 	invocation = "FL'MS"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	/// The radius of the fire ring
 	var/fire_radius = 1
@@ -68,12 +69,13 @@
 	button_icon_state = "fire_ring"
 	sound = 'sound/items/welder.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "C'SC'DE"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	/// The radius the flames will go around the caster.
 	var/flame_radius = 4
@@ -107,12 +109,13 @@
 	button_icon_state = "flames"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 300
 
 	invocation = "F'RE"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	/// The length of the flame line spit out.
 	var/flame_line_length = 15
@@ -145,7 +148,7 @@
 			break
 
 		for(var/mob/living/L in T.contents)
-			if(L.can_block_magic())
+			if(L.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 				L.visible_message(span_danger("The spell bounces off of [L]!"), span_danger("The spell bounces off of you!"))
 				continue
 			if(L in hit_list || L == source)

--- a/code/modules/antagonists/heretic/magic/ash_jaunt.dm
+++ b/code/modules/antagonists/heretic/magic/ash_jaunt.dm
@@ -7,12 +7,13 @@
 	button_icon_state = "ash_shift"
 	sound = null
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 15 SECONDS
 
 	invocation = "ASH'N P'SSG'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	exit_jaunt_sound = null
 	jaunt_duration = 1.1 SECONDS

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -7,12 +7,13 @@
 	button_icon_state = "cleave"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 45 SECONDS
 
 	invocation = "CL'VE!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 4
 
@@ -29,7 +30,7 @@
 	for(var/mob/living/carbon/human/victim in range(cleave_radius, cast_on))
 		if(victim == owner || IS_HERETIC_OR_MONSTER(victim))
 			continue
-		if(victim.can_block_magic(antimagic_flags))
+		if(victim.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			victim.visible_message(
 				span_danger("[victim]'s flashes in a firey glow, but repels the blaze!"),
 				span_danger("Your body begins to flash a firey glow, but you are protected!!")

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -8,12 +8,13 @@
 	button_icon_state = "blood_siphon"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 15 SECONDS
 
 	invocation = "FL'MS O'ET'RN'ITY."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 6
 
@@ -26,7 +27,7 @@
 /datum/action/cooldown/spell/pointed/blood_siphon/cast(mob/living/cast_on)
 	. = ..()
 	playsound(owner, 'sound/magic/demon_attack1.ogg', 75, TRUE)
-	if(cast_on.can_block_magic())
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		owner.balloon_alert(owner, "spell blocked!")
 		cast_on.visible_message(
 			span_danger("The spell bounces off of [cast_on]!"),

--- a/code/modules/antagonists/heretic/magic/burglar_finesse.dm
+++ b/code/modules/antagonists/heretic/magic/burglar_finesse.dm
@@ -6,12 +6,13 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "burglarsfinesse"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 40 SECONDS
 
 	invocation = "Y'O'K!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 4
 
@@ -20,13 +21,13 @@
 
 /datum/action/cooldown/spell/pointed/burglar_finesse/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_danger("You feel a light tug, but are otherwise fine, you were protected by holiness!"))
 		to_chat(owner, span_danger("[cast_on] is protected by holy forces!"))
 		return FALSE
 
 	var/obj/storage_item = locate(/obj/item/storage/backpack) in cast_on.contents
-	
+
 	if(isnull(storage_item))
 		return FALSE
 

--- a/code/modules/antagonists/heretic/magic/caretaker.dm
+++ b/code/modules/antagonists/heretic/magic/caretaker.dm
@@ -10,11 +10,12 @@
 	button_icon_state = "ninja_cloak"
 	sound = 'sound/effects/curse2.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 1 MINUTES
 
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 /datum/action/cooldown/spell/caretaker/Remove(mob/living/remove_from)
 	if(remove_from.has_status_effect(/datum/status_effect/caretaker_refuge))

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -8,12 +8,13 @@
 	button_icon_state = "cosmic_domain"
 
 	sound = 'sound/magic/cosmic_expansion.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 45 SECONDS
 
 	invocation = "C'SM'S 'XP'ND"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	summon_amount = 9
 	summon_radius = 1

--- a/code/modules/antagonists/heretic/magic/cosmic_runes.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_runes.dm
@@ -7,12 +7,13 @@
 	button_icon_state = "cosmic_rune"
 
 	sound = 'sound/magic/forcewall.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 15 SECONDS
 
 	invocation = "ST'R R'N'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	/// Storage for the first rune.
 	var/datum/weakref/first_rune

--- a/code/modules/antagonists/heretic/magic/eldritch_blind.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_blind.dm
@@ -4,8 +4,9 @@
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	invocation = "E'E'S"
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_emplosion.dm
@@ -5,12 +5,13 @@
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "E'P"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	emp_heavy = 6
 	emp_light = 10

--- a/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_shapeshift.dm
@@ -6,7 +6,7 @@
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	invocation = "SH'PE"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE

--- a/code/modules/antagonists/heretic/magic/eldritch_telepathy.dm
+++ b/code/modules/antagonists/heretic/magic/eldritch_telepathy.dm
@@ -1,8 +1,8 @@
 // Given to heretic monsters.
 /datum/action/cooldown/spell/list_target/telepathy/eldritch
 	name = "Eldritch Telepathy"
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	invocation_type = INVOCATION_NONE
-	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
+	antimagic_flags = ALL

--- a/code/modules/antagonists/heretic/magic/fire_blast.dm
+++ b/code/modules/antagonists/heretic/magic/fire_blast.dm
@@ -9,12 +9,13 @@
 	button_icon_state = "flames"
 	sound = 'sound/magic/fireball.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 45 SECONDS
 
 	invocation = "V'LC'N!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 	channel_time = 5 SECONDS
 	target_radius = 5
 	max_beam_bounces = 4
@@ -35,7 +36,7 @@
 
 	// If they block the magic, the chain wont necessarily stop,
 	// but likely will (due to them not catching on fire)
-	if(to_beam.can_block_magic(antimagic_flags))
+	if(to_beam.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_beam.visible_message(
 			span_warning("[to_beam] absorbs the spell, remaining unharmed!"),
 			span_userdanger("You absorb the spell, remaining unharmed!"),

--- a/code/modules/antagonists/heretic/magic/flesh_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_ascension.dm
@@ -7,11 +7,12 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "worm_ascend"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 
 	invocation = "REALITY UNCOIL!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	convert_damage = FALSE // Functionally meaningless on Armsy, we track how many segments it had instead
 	possible_shapes = list(/mob/living/basic/heretic_summon/armsy)

--- a/code/modules/antagonists/heretic/magic/flesh_surgery.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_surgery.dm
@@ -9,11 +9,12 @@
 	button_icon_state = "mad_touch"
 	sound = null
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 20 SECONDS
 	invocation = "CL'M M'N!" // "CLAIM MINE", but also almost "KALI MA"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	hand_path = /obj/item/melee/touch_attack/flesh_surgery
 	can_cast_on_self = TRUE

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -9,12 +9,13 @@
 	button_icon_state = "furious_steel"
 	sound = 'sound/weapons/guillotine.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 60 SECONDS
 	invocation = "F'LSH'NG S'LV'R!"
 	invocation_type = INVOCATION_SHOUT
 
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	active_msg = "You summon forth three blades of furious silver."
 	deactive_msg = "You conceal the blades of furious silver."
@@ -123,7 +124,7 @@
 			if(monster?.master == caster.mind)
 				return PROJECTILE_PIERCE_PHASE
 
-		if(victim.can_block_magic(MAGIC_RESISTANCE))
+		if(victim.can_block_magic(MAGIC_RESISTANCE) & ANTIMAGIC_TIER_IMMUNE)
 			visible_message(span_warning("[src] drops to the ground and melts on contact [victim]!"))
 			return PROJECTILE_DELETE_WITHOUT_HITTING
 

--- a/code/modules/antagonists/heretic/magic/madness_touch.dm
+++ b/code/modules/antagonists/heretic/magic/madness_touch.dm
@@ -7,11 +7,11 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "mad_touch"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 15 SECONDS
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
-	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
+	antimagic_flags = ALL
 
 /datum/action/cooldown/spell/touch/mad_touch/is_valid_target(atom/cast_on)
 	if(!ishuman(cast_on))

--- a/code/modules/antagonists/heretic/magic/manse_link.dm
+++ b/code/modules/antagonists/heretic/magic/manse_link.dm
@@ -8,13 +8,13 @@
 	button_icon_state = "mansus_link"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 20 SECONDS
 
 	invocation = "PI'RC' TH' M'ND."
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
-	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
+	antimagic_flags = ALL
 
 	cast_range = 7
 

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -7,13 +7,14 @@
 	button_icon_state = "mansus_grasp"
 	sound = 'sound/items/welder.ogg'
 
-	school = SCHOOL_EVOCATION
+	school = SCHOOL_FORBIDDEN
 	cooldown_time = 10 SECONDS
 
 	invocation = "R'CH T'H TR'TH!"
 	invocation_type = INVOCATION_SHOUT
 	// Mimes can cast it. Chaplains can cast it. Anyone can cast it, so long as they have a hand.
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	hand_path = /obj/item/melee/touch_attack/mansus_fist
 
@@ -37,12 +38,21 @@
 		return FALSE
 
 	var/mob/living/living_hit = victim
-	living_hit.apply_damage(10, BRUTE, wound_bonus = CANT_WOUND)
-	if(iscarbon(victim))
-		var/mob/living/carbon/carbon_hit = victim
-		carbon_hit.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/heretic)
-		carbon_hit.AdjustKnockdown(5 SECONDS)
-		carbon_hit.adjustStaminaLoss(80)
+	var/magic_tier = living_hit.can_block_magic(antimagic_flags, charge_cost = 0)
+	var/antimagic_mod = 1
+	if(magic_tier & ANTIMAGIC_TIER_STRONG)
+		living_hit.adjust_staggered_up_to(5 SECONDS)
+		antimagic_mod = 0.33
+	else if(magic_tier & ANTIMAGIC_TIER_WEAK)
+		living_hit.adjust_staggered_up_to(2 SECONDS)
+		living_hit.AdjustKnockdown(2 SECONDS)
+		antimagic_mod = 0.66
+	else
+		living_hit.apply_damage(10, BRUTE, wound_bonus = CANT_WOUND)
+		living_hit.AdjustKnockdown(5 SECONDS)
+
+	living_hit.adjust_timed_status_effect(4 SECONDS * antimagic_mod, /datum/status_effect/speech/slurring/heretic)
+	living_hit.adjustStaminaLoss(80 * antimagic_mod)
 
 	return TRUE
 
@@ -93,7 +103,7 @@
 	if(QDELETED(source) || !IS_HERETIC(user))
 		return SHAME
 
-	if(user.can_block_magic(source.antimagic_flags))
+	if(user.can_block_magic(source.antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		return SHAME
 
 	var/escape_our_torment = 0

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -8,13 +8,14 @@
 	button_icon_state = "mind_gate"
 
 	sound = 'sound/magic/curse.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 20 SECONDS
 
 	invocation = "Op' 'oY 'Mi'd"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 	cast_range = 6
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND
 
 	active_msg = "You prepare to open your mind..."
 
@@ -26,7 +27,7 @@
 
 /datum/action/cooldown/spell/pointed/mind_gate/cast(mob/living/carbon/human/cast_on, mob/living/carbon/human/owner)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_notice("Your mind feels closed."))
 		to_chat(owner, span_warning("Their mind doesn't swing open, but neither does yours."))
 		return FALSE

--- a/code/modules/antagonists/heretic/magic/moon_parade.dm
+++ b/code/modules/antagonists/heretic/magic/moon_parade.dm
@@ -8,12 +8,13 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/moon_target.dmi'
 
 	sound = 'sound/magic/cosmic_energy.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "L'N'R P'RAD"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = ALL
 
 	active_msg = "You prepare to make them join the parade!"
 	deactive_msg = "You stop the music and halt the parade... for now."
@@ -64,7 +65,7 @@
 		return PROJECTILE_PIERCE_PHASE
 
 	// Anti-magic destroys the projectile for consistency and counterplay
-	if(victim.can_block_magic(MAGIC_RESISTANCE))
+	if(victim.can_block_magic(ALL) & ANTIMAGIC_TIER_IMMUNE)
 		visible_message(span_warning("The parade hits [victim] and a sudden wave of clarity comes over you!"))
 		return PROJECTILE_DELETE_WITHOUT_HITTING
 

--- a/code/modules/antagonists/heretic/magic/moon_ringleader.dm
+++ b/code/modules/antagonists/heretic/magic/moon_ringleader.dm
@@ -8,12 +8,13 @@
 	button_icon_state = "moon_ringleader"
 	sound = 'sound/effects/moon_parade.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 1 MINUTES
 
 	invocation = "R''S 'E"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = ALL
 
 	aoe_radius = 5
 	/// Effect for when the spell triggers
@@ -33,7 +34,7 @@
 			continue
 		if(IS_HERETIC_OR_MONSTER(nearby_mob))
 			continue
-		if(nearby_mob.can_block_magic(antimagic_flags))
+		if(nearby_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			continue
 
 		stuff += nearby_mob

--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -9,8 +9,9 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/moon_target.dmi'
 
 	sound = 'sound/magic/blind.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 20 SECONDS
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	invocation = "Mo'N S'M'LE"
 	invocation_type = INVOCATION_SHOUT
@@ -29,7 +30,7 @@
 	. = ..()
 	/// The duration of these effects are based on sanity, mainly for flavor but also to make it a weaker alpha strike
 	var/moon_smile_duration = (150 - cast_on.mob_mood.sanity) / 10
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_notice("The moon turns, its smile no longer set on you."))
 		to_chat(owner, span_warning("The moon does not smile upon them."))
 		return FALSE

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -8,8 +8,9 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "smoke"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 1 MINUTES
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	invocation = "GL'RY T' TH' N'GHT'W'TCH'ER"
 	invocation_type = INVOCATION_WHISPER

--- a/code/modules/antagonists/heretic/magic/realignment.dm
+++ b/code/modules/antagonists/heretic/magic/realignment.dm
@@ -9,7 +9,7 @@
 	button_icon_state = "adrenal"
 	// sound = 'sound/magic/whistlereset.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 6 SECONDS
 	cooldown_reduction_per_rank = -6 SECONDS // we're not a wizard spell but we use the levelling mechanic
 	spell_max_level = 10 // we can get up to / over a minute duration cd time

--- a/code/modules/antagonists/heretic/magic/rust_construction.dm
+++ b/code/modules/antagonists/heretic/magic/rust_construction.dm
@@ -7,13 +7,14 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 5 SECONDS
 
 	invocation = "Someone raises a wall of rust."
 	invocation_self_message = "You raise a wall of rust."
 	invocation_type = INVOCATION_EMOTE
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 4
 	aim_assist = FALSE

--- a/code/modules/antagonists/heretic/magic/rust_wave.dm
+++ b/code/modules/antagonists/heretic/magic/rust_wave.dm
@@ -10,12 +10,13 @@
 	button_icon_state = "entropic_plume"
 	sound = 'sound/magic/forcewall.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "'NTR'P'C PL'M'"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cone_levels = 5
 	respect_density = TRUE
@@ -72,12 +73,13 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "rust_wave"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 35 SECONDS
 
 	invocation = "SPR'D TH' WO'D"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	projectile_type = /obj/projectile/magic/aoe/rust_wave
 

--- a/code/modules/antagonists/heretic/magic/shadow_cloak.dm
+++ b/code/modules/antagonists/heretic/magic/shadow_cloak.dm
@@ -9,11 +9,12 @@
 	button_icon_state = "ninja_cloak"
 	sound = 'sound/effects/curse2.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 6 SECONDS
 
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	/// How long before we automatically uncloak?
 	var/uncloak_time = 3 MINUTES

--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -12,7 +12,7 @@
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'
 	button_icon_state = "space_crawl"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -7,12 +7,13 @@
 	button_icon_state = "star_blast"
 
 	sound = 'sound/magic/cosmic_energy.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 20 SECONDS
 
 	invocation = "R'T'T' ST'R!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	active_msg = "You prepare to cast your star blast!"
 	deactive_msg = "You stop swirling cosmic energies from the palm of your hand... for now."

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -10,12 +10,12 @@
 	button_icon_state = "star_touch"
 
 	sound = 'sound/items/welder.ogg'
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 15 SECONDS
 	invocation = "ST'R 'N'RG'!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
-	antimagic_flags = MAGIC_RESISTANCE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	hand_path = /obj/item/melee/touch_attack/star_touch
 	/// Stores the weakref for the Star Gazer after ascending

--- a/code/modules/antagonists/heretic/magic/void_cold_cone.dm
+++ b/code/modules/antagonists/heretic/magic/void_cold_cone.dm
@@ -8,12 +8,13 @@
 	overlay_icon_state = "bg_heretic_border"
 	button_icon_state = "icebeam"
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "FR'ZE!"
 	invocation_type = INVOCATION_SHOUT
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	// In room temperature, the ice won't last very long
 	// ...but in space / freezing rooms, it will stick around

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -9,12 +9,13 @@
 	button_icon_state = "voidblink"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 30 SECONDS
 
 	invocation = "RE'L'TY PH'S'E."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	cast_range = 9
 	/// The minimum range to cast the phase.
@@ -54,7 +55,7 @@
 	for(var/mob/living/living_mob in range(damage_radius, target_turf))
 		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
 			continue
-		if(living_mob.can_block_magic(antimagic_flags))
+		if(living_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			continue
 		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
 

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -8,12 +8,13 @@
 	button_icon_state = "voidpull"
 	sound = 'sound/magic/voidblink.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 40 SECONDS
 
 	invocation = "BR'NG F'RTH TH'M T' M'."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	aoe_radius = 7
 	/// The radius of the actual damage circle done before cast
@@ -43,7 +44,7 @@
 			continue
 		if(IS_HERETIC_OR_MONSTER(nearby_mob))
 			continue
-		if(nearby_mob.can_block_magic(antimagic_flags))
+		if(nearby_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			continue
 
 		things += nearby_mob

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -8,12 +8,13 @@
 	button_icon_state = "uncuff"
 	sound = 'sound/magic/swap.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_ELDRITCH
 	cooldown_time = 5 MINUTES
 
 	invocation = "F'K 'FF."
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY
 
 	aoe_radius = 3
 
@@ -53,7 +54,7 @@
 			continue
 		if(IS_HERETIC_OR_MONSTER(nearby_mob))
 			continue
-		if(nearby_mob.can_block_magic(antimagic_flags))
+		if(nearby_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			continue
 
 		. += nearby_mob

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -23,6 +23,7 @@
 		/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE_MIND, \
 		inventory_flags = ITEM_SLOT_HEAD, \
+		anti_magic_tier = ANTIMAGIC_TIER_STRONG, \
 		charges = 6, \
 		drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \
 		expiration = CALLBACK(src, PROC_REF(warp_up)) \

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -21,9 +21,14 @@
 		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
 		inventory_flags = ITEM_SLOT_HANDS, \
 		charges = shield_uses, \
+		on_block = CALLBACK(src, PROC_REF(block_magic)), \
 		drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \
 		expiration = CALLBACK(src, PROC_REF(expire)), \
 	)
+
+// Holy magic we're especially good at blocking, everything else is lackluster.
+/datum/plant_gene/trait/anti_magic/proc/block_magic(mob/user, obj/item/our_plant, casted_magic_flags, charge_cost)
+	return (casted_magic_flags & MAGIC_RESISTANCE_HOLY) ? ANTIMAGIC_TIER_IMMUNE : ANTIMAGIC_TIER_WEAK
 
 /// When the plant our gene is hosted in is drained of an anti-magic charge.
 /datum/plant_gene/trait/anti_magic/proc/drain_antimagic(mob/user, obj/item/our_plant)

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -26,7 +26,10 @@
 
 /obj/item/nullrod/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_IMMUNE, \
+	)
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BEGONE FOUL MAGIKS!!", \

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -79,7 +79,10 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 /obj/item/vorpalscythe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_IMMUNE, \
+	)
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "TO DUST WITH YE!! AWAY!!", \

--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -82,7 +82,10 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 
 /obj/item/book/bible/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_WEAK, \
+	)
 	bullet_catcher = AddComponent(\
 		/datum/component/bullet_intercepting,\
 		active_slots = ITEM_SLOT_SUITSTORE,\
@@ -366,7 +369,11 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 
 /obj/item/book/bible/syndicate/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_STRONG, \
+		on_block = CALLBACK(src, PROC_REF(check_holiness)), \
+	)
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BEGONE FOUL MAGIKS!!", \
@@ -374,6 +381,11 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 		effects_we_clear = list(/obj/effect/rune, /obj/effect/heretic_rune, /obj/effect/cosmic_rune), \
 	)
 	AddElement(/datum/element/bane, target_type = /mob/living/basic/revenant, damage_multiplier = 0, added_damage = 25, requires_combat_mode = FALSE)
+
+/obj/item/book/bible/syndicate/proc/check_holiness(mob/user, ...)
+	if(!user.mind?.holy_role)
+		return NONE
+	return null // default
 
 /obj/item/book/bible/syndicate/attack_self(mob/living/carbon/human/user, modifiers)
 	if(!uses || !istype(user))

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -379,7 +379,10 @@
 
 /obj/item/immortality_talisman/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, ALL)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = ALL, \
+		anti_magic_tier = ANTIMAGIC_TIER_STRONG, \
+	)
 
 /datum/action/item_action/immortality
 	name = "Immortality"
@@ -689,7 +692,11 @@
 
 /obj/item/clothing/suit/hooded/berserker/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, ALL, inventory_flags = ITEM_SLOT_OCLOTHING)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = ALL, \
+		inventory_flags = ITEM_SLOT_OCLOTHING, \
+		anti_magic_tier = ANTIMAGIC_TIER_STRONG, \
+	)
 
 #define MAX_BERSERK_CHARGE 100
 #define PROJECTILE_HIT_MULTIPLIER 1.5

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_abilities.dm
@@ -131,7 +131,7 @@
 		if(human_mob == caster)
 			continue
 		to_shock.Beam(human_mob, icon_state = "purple_lightning", time = 0.5 SECONDS)
-		if(!human_mob.can_block_magic(antimagic_flags))
+		if(!(human_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_WEAK))
 			human_mob.electrocute_act(shock_damage, to_shock, flags = SHOCK_NOGLOVES)
 
 		do_sparks(4, FALSE, human_mob)
@@ -209,7 +209,7 @@
 	for(var/mob/living/carbon/human/human in victim)
 		if(human == caster)
 			continue
-		if(human.can_block_magic(antimagic_flags))
+		if(human.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_WEAK)
 			continue
 		to_chat(human, span_revenwarning("You feel [pick("your sense of direction flicker out", "a stabbing pain in your head", "your mind fill with static")]."))
 		new /obj/effect/temp_visual/revenant(human.loc)
@@ -244,7 +244,7 @@
 	for(var/mob/living/mob in victim)
 		if(mob == caster)
 			continue
-		if(mob.can_block_magic(antimagic_flags))
+		if(mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_WEAK)
 			to_chat(caster, span_warning("The spell had no effect on [mob]!"))
 			continue
 		new /obj/effect/temp_visual/revenant(mob.loc)

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_harvest.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_harvest.dm
@@ -102,7 +102,7 @@
 
 	target.visible_message(span_warning("[target] suddenly rises slightly into the air, [target_their] skin turning an ashy gray."))
 
-	if(target.can_block_magic(MAGIC_RESISTANCE_HOLY))
+	if(target.can_block_magic(MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_WEAK)
 		to_chat(src, span_revenminor("Something's wrong! [target] seems to be resisting the siphoning, leaving you vulnerable!"))
 		target.visible_message(
 			span_warning("[target] slumps onto the ground."),

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -138,7 +138,7 @@ Doesn't work on other aliens/AI.*/
 	var/to_whisper = tgui_input_text(owner, title = "Alien Whisper")
 	if(QDELETED(chosen_recipient) || QDELETED(src) || QDELETED(owner) || !IsAvailable(feedback = TRUE) || !to_whisper)
 		return FALSE
-	if(chosen_recipient.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+	if(chosen_recipient.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 		to_chat(owner, span_warning("As you reach into [chosen_recipient]'s mind, you are stopped by a mental blockage. It seems you've been foiled."))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -766,7 +766,7 @@
 	var/msg = tgui_input_text(telepath, title = "Telepathy")
 	if(isnull(msg))
 		return
-	if(recipient.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+	if(recipient.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)
 		to_chat(telepath, span_warning("As you reach into [recipient]'s mind, you are stopped by a mental blockage. It seems you've been foiled."))
 		return
 	log_directed_talk(telepath, recipient, msg, LOG_SAY, "slime telepathy")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -178,7 +178,7 @@
 				to_chat(H, span_warning("[victim] doesn't have valid blood!")) // NON-MODULE CHANGE
 				return
 			COOLDOWN_START(V, drain_cooldown, 3 SECONDS)
-			if(victim.can_block_magic(MAGIC_RESISTANCE_HOLY, charge_cost = 0))
+			if(victim.can_block_magic(MAGIC_RESISTANCE_HOLY, charge_cost = 0) & ANTIMAGIC_TIER_WEAK)
 				victim.show_message(span_warning("[H] tries to bite you, but stops before touching you!"))
 				to_chat(H, span_warning("[victim] is blessed! You stop just in time to avoid catching fire."))
 				return

--- a/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
@@ -22,7 +22,10 @@
 
 /obj/item/gun/ballistic/bow/divine/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_IMMUNE, \
+	)
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BOW-GONE FOUL MAGIKS!!", \

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	var/mob/M = target
 	if(istype(M))
-		if(M.can_block_magic())
+		if(M.can_block_magic() & ANTIMAGIC_TIER_STRONG)
 			return BULLET_ACT_BLOCK
 		else
 			M.slip(100, M.loc, GALOSHES_DONT_HELP|SLIDE, 0, FALSE)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -9,13 +9,15 @@
 	var/antimagic_flags = MAGIC_RESISTANCE
 	/// determines the drain cost on the antimagic item
 	var/antimagic_charge_cost = 1
+	/// determines the strength of the antimagic needed to block the spell projectile
+	var/antimagic_strength = ANTIMAGIC_TIER_IMMUNE
 
 /obj/projectile/magic/prehit_pierce(atom/target)
 	. = ..()
 
 	if(isliving(target))
 		var/mob/living/victim = target
-		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
+		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost) & antimagic_strength)
 			visible_message(span_warning("[src] fizzles on contact with [victim]!"))
 			return PROJECTILE_DELETE_WITHOUT_HITTING
 
@@ -56,6 +58,7 @@
 /obj/projectile/magic/resurrection
 	name = "bolt of resurrection"
 	icon_state = "ion"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/resurrection/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -82,6 +85,7 @@
 /obj/projectile/magic/teleport
 	name = "bolt of teleportation"
 	icon_state = "bluespace"
+	antimagic_strength = ANTIMAGIC_TIER_STRONG
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
@@ -103,6 +107,7 @@
 /obj/projectile/magic/safety
 	name = "bolt of safety"
 	icon_state = "bluespace"
+	antimagic_strength = ANTIMAGIC_TIER_STRONG
 
 /obj/projectile/magic/safety/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -121,6 +126,7 @@
 /obj/projectile/magic/door
 	name = "bolt of door creation"
 	icon_state = "energy"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 	var/list/door_types = list(/obj/structure/mineral_door/wood, /obj/structure/mineral_door/iron, /obj/structure/mineral_door/silver, /obj/structure/mineral_door/gold, /obj/structure/mineral_door/uranium, /obj/structure/mineral_door/sandstone, /obj/structure/mineral_door/transparent/plasma, /obj/structure/mineral_door/transparent/diamond)
 
 /obj/projectile/magic/door/on_hit(atom/target, blocked = 0, pierce_hit)
@@ -148,6 +154,7 @@
 	name = "bolt of change"
 	icon_state = "ice_1"
 	damage_type = BURN
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 	/// If set, this projectile will only do a certain wabbajack effect
 	var/set_wabbajack_effect
 	/// If set, this projectile will only pass certain changeflags to wabbajack
@@ -170,6 +177,7 @@
 	name = "bolt of animation"
 	icon_state = "red_1"
 	damage_type = BURN
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/animate/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -197,6 +205,7 @@
 /obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
@@ -283,6 +292,7 @@
 /obj/projectile/magic/flying
 	name = "bolt of flying"
 	icon_state = "flight"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/flying/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -293,6 +303,7 @@
 /obj/projectile/magic/bounty
 	name = "bolt of bounty"
 	icon_state = "bounty"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/bounty/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -302,6 +313,7 @@
 /obj/projectile/magic/antimagic
 	name = "bolt of antimagic"
 	icon_state = "antimagic"
+	antimagic_flags = NONE
 
 /obj/projectile/magic/antimagic/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -311,6 +323,7 @@
 /obj/projectile/magic/fetch
 	name = "bolt of fetching"
 	icon_state = "fetch"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/fetch/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -321,6 +334,7 @@
 /obj/projectile/magic/babel
 	name = "bolt of babel"
 	icon_state = "babel"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/babel/on_hit(mob/living/carbon/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -331,6 +345,7 @@
 /obj/projectile/magic/necropotence
 	name = "bolt of necropotence"
 	icon_state = "necropotence"
+	antimagic_strength = ANTIMAGIC_TIER_STRONG
 
 /obj/projectile/magic/necropotence/on_hit(mob/living/target, blocked = 0, pierce_hit)
 	. = ..()
@@ -479,7 +494,7 @@
 	zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_LOW_POWER_GEN
 
 /obj/projectile/magic/fireball
-	name = "bolt of fireball"
+	name = "fireball"
 	icon_state = "fireball"
 	damage = 10
 	damage_type = BRUTE
@@ -573,6 +588,7 @@
 
 /obj/projectile/magic/nothing
 	name = "bolt of nothing"
+	antimagic_strength = ANTIMAGIC_TIER_WEAK
 
 /obj/projectile/magic/spellcard
 	name = "enchanted card"
@@ -581,3 +597,4 @@
 	damage_type = BURN
 	damage = 2
 	antimagic_charge_cost = 0 // since the cards gets spammed like a shotgun
+	antimagic_strength = ANTIMAGIC_TIER_WEAK

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -10,15 +10,18 @@
 	organ_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_LITERATE, TRAIT_CAN_STRIP, TRAIT_ANTIMAGIC_NO_SELFBLOCK)
 	w_class = WEIGHT_CLASS_NORMAL
 
+	var/datum/component/echo_comp
+	var/datum/component/anti_magic_comp
+
 /obj/item/organ/internal/brain/psyker/on_mob_insert(mob/living/carbon/inserted_into)
 	. = ..()
-	inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker)
-	inserted_into.AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE_MIND)
+	echo_comp = inserted_into.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DUMB, echo_group = "psyker", echo_icon = "psyker", color_path = /datum/client_colour/psyker)
+	anti_magic_comp = inserted_into.AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE_MIND, anti_magic_tier = ANTIMAGIC_TIER_IMMUNE)
 
 /obj/item/organ/internal/brain/psyker/on_mob_remove(mob/living/carbon/removed_from)
 	. = ..()
-	qdel(removed_from.GetComponent(/datum/component/echolocation))
-	qdel(removed_from.GetComponent(/datum/component/anti_magic))
+	qdel(echo_comp)
+	qdel(anti_magic_comp)
 
 /obj/item/organ/internal/brain/psyker/on_life(seconds_per_tick, times_fired)
 	. = ..()
@@ -175,7 +178,10 @@
 
 /obj/item/gun/ballistic/revolver/chaplain/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_IMMUNE, \
+	)
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BEGONE FOUL MAGIKS!!", \
@@ -289,7 +295,7 @@
 
 /datum/action/cooldown/spell/pointed/psychic_projection/cast(mob/living/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_notice("Your mind feels weird, but it passes momentarily."))
 		to_chat(owner, span_warning("The spell had no effect!"))
 		return FALSE

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -166,7 +166,7 @@
 	switch(school)
 		if(SCHOOL_UNSET, SCHOOL_HOLY, SCHOOL_MIME, SCHOOL_RESTORATION, SCHOOL_PSYCHIC)
 			return
-		if(SCHOOL_NECROMANCY, SCHOOL_FORBIDDEN, SCHOOL_SANGUINE)
+		if(SCHOOL_NECROMANCY, SCHOOL_FORBIDDEN, SCHOOL_SANGUINE, SCHOOL_ELDRITCH)
 			to_chat(user, span_userdanger("[GLOB.deity] is enraged by your use of forbidden magic!"))
 			lightningbolt(user)
 			user.mind.holy_role = NONE

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -98,6 +98,7 @@
 	. = ..()
 	AddComponent(/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_IMMUNE, \
 		charges = 1, \
 		expiration = CALLBACK(src, PROC_REF(expire)), \
 	)

--- a/code/modules/spells/spell_types/aoe_spell/repulse.dm
+++ b/code/modules/spells/spell_types/aoe_spell/repulse.dm
@@ -38,7 +38,7 @@
 /datum/action/cooldown/spell/aoe/repulse/cast_on_thing_in_aoe(atom/movable/victim, atom/caster)
 	if(ismob(victim))
 		var/mob/victim_mob = victim
-		if(victim_mob.can_block_magic(antimagic_flags))
+		if(victim_mob.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 			return
 
 	var/turf/throwtarget = get_edge_target_turf(caster, get_dir(caster, get_step_away(victim, caster)))

--- a/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
+++ b/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
@@ -24,7 +24,7 @@
 	return things
 
 /datum/action/cooldown/spell/aoe/sacred_flame/cast_on_thing_in_aoe(mob/living/victim, mob/living/caster)
-	if(victim.can_block_magic(antimagic_flags))
+	if(victim.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_WEAK)
 		return
 
 	victim.adjust_fire_stacks(firestacks_to_give)

--- a/code/modules/spells/spell_types/charged/tesla_blast.dm
+++ b/code/modules/spells/spell_types/charged/tesla_blast.dm
@@ -29,7 +29,7 @@
 	origin.Beam(to_beam, icon_state = "lightning[rand(1,12)]", time = 0.5 SECONDS)
 	playsound(get_turf(to_beam), 'sound/magic/lightningshock.ogg', 50, TRUE, -1)
 
-	if(to_beam.can_block_magic(antimagic_flags))
+	if(to_beam.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_STRONG)
 		to_beam.visible_message(
 			span_warning("[to_beam] absorbs the spell, remaining unharmed!"),
 			span_userdanger("You absorb the spell, remaining unharmed!"),

--- a/code/modules/spells/spell_types/list_target/telepathy.dm
+++ b/code/modules/spells/spell_types/list_target/telepathy.dm
@@ -43,7 +43,7 @@
 	var/failure_message_for_ghosts = ""
 
 	to_chat(owner, "<span class='[bold_telepathy_span]'>You transmit to [cast_on]:</span> [formatted_message]")
-	if(!cast_on.can_block_magic(antimagic_flags, charge_cost = 0)) //hear no evil
+	if(!(cast_on.can_block_magic(antimagic_flags, charge_cost = 0) & ANTIMAGIC_TIER_STRONG)) //hear no evil
 		cast_on.balloon_alert(cast_on, "you hear a voice")
 		to_chat(cast_on, "<span class='[bold_telepathy_span]'>You hear a voice in your head...</span> [formatted_message]")
 	else

--- a/code/modules/spells/spell_types/pointed/abyssal_gaze.dm
+++ b/code/modules/spells/spell_types/pointed/abyssal_gaze.dm
@@ -28,7 +28,7 @@
 
 /datum/action/cooldown/spell/pointed/abyssal_gaze/cast(mob/living/carbon/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(owner, span_warning("The spell had no effect!"))
 		to_chat(cast_on, span_warning("You feel a freezing darkness closing in on you, but it rapidly dissipates."))
 		return FALSE

--- a/code/modules/spells/spell_types/pointed/barnyard.dm
+++ b/code/modules/spells/spell_types/pointed/barnyard.dm
@@ -30,7 +30,7 @@
 
 /datum/action/cooldown/spell/pointed/barnyardcurse/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		cast_on.visible_message(
 			span_danger("[cast_on]'s face bursts into flames, which instantly burst outward, leaving [cast_on.p_them()] unharmed!"),
 			span_danger("Your face starts burning up, but the flames are repulsed by your anti-magic protection!"),

--- a/code/modules/spells/spell_types/pointed/blind.dm
+++ b/code/modules/spells/spell_types/pointed/blind.dm
@@ -32,12 +32,19 @@
 
 /datum/action/cooldown/spell/pointed/blind/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	var/magic_tier = cast_on.can_block_magic(antimagic_flags)
+	if(magic_tier & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_notice("Your eye itches, but it passes momentarily."))
 		to_chat(owner, span_warning("The spell had no effect!"))
 		return FALSE
 
+	var/duration_mod = 1
+	if(magic_tier & ANTIMAGIC_TIER_STRONG)
+		duration_mod = 0.33
+	else if(magic_tier & ANTIMAGIC_TIER_WEAK)
+		duration_mod = 0.66
+
 	to_chat(cast_on, span_warning("Your eyes cry out in pain!"))
-	cast_on.adjust_temp_blindness(eye_blind_duration)
-	cast_on.set_eye_blur_if_lower(eye_blur_duration)
+	cast_on.adjust_temp_blindness(eye_blind_duration * duration_mod)
+	cast_on.set_eye_blur_if_lower(eye_blur_duration * duration_mod)
 	return TRUE

--- a/code/modules/spells/spell_types/pointed/dominate.dm
+++ b/code/modules/spells/spell_types/pointed/dominate.dm
@@ -39,7 +39,7 @@
 
 /datum/action/cooldown/spell/pointed/dominate/cast(mob/living/simple_animal/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(cast_on, span_warning("Your feel someone attempting to subject your mind to terrible machinations!"))
 		to_chat(owner, span_warning("[cast_on] resists your domination!"))
 		return FALSE

--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -105,7 +105,7 @@
 		to_swap.mind_initialize()
 
 	var/datum/mind/mind_to_swap = to_swap.mind
-	if(to_swap.can_block_magic(antimagic_flags) \
+	if((to_swap.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE) \
 		|| mind_to_swap.has_antag_datum(/datum/antagonist/wizard) \
 		|| mind_to_swap.has_antag_datum(/datum/antagonist/cult) \
 		|| mind_to_swap.has_antag_datum(/datum/antagonist/changeling) \

--- a/code/modules/spells/spell_types/pointed/swap.dm
+++ b/code/modules/spells/spell_types/pointed/swap.dm
@@ -61,7 +61,7 @@
 
 /datum/action/cooldown/spell/pointed/swap/cast(mob/living/carbon/cast_on)
 	. = ..()
-	if(cast_on.can_block_magic(antimagic_flags))
+	if(cast_on.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE)
 		to_chat(owner, span_warning("The spell had no effect!"))
 		to_chat(cast_on, span_warning("You feel space bending, but it rapidly dissipates."))
 		return FALSE

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -219,7 +219,7 @@
 	SEND_SIGNAL(src, COMSIG_SPELL_TOUCH_HAND_HIT, victim, caster, hand)
 
 	var/mob/mob_victim = victim
-	if(istype(mob_victim) && mob_victim.can_block_magic(antimagic_flags))
+	if(istype(mob_victim) && (mob_victim.can_block_magic(antimagic_flags) & ANTIMAGIC_TIER_IMMUNE))
 		on_antimagic_triggered(hand, victim, caster)
 
 	else if(!cast_on_hand_hit(hand, victim, caster))

--- a/code/modules/spells/spell_types/touch/flesh_to_stone.dm
+++ b/code/modules/spells/spell_types/touch/flesh_to_stone.dm
@@ -18,11 +18,16 @@
 
 /datum/action/cooldown/spell/touch/flesh_to_stone/cast_on_hand_hit(obj/item/melee/touch_attack/hand, mob/living/victim, mob/living/carbon/caster)
 	var/mob/living/living_victim = victim
-	if(living_victim.can_block_magic(antimagic_flags))
+	var/magic_tier = living_victim.can_block_magic(antimagic_flags)
+	if(magic_tier & ANTIMAGIC_TIER_IMMUNE)
 		return TRUE
-
 	living_victim.Stun(4 SECONDS)
-	living_victim.petrify()
+	if(magic_tier & ANTIMAGIC_TIER_STRONG)
+		return TRUE
+	if(magic_tier & ANTIMAGIC_TIER_WEAK)
+		living_victim.petrify(1 MINUTES)
+		return TRUE
+	living_victim.petrify(8 MINUTES)
 	return TRUE
 
 /obj/item/melee/touch_attack/flesh_to_stone

--- a/maplestation_modules/code/game/objects/items/weaponry.dm
+++ b/maplestation_modules/code/game/objects/items/weaponry.dm
@@ -149,7 +149,10 @@
 	custom_materials = null
 
 /obj/item/knife/combat/nullknife/Initialize(mapload)
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		anti_magic_tier = ANTIMAGIC_TIER_WEAK, \
+	)
 	AddElement(/datum/element/bane, target_type = /mob/living/basic/revenant, damage_multiplier = 0, added_damage = 25, requires_combat_mode = FALSE)
 	return ..()
 

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/blood_cult/magic/blood_magic_disable.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/blood_cult/magic/blood_magic_disable.dm
@@ -55,7 +55,7 @@
 	user.mob_light(range = 3, color = LIGHT_COLOR_LIGHT_CYAN, duration = 0.3 SECONDS)
 
 	var/applied_effects = FALSE
-	if(living_target.can_block_magic())
+	if(living_target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 		applied_effects = TRUE
 	else
 		if(living_target.getStaminaLoss() >= 70)

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/blood_cult/magic/blood_magic_pain.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/blood_cult/magic/blood_magic_pain.dm
@@ -39,7 +39,7 @@
 
 	user.mob_light(range = 3, color = LIGHT_COLOR_BLOOD_MAGIC, duration = 0.3 SECONDS)
 
-	if(!human_target.can_block_magic())
+	if(!(human_target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE))
 		to_chat(user, span_cultitalic("You curse [human_target] with [src]!"))
 		target.visible_message(
 			span_warning("[human_target] writhes in pain!"),

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/judicial_visor.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/items/judicial_visor.dm
@@ -60,8 +60,8 @@
 
 	// This point on, our attack was successful
 	COOLDOWN_START(src, examine_damage_cooldown, 10 SECONDS)
-	playsound(get_turf(source), 'sound/weapons/marauder.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
-	playsound(get_turf(examined), 'sound/weapons/sear.ogg', 30, TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE)
+	playsound(source, 'sound/weapons/marauder.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
+	playsound(examined, 'sound/weapons/sear.ogg', 30, TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE)
 	new /obj/effect/temp_visual/clock/marker(get_turf(examined))
 
 	// Sets our icon to the "off" state.
@@ -69,7 +69,7 @@
 	source.update_worn_glasses()
 	addtimer(CALLBACK(src, PROC_REF(reset_icon), source), 10 SECONDS)
 
-	if(target.can_block_magic())
+	if(target.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 		return
 
 	// And THIS point on, is where attack effects are done to the target

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/magic/clock_magic_disable.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/magic/clock_magic_disable.dm
@@ -23,7 +23,7 @@
 
 	user.mob_light(range = 3, color = LIGHT_COLOR_TUNGSTEN, duration = 0.8 SECONDS)
 
-	if(victim.can_block_magic())
+	if(victim.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 		return TRUE
 
 	if(living_target.getStaminaLoss() >= 70)

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/runes/trap_rune.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/clock_cult/runes/trap_rune.dm
@@ -52,7 +52,7 @@
 		if(victim in people_we_dazed)
 			continue
 
-		if(victim.can_block_magic())
+		if(victim.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 			continue
 
 		daze_victim(victim)
@@ -89,7 +89,7 @@
 	if(victim in people_we_dazed)
 		return
 
-	if(victim.can_block_magic())
+	if(victim.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 		return
 
 	new /obj/effect/particle_effect/sparks(get_turf(victim))

--- a/maplestation_modules/code/modules/antagonists/advanced_cult/conversion_rune.dm
+++ b/maplestation_modules/code/modules/antagonists/advanced_cult/conversion_rune.dm
@@ -96,7 +96,7 @@
 			fail_invoke()
 			return FALSE
 
-		if(convertee.can_block_magic())
+		if(convertee.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY) & ANTIMAGIC_TIER_IMMUNE)
 			fail_invoke()
 			return FALSE
 


### PR DESCRIPTION
Antimagic is now tiered, split between "Weak", "Strong", and "Immune"

Items now provide differing strength of antimagic. Some items are better at warding magic than others.

Holymelons, for example, provide "Immune" to Holy Magic, but only "Weak" to generic magic.
This means they will either not be sufficiently strong enough to block certain spells (providing nothing at all), or will only partially block the effect (resulting in a lessened total effect).

Bibles only provide "Weak" holy resistance, which is strong enough to block Revenants, but not strong enough to block Cult magic. Which means it maintains status quo.

The Chaplain's Nullrod retains full immunity to "holy" and "generic" magic. 

#### Disclaimer: 

I didn't think too hard about the values I assigned, it was almost completely vibes based. Some stuff might be stupid.
*It'd be appreciated if someone else took a closer look at what blocks what (and also, if someone added partial effects to more spells).*

#### Other:
- I made heretic spells its own spell school rather than copying forbidden. And then I made them blocked by high tier holy resistance as well as generic resistance.
- Cult spells are blocked by high tier holy resistance as well.
- Holy and mind "magic block" effect will occur more commonly now. I changed the logic on how it determines which is played.