### PR TITLE
Speech sounds for carbon mobs work on tongue rather than species.

### DIFF
--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/abductor.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/abductor.dm
@@ -1,6 +1,3 @@
-/datum/species/abductor/get_species_speech_sounds(sound_type)
-	return
-
 /datum/species/abductor/get_species_description()
 	return "Abductors, colloquially known as \"Greys\" (or \"Grays\"), \
 		are pale skinned inquisitive aliens who can't communicate well to the average crew-member."
@@ -55,3 +52,6 @@
 			They intead naturally communicate telepathically to other Abductors, a process which all other species cannot hear.",
 	))
 	return perks
+
+/obj/item/organ/internal/tongue/abductor
+	speech_sounds_enabled = FALSE

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -4,5 +4,6 @@
 	exotic_bloodtype = /datum/blood_type/oil
 
 /obj/item/organ/internal/tongue/robot
-	speech_sound_only_normal = TRUE
 	speech_sound_list = list('goon/sound/voice/radio_ai.ogg' = 100)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -3,5 +3,6 @@
 	species_pain_mod = 0.2
 	exotic_bloodtype = /datum/blood_type/oil
 
-/datum/species/android/get_species_speech_sounds(sound_type)
-	return string_assoc_list(list('goon/sound/voice/radio_ai.ogg' = 100))
+/obj/item/organ/internal/tongue/robot
+	speech_sound_only_normal = TRUE
+	speech_sound_list = list('goon/sound/voice/radio_ai.ogg' = 100)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -1,11 +1,6 @@
 // -- Ethereal species additions --
-/datum/species/ethereal
 
-/datum/species/ethereal/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/etheral_ask.ogg' = 80))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/etheral_exclaim.ogg' = 80))
-		else
-			return string_assoc_list(list('maplestation_modules/sound/voice/etheral.ogg' = 60))
+/obj/item/organ/internal/tongue/ethereal
+	speech_sound_list = list('maplestation_modules/sound/voice/etheral.ogg' = 60)
+	speech_sound_list_question = list('maplestation_modules/sound/voice/etheral_ask.ogg' = 80)
+	speech_sound_list_exclamation = list('maplestation_modules/sound/voice/etheral_exclaim.ogg' = 80)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -1,9 +1,10 @@
 // -- Felinid species additions --
 
 /obj/item/organ/internal/tongue/cat
-	speech_sound_only_normal = TRUE
 	speech_sound_list = list(
 		'maplestation_modules/sound/voice/meow1.ogg' = 50,
 		'maplestation_modules/sound/voice/meow2.ogg' = 50,
 		'maplestation_modules/sound/voice/meow3.ogg' = 50,
 	)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -1,9 +1,9 @@
 // -- Felinid species additions --
-/datum/species/human/felinid
 
-/datum/species/human/felinid/get_species_speech_sounds(sound_type)
-	return string_assoc_list(list(
+/obj/item/organ/internal/tongue/cat
+	speech_sound_only_normal = TRUE
+	speech_sound_list = list(
 		'maplestation_modules/sound/voice/meow1.ogg' = 50,
 		'maplestation_modules/sound/voice/meow2.ogg' = 50,
 		'maplestation_modules/sound/voice/meow3.ogg' = 50,
-	))
+	)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -2,14 +2,10 @@
 /datum/species/fly
 	species_pain_mod = 1.2
 
-/datum/species/fly/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/fly_ask.ogg' = 80))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/fly_exclaim.ogg' = 80))
-		else
-			return string_assoc_list(list(
+/obj/item/organ/internal/tongue/fly
+	speech_sound_list = list(
 				'maplestation_modules/sound/voice/fly.ogg' = 80,
 				'maplestation_modules/sound/voice/fly2.ogg' = 80,
-			))
+			)
+	speech_sound_list_question = list('maplestation_modules/sound/voice/fly_ask.ogg' = 80)
+	speech_sound_list_exclamation = list('maplestation_modules/sound/voice/fly_exclaim.ogg' = 80)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -19,10 +19,11 @@
 	human.update_body(is_creating = TRUE)
 
 /obj/item/organ/internal/tongue/lizard
-	speech_sound_only_normal = TRUE
 	// These sounds have been ported from Goonstation.
 	speech_sound_list = list(
 		'maplestation_modules/sound/voice/lizard_1.ogg' = 80,
 		'maplestation_modules/sound/voice/lizard_2.ogg' = 80,
 		'maplestation_modules/sound/voice/lizard_3.ogg' = 80,
 	)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,14 +1,6 @@
 // -- Lizardperson species additions --
 /datum/species/lizard
 
-/datum/species/lizard/get_species_speech_sounds(sound_type)
-	// These sounds have been ported from Goonstation.
-	return string_assoc_list(list(
-		'maplestation_modules/sound/voice/lizard_1.ogg' = 80,
-		'maplestation_modules/sound/voice/lizard_2.ogg' = 80,
-		'maplestation_modules/sound/voice/lizard_3.ogg' = 80,
-	))
-
 /datum/species/lizard/replace_body(mob/living/carbon/target, datum/species/new_species)
 	. = ..()
 	if(target.dna?.features["lizard_has_hair"])
@@ -26,11 +18,11 @@
 
 	human.update_body(is_creating = TRUE)
 
-// Same for the small ones
-/datum/species/monkey/lizard/get_species_speech_sounds(sound_type)
+/obj/item/organ/internal/tongue/lizard
+	speech_sound_only_normal = TRUE
 	// These sounds have been ported from Goonstation.
-	return string_assoc_list(list(
+	speech_sound_list = list(
 		'maplestation_modules/sound/voice/lizard_1.ogg' = 80,
 		'maplestation_modules/sound/voice/lizard_2.ogg' = 80,
 		'maplestation_modules/sound/voice/lizard_3.ogg' = 80,
-	))
+	)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/monkey.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/monkey.dm
@@ -1,5 +1,5 @@
 // -- Monke species additions --
-/datum/species/monkey
 
-/datum/species/monkey/get_species_speech_sounds(sound_type)
-	return string_assoc_list(list('maplestation_modules/sound/voice/monkey_1.ogg' = 90))
+/obj/item/organ/internal/tongue/monkey
+	speech_sound_only_normal = TRUE
+	speech_sound_list = list('maplestation_modules/sound/voice/monkey_1.ogg' = 90)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/monkey.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/monkey.dm
@@ -1,5 +1,6 @@
 // -- Monke species additions --
 
 /obj/item/organ/internal/tongue/monkey
-	speech_sound_only_normal = TRUE
 	speech_sound_list = list('maplestation_modules/sound/voice/monkey_1.ogg' = 90)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -2,9 +2,10 @@
 /datum/species/moth
 	species_pain_mod = 1.1
 
-/datum/species/moth/get_species_speech_sounds(sound_type)
-	return string_assoc_list(list(
+/obj/item/organ/internal/tongue/moth
+	speech_sound_only_normal = TRUE
+	speech_sound_list = list(
 		'maplestation_modules/sound/voice/moff_1.ogg' = 80,
 		'maplestation_modules/sound/voice/moff_2.ogg' = 80,
 		'maplestation_modules/sound/voice/moff_3.ogg' = 80,
-	))
+	)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -3,9 +3,10 @@
 	species_pain_mod = 1.1
 
 /obj/item/organ/internal/tongue/moth
-	speech_sound_only_normal = TRUE
 	speech_sound_list = list(
 		'maplestation_modules/sound/voice/moff_1.ogg' = 80,
 		'maplestation_modules/sound/voice/moff_2.ogg' = 80,
 		'maplestation_modules/sound/voice/moff_3.ogg' = 80,
 	)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -1,12 +1,3 @@
 // -- Plasmaman species additions --
 /datum/species/plasmaman
 	species_pain_mod = 0.75
-
-/datum/species/plasmaman/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list('goon/sound/voice/skelly_ask.ogg' = 90))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('goon/sound/voice/skelly_exclaim.ogg' = 90))
-		else
-			return string_assoc_list(list('goon/sound/voice/skelly.ogg' = 90))

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -2,9 +2,6 @@
 /datum/species/pod
 	species_pain_mod = 1.05
 
-/datum/species/pod/get_species_speech_sounds(sound_type)
-	return string_assoc_list(list('maplestation_modules/sound/voice/pod.ogg' = 70, 'maplestation_modules/sound/voice/pod2.ogg' = 60))
-
 /datum/species/pod/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.dna.features["mcolor"] = "#886600" // player reference :smug:
 	human.dna.features["pod_hair"] = "Rose"
@@ -75,3 +72,10 @@
 			podpeople are more vulnerable to fire.",
 	))
 	return perks
+
+/obj/item/organ/internal/tongue/pod
+	speech_sound_only_normal = TRUE
+	speech_sound_list = list(
+		'maplestation_modules/sound/voice/pod.ogg' = 70,
+		'maplestation_modules/sound/voice/pod2.ogg' = 60,
+		)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -74,8 +74,9 @@
 	return perks
 
 /obj/item/organ/internal/tongue/pod
-	speech_sound_only_normal = TRUE
 	speech_sound_list = list(
 		'maplestation_modules/sound/voice/pod.ogg' = 70,
 		'maplestation_modules/sound/voice/pod2.ogg' = 60,
 		)
+	speech_sound_list_question = null
+	speech_sound_list_exclamation = null

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -1,10 +1,4 @@
 // -- Shadowperson (& Nightmare) species additions --
 /datum/species/shadow
 	name = "Shadowperson"
-
-/datum/species/shadow/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/shad_exclaim.ogg' = 55))
-		else
-			return string_assoc_list(list('maplestation_modules/sound/voice/shad1.ogg' = 55, 'maplestation_modules/sound/voice/shad2.ogg' = 55))
+	mutanttongue = /obj/item/organ/internal/tongue/shadow

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -3,11 +3,7 @@
 	name = "Skeleton"
 	species_pain_mod = 0.4
 
-/datum/species/skeleton/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list('goon/sound/voice/skelly_ask.ogg' = 90))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('goon/sound/voice/skelly_exclaim.ogg' = 90))
-		else
-			return string_assoc_list(list('goon/sound/voice/skelly.ogg' = 90))
+/obj/item/organ/internal/tongue/bone
+	speech_sound_list = list('goon/sound/voice/skelly.ogg' = 90)
+	speech_sound_list_question = list('goon/sound/voice/skelly_ask.ogg' = 90)
+	speech_sound_list_exclamation = list('goon/sound/voice/skelly_exclaim.ogg' = 90)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/skrell.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/skrell.dm
@@ -28,15 +28,6 @@ GLOBAL_LIST_EMPTY(head_tentacles_list)
 	mutanteyes = /obj/item/organ/internal/eyes/skrell
 	mutanttongue = /obj/item/organ/internal/tongue/skrell
 
-/datum/species/skrell/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/huff_ask.ogg' = 120))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list('maplestation_modules/sound/voice/huff_exclaim.ogg' = 120))
-		else
-			return string_assoc_list(list('maplestation_modules/sound/voice/huff.ogg' = 120))
-
 /datum/species/skrell/spec_life(mob/living/carbon/human/skrell_mob, seconds_per_tick, times_fired)
 	. = ..()
 	if(skrell_mob.nutrition > NUTRITION_LEVEL_ALMOST_FULL)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/species.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/species.dm
@@ -3,30 +3,6 @@
 	/// Pain modifier that this species receives.
 	var/species_pain_mod = 1
 
-/datum/species/proc/get_species_speech_sounds(sound_type)
-	switch(sound_type)
-		if(SOUND_QUESTION)
-			return string_assoc_list(list(
-				'goon/sound/voice/speak_1_ask.ogg' = 120,
-				'goon/sound/voice/speak_2_ask.ogg' = 120,
-				'goon/sound/voice/speak_3_ask.ogg' = 120,
-				'goon/sound/voice/speak_4_ask.ogg' = 120,
-			))
-		if(SOUND_EXCLAMATION)
-			return string_assoc_list(list(
-				'goon/sound/voice/speak_1_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_2_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_3_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_4_exclaim.ogg' = 120,
-			))
-		else
-			return string_assoc_list(list(
-				'goon/sound/voice/speak_1.ogg' = 120,
-				'goon/sound/voice/speak_2.ogg' = 120,
-				'goon/sound/voice/speak_3.ogg' = 120,
-				'goon/sound/voice/speak_4.ogg' = 120,
-			))
-
 /datum/species/create_pref_damage_perks()
 	var/list/perks = ..()
 

--- a/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
+++ b/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
@@ -56,7 +56,21 @@
 		return ..()
 	if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
 		return null
-	return dna?.species?.get_species_speech_sounds(sound_type)
+	var/obj/item/organ/internal/tongue/tongue = src?.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(isnull(tongue))
+		return null
+	if(!tongue.speech_sounds_enabled)
+		return null
+	if(tongue.speech_sound_only_normal)
+		sound_type = SOUND_NORMAL
+	switch(sound_type)
+		if(SOUND_NORMAL)
+			return string_assoc_list(tongue.speech_sound_list)
+		if(SOUND_QUESTION)
+			return string_assoc_list(tongue.speech_sound_list_question)
+		if(SOUND_EXCLAMATION)
+			return string_assoc_list(tongue.speech_sound_list_exclamation)
+	return null
 
 /mob/living/basic/robot_customer/get_speech_sounds(sound_type)
 	var/datum/customer_data/customer_info = ai_controller?.blackboard[BB_CUSTOMER_CUSTOMERINFO]

--- a/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
+++ b/maplestation_modules/code/modules/mob/living/speech_and_radio_sounds.dm
@@ -56,20 +56,21 @@
 		return ..()
 	if(HAS_TRAIT(src, TRAIT_SIGN_LANG))
 		return null
-	var/obj/item/organ/internal/tongue/tongue = src?.get_organ_slot(ORGAN_SLOT_TONGUE)
-	if(isnull(tongue))
+	var/obj/item/organ/internal/tongue/tongue = get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(isnull(tongue) || !tongue.speech_sounds_enabled)
 		return null
-	if(!tongue.speech_sounds_enabled)
-		return null
-	if(tongue.speech_sound_only_normal)
-		sound_type = SOUND_NORMAL
 	switch(sound_type)
-		if(SOUND_NORMAL)
-			return string_assoc_list(tongue.speech_sound_list)
 		if(SOUND_QUESTION)
-			return string_assoc_list(tongue.speech_sound_list_question)
+			if(length(tongue.speech_sound_list_question))
+				return string_assoc_list(tongue.speech_sound_list_question)
+
 		if(SOUND_EXCLAMATION)
-			return string_assoc_list(tongue.speech_sound_list_exclamation)
+			if(length(tongue.speech_sound_list_exclamation))
+				return string_assoc_list(tongue.speech_sound_list_exclamation)
+
+	// sound type is normal, OR an unrecognized value, OR we don't have a question/exclamation sound
+	if(length(tongue.speech_sound_list))
+		return string_assoc_list(tongue.speech_sound_list)
 	return null
 
 /mob/living/basic/robot_customer/get_speech_sounds(sound_type)

--- a/maplestation_modules/code/modules/surgery/organs/tongue.dm
+++ b/maplestation_modules/code/modules/surgery/organs/tongue.dm
@@ -3,26 +3,24 @@
 /obj/item/organ/internal/tongue
 	/// Use speech sounds, if false, well, dont.
 	var/speech_sounds_enabled = TRUE
-	/// If set to TRUE, use only the speech_sound_list variable and not question or exclamation sounds.
-	var/speech_sound_only_normal = FALSE
-	var/speech_sound_list = list(
-				'goon/sound/voice/speak_1.ogg' = 120,
-				'goon/sound/voice/speak_2.ogg' = 120,
-				'goon/sound/voice/speak_3.ogg' = 120,
-				'goon/sound/voice/speak_4.ogg' = 120,
-			)
-	var/speech_sound_list_question = list(
-				'goon/sound/voice/speak_1_ask.ogg' = 120,
-				'goon/sound/voice/speak_2_ask.ogg' = 120,
-				'goon/sound/voice/speak_3_ask.ogg' = 120,
-				'goon/sound/voice/speak_4_ask.ogg' = 120,
-			)
-	var/speech_sound_list_exclamation = list(
-				'goon/sound/voice/speak_1_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_2_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_3_exclaim.ogg' = 120,
-				'goon/sound/voice/speak_4_exclaim.ogg' = 120,
-			)
+	var/list/speech_sound_list = list(
+		'goon/sound/voice/speak_1.ogg' = 120,
+		'goon/sound/voice/speak_2.ogg' = 120,
+		'goon/sound/voice/speak_3.ogg' = 120,
+		'goon/sound/voice/speak_4.ogg' = 120,
+	)
+	var/list/speech_sound_list_question = list(
+		'goon/sound/voice/speak_1_ask.ogg' = 120,
+		'goon/sound/voice/speak_2_ask.ogg' = 120,
+		'goon/sound/voice/speak_3_ask.ogg' = 120,
+		'goon/sound/voice/speak_4_ask.ogg' = 120,
+	)
+	var/list/speech_sound_list_exclamation = list(
+		'goon/sound/voice/speak_1_exclaim.ogg' = 120,
+		'goon/sound/voice/speak_2_exclaim.ogg' = 120,
+		'goon/sound/voice/speak_3_exclaim.ogg' = 120,
+		'goon/sound/voice/speak_4_exclaim.ogg' = 120,
+	)
 
 /obj/item/organ/internal/tongue/get_possible_languages()
 	return ..() + list(
@@ -70,5 +68,5 @@
 	color = "#333333" // too lazy to make a sprite? just color it!
 
 	speech_sound_list = list('maplestation_modules/sound/voice/shad1.ogg' = 55, 'maplestation_modules/sound/voice/shad2.ogg' = 55)
-	speech_sound_list_question = list('maplestation_modules/sound/voice/shad1.ogg' = 55, 'maplestation_modules/sound/voice/shad2.ogg' = 55) // same as regular speech sounds
+	speech_sound_list_question = null // same as regular speech sounds
 	speech_sound_list_exclamation = list('maplestation_modules/sound/voice/shad_exclaim.ogg' = 55)

--- a/maplestation_modules/code/modules/surgery/organs/tongue.dm
+++ b/maplestation_modules/code/modules/surgery/organs/tongue.dm
@@ -1,5 +1,28 @@
 // Adds some modular languages to tongue languages
+// also speech sounds
 /obj/item/organ/internal/tongue
+	/// Use speech sounds, if false, well, dont.
+	var/speech_sounds_enabled = TRUE
+	/// If set to TRUE, use only the speech_sound_list variable and not question or exclamation sounds.
+	var/speech_sound_only_normal = FALSE
+	var/speech_sound_list = list(
+				'goon/sound/voice/speak_1.ogg' = 120,
+				'goon/sound/voice/speak_2.ogg' = 120,
+				'goon/sound/voice/speak_3.ogg' = 120,
+				'goon/sound/voice/speak_4.ogg' = 120,
+			)
+	var/speech_sound_list_question = list(
+				'goon/sound/voice/speak_1_ask.ogg' = 120,
+				'goon/sound/voice/speak_2_ask.ogg' = 120,
+				'goon/sound/voice/speak_3_ask.ogg' = 120,
+				'goon/sound/voice/speak_4_ask.ogg' = 120,
+			)
+	var/speech_sound_list_exclamation = list(
+				'goon/sound/voice/speak_1_exclaim.ogg' = 120,
+				'goon/sound/voice/speak_2_exclaim.ogg' = 120,
+				'goon/sound/voice/speak_3_exclaim.ogg' = 120,
+				'goon/sound/voice/speak_4_exclaim.ogg' = 120,
+			)
 
 /obj/item/organ/internal/tongue/get_possible_languages()
 	return ..() + list(
@@ -19,6 +42,10 @@
 	disliked_foodtypes = GROSS
 	toxic_foodtypes = MEAT | RAW | DAIRY | TOXIC | SEAFOOD
 
+	speech_sound_list = list('maplestation_modules/sound/voice/huff.ogg' = 120)
+	speech_sound_list_question = list('maplestation_modules/sound/voice/huff_ask.ogg' = 120)
+	speech_sound_list_exclamation = list('maplestation_modules/sound/voice/huff_exclaim.ogg' = 120)
+
 /obj/item/organ/internal/tongue/skrell/get_possible_languages()
 	return ..() + /datum/language/skrell
 
@@ -36,3 +63,12 @@
 
 /obj/item/organ/internal/tongue/lizard/get_possible_languages()
 	return ..() + /datum/language/impdraconic
+
+/obj/item/organ/internal/tongue/shadow
+	name = "umbral tongue"
+	desc = "A dark fleshy muscle mostly used to tell scary stories."
+	color = "#333333" // too lazy to make a sprite? just color it!
+
+	speech_sound_list = list('maplestation_modules/sound/voice/shad1.ogg' = 55, 'maplestation_modules/sound/voice/shad2.ogg' = 55)
+	speech_sound_list_question = list('maplestation_modules/sound/voice/shad1.ogg' = 55, 'maplestation_modules/sound/voice/shad2.ogg' = 55) // same as regular speech sounds
+	speech_sound_list_exclamation = list('maplestation_modules/sound/voice/shad_exclaim.ogg' = 55)


### PR DESCRIPTION
Yeah, this PR makes the speech sound work on tongues rather than hardcoded getters for every species.
This means you can take out someone's tongue, replace it with another species' tongue and get those speech sounds instead!

Also makes it way more easily vareditable for admins and coder/sound design testing.