### PR TITLE
Adds a bespoke pre-game lobby chat 

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -74,6 +74,9 @@
 /// It should not be used simply to silence CI.
 #define SS_OK_TO_FAIL_INIT (1 << 6)
 
+/// Don't show when this has init'd
+#define SS_NO_INIT_MESSAGE (1 << 7)
+
 //! SUBSYSTEM STATES
 #define SS_IDLE 0 /// ain't doing shit.
 #define SS_QUEUED 1 /// queued to run

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -122,9 +122,6 @@
 /// If your system doesn't need to be initialized (by being disabled or something)
 #define SS_INIT_NO_NEED 3
 
-/// Succesfully initialized, BUT do not announce it to players (generally to hide game mechanics it would otherwise spoil)
-#define SS_INIT_NO_MESSAGE 4
-
 //! ### SS initialization load orders
 // Subsystem init_order, from highest priority to lowest priority
 // Subsystems shutdown in the reverse of the order they initialize in

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -300,4 +300,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, span_purple(examine_block("<span class='oocplain'><b>Tip of the round: </b>[message]</span>")))
+	to_chat(target, span_purple(examine_block("<b>Tip of the round: </b>[message]")))

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -216,8 +216,6 @@ GLOBAL_REAL(Master, /datum/controller/master)
 	init_stage_completed = 0
 	var/mc_started = FALSE
 
-	to_chat(world, span_boldannounce("Initializing subsystems..."))
-
 	var/list/stage_sorted_subsystems = new(INITSTAGE_MAX)
 	for (var/i in 1 to INITSTAGE_MAX)
 		stage_sorted_subsystems[i] = list()
@@ -251,14 +249,9 @@ GLOBAL_REAL(Master, /datum/controller/master)
 			// Loop.
 			Master.StartProcessing(0)
 
-	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-
-
-
-	var/msg = "Initializations complete within [time] second[time == 1 ? "" : "s"]!"
-	to_chat(world, span_boldannounce("[msg]"))
-	log_world(msg)
-
+	var/time = (REALTIMEOFDAY - start_timeofday) / (1 SECONDS)
+	SStitle.total_init_time = time
+	log_world("Initializations complete within [time] second\s!")
 
 	if(world.system_type == MS_WINDOWS && CONFIG_GET(flag/toast_notification_on_init) && !length(GLOB.clients))
 		world.shelleo("start /min powershell -ExecutionPolicy Bypass -File tools/initToast/initToast.ps1 -name \"[world.name]\" -icon %CD%\\icons\\ui_icons\\common\\tg_16.png -port [world.port]")
@@ -290,7 +283,6 @@ GLOBAL_REAL(Master, /datum/controller/master)
 		SS_INIT_NONE,
 		SS_INIT_SUCCESS,
 		SS_INIT_NO_NEED,
-		SS_INIT_NO_MESSAGE,
 	)
 
 	if (subsystem.flags & SS_NO_INIT || subsystem.initialized) //Don't init SSs with the corresponding flag or if they already are initialized
@@ -298,7 +290,8 @@ GLOBAL_REAL(Master, /datum/controller/master)
 
 	current_initializing_subsystem = subsystem
 	rustg_time_reset(SS_INIT_TIMER_KEY)
-
+	if(!(subsystem.flags & SS_NO_INIT_MESSAGE))
+		SStitle.add_init_text(subsystem.type, "- [subsystem.name]", "<font color='yellow'>INITIALIZING...</font>")
 	var/result = subsystem.Initialize()
 
 	// Capture end time
@@ -326,32 +319,33 @@ GLOBAL_REAL(Master, /datum/controller/master)
 		subsystem.initialized = FALSE
 		subsystem.can_fire = FALSE
 
-	// The rest of this proc is printing the world log and chat message.
+	// The rest of this proc is printing the world log and updating the splash screen.
 	var/message_prefix
-
-	// If true, print the chat message with boldwarning text.
-	var/chat_warning = FALSE
-
+	var/screen_display = ""
+	var/always_show = FALSE
 	switch(result)
 		if(SS_INIT_FAILURE)
 			message_prefix = "Failed to initialize [subsystem.name] subsystem after"
-			chat_warning = TRUE
-		if(SS_INIT_SUCCESS, SS_INIT_NO_MESSAGE)
+			screen_display = "<font color='red'>FAILED</font>"
+			always_show = TRUE
+		if(SS_INIT_SUCCESS)
 			message_prefix = "Initialized [subsystem.name] subsystem within"
+			screen_display = "<font color='green'>DONE</font>"
 		if(SS_INIT_NO_NEED)
 			// This SS is disabled or is otherwise shy.
-			return
+			pass()
 		else
 			// SS_INIT_NONE or an invalid value.
 			message_prefix = "Initialized [subsystem.name] subsystem with errors within"
-			chat_warning = TRUE
+			screen_display = "<font color='yellow'>ERRORED</font>"
+			always_show = TRUE
 
-	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
-	var/chat_message = chat_warning ? span_boldwarning(message) : span_boldannounce(message)
+	if(screen_display && (always_show || (seconds > 0.01 && !(subsystem.flags & SS_NO_INIT_MESSAGE))))
+		SStitle.add_init_text(subsystem.type, "- [subsystem.name]", screen_display, seconds, major_update = TRUE)
+	else
+		SStitle.remove_init_text(subsystem.type)
 
-	if(result != SS_INIT_NO_MESSAGE)
-		to_chat(world, chat_message)
-	log_world(message)
+	log_world("[message_prefix] [seconds] second\s!")
 
 /datum/controller/master/proc/SetRunLevel(new_runlevel)
 	var/old_runlevel = current_runlevel

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -340,7 +340,7 @@ GLOBAL_REAL(Master, /datum/controller/master)
 			screen_display = "<font color='yellow'>ERRORED</font>"
 			always_show = TRUE
 
-	if(screen_display && (always_show || (seconds > 0.01 && !(subsystem.flags & SS_NO_INIT_MESSAGE))))
+	if(screen_display && (always_show || (seconds > 0.1 && !(subsystem.flags & SS_NO_INIT_MESSAGE))))
 		SStitle.add_init_text(subsystem.type, "- [subsystem.name]", screen_display, seconds, major_update = TRUE)
 	else
 		SStitle.remove_init_text(subsystem.type)

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -23,10 +23,27 @@ SUBSYSTEM_DEF(assets)
 
 
 /datum/controller/subsystem/assets/Initialize()
-	for(var/type in typesof(/datum/asset))
-		var/datum/asset/A = type
-		if (type != initial(A._abstract))
-			load_asset_datum(type)
+	for(var/datum/asset/asset_type as anything in typesof(/datum/asset))
+		if (asset_type == initial(asset_type._abstract))
+			continue
+
+		if (initial(asset_type.early))
+			continue
+
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
+			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>")
 
 	transport.Initialize(cache)
 

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -16,8 +16,20 @@ SUBSYSTEM_DEF(early_assets)
 		if (!initial(asset_type.early))
 			continue
 
-		if (!load_asset_datum(asset_type))
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
 			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>")
 
 		CHECK_TICK
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -156,7 +156,7 @@ SUBSYSTEM_DEF(mapping)
 		load_all_away_missions()
 		SStitle.add_init_text("Away Mission", "> All Away Missions", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
 	else
-		SStitle.add_init_text("Away Mission", "> Away Mission", "<font color='yellow'>SKIPPED</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+		SStitle.add_init_text("Away Mission", "> Away Mission", "<font color='yellow'>SKIPPED</font>")
 
 	start_time = REALTIMEOFDAY
 	SStitle.add_init_text("Ruins", "> Ruins", "<font color='yellow'>LOADING...</font>")

--- a/code/controllers/subsystem/radioactive_nebula.dm
+++ b/code/controllers/subsystem/radioactive_nebula.dm
@@ -4,7 +4,7 @@
 /// Controls making objects irradiated when Radioactive Nebula is in effect.
 SUBSYSTEM_DEF(radioactive_nebula)
 	name = "Radioactive Nebula"
-	flags = SS_BACKGROUND
+	flags = SS_BACKGROUND|SS_NO_INIT_MESSAGE
 	wait = 30 SECONDS
 
 	VAR_PRIVATE
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(radioactive_nebula)
 		irradiate_everything()
 
 	// Don't leak that the station trait has been picked
-	return SS_INIT_NO_MESSAGE
+	return SS_INIT_SUCCESS
 
 /// Makes something appear irradiated for the purposes of the Radioactive Nebula
 /datum/controller/subsystem/radioactive_nebula/proc/fake_irradiate(atom/movable/target)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(ticker)
 			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.config.map_name]!"), CONFIG_GET(string/channel_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
-
+			SStitle.update_init_text()
 			fire()
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels
@@ -188,6 +188,7 @@ SUBSYSTEM_DEF(ticker)
 			if(timeLeft <= 300 && !tipped)
 				send_tip_of_the_round(world, selected_tip)
 				tipped = TRUE
+				SStitle.fade_init_text()
 
 			if(timeLeft <= 0)
 				SEND_SIGNAL(src, COMSIG_TICKER_ENTER_SETTING_UP)

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -3,11 +3,23 @@ SUBSYSTEM_DEF(title)
 	flags = SS_NO_FIRE
 	init_order = INIT_ORDER_TITLE
 	init_stage = INITSTAGE_EARLY
-
+	/// The path to the title screen image
 	var/file_path
+	/// The icon to use for the title screen
 	var/icon/icon
+	/// The previous title screen icon (from the last round)
 	var/icon/previous_icon
+	/// Reference to the turf in the lobby, which is where we hold the title screen
 	var/turf/closed/indestructible/splashscreen/splash_turf
+	/// A holder for maptext that displays initialization information on the title screen
+	var/obj/effect/abstract/init_order_holder/maptext_holder
+
+	/// A list of initialization information
+	var/list/init_infos = list()
+	/// Tracks the number of dots to display
+	var/num_dots = 1
+	/// The total time taken to initialize the game
+	var/total_init_time = -1
 
 /datum/controller/subsystem/title/Initialize()
 	if(file_path && icon)
@@ -68,3 +80,109 @@ SUBSYSTEM_DEF(title)
 	splash_turf = SStitle.splash_turf
 	file_path = SStitle.file_path
 	previous_icon = SStitle.previous_icon
+	init_infos = SStitle.init_infos
+
+/**
+ * Adds an entry to the initialization information list
+ *
+ * * init_category: The category of the initialization information - this must be a unique key, such as a typepath.
+ * Tt's not displayed to the player, so don't worry about making it pretty.
+ * * name: The name of the initialization information. This is displayed to the player.
+ * * stage: The "stage" of the initialization information, such as "loading" / "complete" / "failed".
+ * * seconds: The number of seconds this initialization information took. Optional.
+ * * override: If TRUE, this will overwrite any existing entry with the same init_category.
+ * Othewise, it will try to update the existing entry's state and time.
+ * * major_update: Indicates this init text is a major update, which will update a "dot" animation.
+ */
+/datum/controller/subsystem/title/proc/add_init_text(init_category, name, stage, seconds, override = FALSE, major_update = FALSE)
+	if(override || !init_infos[init_category])
+		init_infos[init_category] = list(name, stage, seconds)
+	else
+		init_infos[init_category][2] = stage
+		init_infos[init_category][3] += seconds
+	if(major_update)
+		num_dots = (num_dots % 6 + 1)
+	update_init_text()
+
+
+/// Removes the passed category from the initialization information list
+/datum/controller/subsystem/title/proc/remove_init_text(init_category)
+	init_infos -= init_category
+	update_init_text()
+
+/// Updates the displayed initialization text according to all initialization information
+/datum/controller/subsystem/title/proc/update_init_text()
+	if(!maptext_holder)
+		if(!splash_turf)
+			return
+		maptext_holder = new(splash_turf)
+
+	maptext_holder.maptext = "<span class='maptext'>"
+	maptext_holder.maptext += "<span class='big'>"
+	if(SSticker?.current_state == GAME_STATE_PREGAME)
+		var/total_time_formatted = "[total_init_time]s"
+		switch(total_init_time)
+			if(0 to 60)
+				total_time_formatted = "<font color='green'>[total_init_time]s</font>"
+			if(60 to 120)
+				total_time_formatted = "<font color='yellow'>[total_init_time]s</font>"
+			if(120 to INFINITY)
+				total_time_formatted = "<font color='red'>[total_init_time]s</font>"
+
+		maptext_holder.maptext += "Game Ready! ([total_time_formatted])"
+	else
+		maptext_holder.maptext += "Initializing game"
+		for(var/i in 1 to num_dots)
+			maptext_holder.maptext += "."
+	maptext_holder.maptext += "</span><br>"
+	for(var/sstype in init_infos)
+		var/list/init_data = init_infos[sstype]
+		var/init_name = init_data[1]
+		var/init_stage = init_data[2]
+		var/init_time = isnum(init_data[3]) ? "([init_data[3]]s)" : ""
+		maptext_holder.maptext += "<br>[init_name] [init_stage] [init_time]"
+	maptext_holder.maptext += "<br></span>"
+
+/// Simply fades out the initialization text
+/datum/controller/subsystem/title/proc/fade_init_text()
+	update_init_text()
+	animate(maptext_holder, alpha = 0, time = 8 SECONDS)
+
+/// Abstract holder for maptext on the lobby screen
+/obj/effect/abstract/init_order_holder
+	icon = null
+	icon_state = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_height = 500
+	maptext_width = 200
+	maptext_x = 12
+	maptext_y = 12
+	plane = SPLASHSCREEN_PLANE
+	pixel_x = -64
+	/// Conceals the holder from clients who don't want to see it
+	var/image/hide_me
+
+/obj/effect/abstract/init_order_holder/Initialize(mapload)
+	. = ..()
+	for(var/mob/dead/new_player/lobby_goer as anything in GLOB.new_player_list)
+		check_client(lobby_goer.client)
+
+/// Check if the client should see or should not see the initialization information. Updates accordingly.
+/obj/effect/abstract/init_order_holder/proc/check_client(client/seer)
+	if(isnull(seer))
+		return
+	if(!seer.prefs.read_preference(/datum/preference/toggle/show_init_stats))
+		hide_from_client(seer)
+		return
+	show_to_client(seer)
+
+/// Hides the initialization information from the client
+/obj/effect/abstract/init_order_holder/proc/hide_from_client(client/seer)
+	if(isnull(hide_me))
+		hide_me = image(loc = src)
+		hide_me.override = TRUE
+	seer?.images |= hide_me
+
+/// Shows the initialization information to the client (if already hidden, otherwise nothing happens)
+/obj/effect/abstract/init_order_holder/proc/show_to_client(client/seer)
+	seer?.images -= hide_me

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -82,6 +82,8 @@ SUBSYSTEM_DEF(title)
 	previous_icon = SStitle.previous_icon
 	init_infos = SStitle.init_infos
 
+#define MAX_INIT_TEXT 40
+
 /**
  * Adds an entry to the initialization information list
  *
@@ -102,8 +104,11 @@ SUBSYSTEM_DEF(title)
 		init_infos[init_category][3] += seconds
 	if(major_update)
 		num_dots = (num_dots % 6 + 1)
+	if(length(init_infos) > MAX_INIT_TEXT)
+		init_infos.Cut(1, length(init_infos) - MAX_INIT_TEXT + 1)
 	update_init_text()
 
+#undef MAX_INIT_TEXT
 
 /// Removes the passed category from the initialization information list
 /datum/controller/subsystem/title/proc/remove_init_text(init_category)

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -85,6 +85,7 @@
 		return
 
 	var/start_time = REALTIMEOFDAY
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='yellow'>LOADING</font>")
 	string_gen = rustg_cnoise_generate("[initial_closed_chance]", "[smoothing_iterations]", "[birth_limit]", "[death_limit]", "[world.maxx]", "[world.maxy]") //Generate the raw CA data
 
 	for(var/turf/gen_turf as anything in turfs) //Go through all the turfs and generate them
@@ -99,9 +100,8 @@
 		if(gen_turf.turf_flags & NO_RUINS)
 			new_turf.turf_flags |= NO_RUINS
 
-	var/message = "[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!"
-	to_chat(world, span_boldannounce("[message]"))
-	log_world(message)
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!")
 
 /datum/map_generator/cave_generator/populate_terrain(list/turfs, area/generate_in)
 	// Area var pullouts to make accessing in the loop faster
@@ -110,6 +110,7 @@
 	var/mobs_allowed = (generate_in.area_flags & MOB_SPAWN_ALLOWED) && length(mob_spawn_list)
 	var/megas_allowed = (generate_in.area_flags & MEGAFAUNA_SPAWN_ALLOWED) && length(megafauna_spawn_list)
 
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='yellow'>LOADING</font>")
 	var/start_time = REALTIMEOFDAY
 
 	for(var/turf/target_turf as anything in turfs)
@@ -187,6 +188,5 @@
 				spawned_something = TRUE
 		CHECK_TICK
 
-	var/message = "[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!"
-	to_chat(world, span_boldannounce("[message]"))
-	log_world(message)
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -98,6 +98,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/cmd_admin_law_panel,
 	/client/proc/log_viewer_new,
 	/client/proc/player_ticket_history,
+	/client/proc/admin_lobby_chat, // NON-MODULE CHANGE
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel, /client/proc/library_control))
 GLOBAL_PROTECT(admin_verbs_ban)

--- a/code/modules/client/preferences/init_stats.dm
+++ b/code/modules/client/preferences/init_stats.dm
@@ -1,0 +1,9 @@
+/datum/preference/toggle/show_init_stats
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "show_init_stats"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = TRUE
+
+/datum/preference/toggle/show_init_stats/apply_to_client_updated(client/client, value)
+	if(isnewplayer(client.mob))
+		SStitle?.maptext_holder?.check_client(client)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -53,7 +53,6 @@
 		return
 
 	if(SSticker.current_state < GAME_STATE_SETTING_UP)
+		SStitle?.maptext_holder?.check_client(client)
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")
-
-

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -434,7 +434,7 @@
 		to_chat(src, span_danger("You have been banned from lobby chat."))
 		return
 
-	message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
+	message = trim(sanitize(message), MAX_MESSAGE_LEN)
 	var/list/filter_result = is_ooc_filtered(message)
 	if (!CAN_BYPASS_FILTER(mob) && filter_result)
 		REPORT_CHAT_FILTER_TO_USER(src, filter_result)
@@ -446,7 +446,7 @@
 			return
 		message_admins("[ADMIN_LOOKUPFLW(src)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Message: \"[message]\"")
 		log_admin_private("[key_name(src)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Message: \"[message]\"")
-	if(!message)
+	if(!message || QDELETED(src))
 		return
 	mob.log_talk(message, LOG_OOC)
 	message = "<span class='message linkify'>[emoji_parse(message)]</span>"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -417,4 +417,89 @@
 	SSticker.ready_report -= src // should be redundant but just in case.
 	return ..()
 
+/mob/dead/new_player/say(message, bubble_type, list/spans, sanitize, datum/language/language, ignore_spam, forced, filterproof, message_range, datum/saymode/saymode)
+	if(isnull(client) || client.interviewee)
+		return
+
+	client.lobby_chat(message)
+
+/// Lobby chat: An intermedium between OOC and IC chat, where players can talk to each other before joining the game / while the game sets up
+/client/proc/lobby_chat(message)
+	VALIDATE_CLIENT(src)
+
+	if(GLOB.say_disabled) //This is here to try to identify lag problems
+		to_chat(src, span_danger("Speech is currently admin-disabled."))
+		return
+	if(is_banned_from(ckey, "OOC"))
+		to_chat(src, span_danger("You have been banned from lobby chat."))
+		return
+
+	message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
+	var/list/filter_result = is_ooc_filtered(message)
+	if (!CAN_BYPASS_FILTER(mob) && filter_result)
+		REPORT_CHAT_FILTER_TO_USER(src, filter_result)
+		log_filter("OOC", message, filter_result)
+		return
+	var/list/soft_filter_result = filter_result || is_soft_ooc_filtered(message)
+	if (soft_filter_result)
+		if(tgui_alert(src, "Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to say it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
+			return
+		message_admins("[ADMIN_LOOKUPFLW(src)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Message: \"[message]\"")
+		log_admin_private("[key_name(src)] has passed the soft filter for \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Message: \"[message]\"")
+	if(!message)
+		return
+	mob.log_talk(message, LOG_OOC)
+	message = "<span class='message linkify'>[emoji_parse(message)]</span>"
+
+	var/player_name = key
+	var/fake_key = holder?.fakekey
+	if(fake_key)
+		player_name = fake_key
+	else if(length(holder?.ranks))
+		player_name = "[span_tooltip(holder.rank_names(), "STAFF")] [key]"
+
+	if(prefs.hearted)
+		var/datum/asset/spritesheet/sheet = get_asset_datum(/datum/asset/spritesheet/chat)
+		player_name = "[sheet.icon_tag("emoji-heart")] [player_name]"
+	if(prefs.unlock_content && (prefs.toggles & MEMBER_PUBLIC))
+		player_name = "<font color='[prefs.read_preference(/datum/preference/color/ooc_color)]'>[icon2html('icons/ui_icons/chat/member_content.dmi', world, "blag")] [player_name]</font>"
+
+	// relay lobby chat to all people in the lobby
+	// goes to info, so people who separate ooc can still see it in the main tab
+	for(var/mob/dead/new_player/recipient as anything in GLOB.new_player_list)
+		if(isnull(recipient.client)) // allegedly all new players are cliented, but who knows?
+			continue
+
+		var/visible_name = player_name
+		if(fake_key)
+			if(recipient == src || check_rights_for(recipient.client, R_STEALTH))
+				visible_name += " / ([key])"
+			else if(fake_key in recipient.client.prefs.ignoring)
+				continue
+
+		else if(key in recipient.client.prefs.ignoring)
+			continue
+
+		to_chat(recipient, span_nicegreen("[span_prefix("LOBBY:")] <em>[visible_name]:</em> [message]"), avoid_highlighting = (recipient == src), type = MESSAGE_TYPE_INFO)
+
+	// relay lobby chat to admins who aren't in the lobby, so they can monitor it
+	// spits to OOC instead of info, so as to not annoy admins who separate their chats out
+	for(var/client/admin as anything in GLOB.admins)
+		if(isnewplayer(admin.mob)) // already sees it
+			continue
+
+		var/visible_name = player_name
+		if(fake_key && (admin == src || check_rights_for(admin, R_STEALTH)))
+			visible_name += " / ([key])"
+
+		to_chat(admin, span_nicegreen("[span_prefix("LOBBY (RELAYED):")] <em>[visible_name]:</em> [message]"), type = MESSAGE_TYPE_OOC)
+
+/// Allows admins in game to speak to people in lobby chat
+/client/proc/admin_lobby_chat(msg as text)
+	set name = "Lobby Chat Relay"
+	set category = "OOC"
+	set desc = "Relay a message to the lobby chat from in game."
+
+	lobby_chat(msg)
+
 #undef RESET_HUD_INTERVAL

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -3581,6 +3581,7 @@
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
+#include "code\modules\client\preferences\init_stats.dm"
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\language.dm"

--- a/maplestation_modules/code/modules/client/verbs/looc.dm
+++ b/maplestation_modules/code/modules/client/verbs/looc.dm
@@ -55,8 +55,7 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 	if(QDELETED(src))
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
-
+	msg = trim(sanitize(msg), MAX_MESSAGE_LEN)
 	if(!msg)
 		return
 

--- a/maplestation_modules/code/modules/client/verbs/looc.dm
+++ b/maplestation_modules/code/modules/client/verbs/looc.dm
@@ -25,7 +25,7 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 			to_chat(src, span_danger("LOOC is globally muted."))
 			return
 		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-			to_chat(src, span_danger("OOC / LOOC for dead mobs has been turned off."))
+			to_chat(src, span_danger("LOOC for dead mobs has been turned off."))
 			return
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, span_danger("You cannot use LOOC (muted)."))
@@ -36,10 +36,10 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 	// Really?
 	if(!SSticker.HasRoundStarted())
-		to_chat(src, span_danger("The round hasn't started yet, dummy! Just use OOC."))
+		to_chat(src, span_danger("The round hasn't started yet!"))
 		return
-	if(istype(mob, /mob/dead/new_player))
-		to_chat(src, span_danger("You're not in game to broadcast LOOC anywhere! Use OOC."))
+	if(isnewplayer(mob))
+		to_chat(src, span_danger("You're not in game to broadcast LOOC anywhere!"))
 		return
 
 	// Check for people with OOC muted
@@ -49,7 +49,7 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 	// Check for people banned from OOC
 	if(is_banned_from(ckey, "OOC"))
-		to_chat(src, span_danger("You have been banned from OOC / LOOC."))
+		to_chat(src, span_danger("You have been banned from LOOC."))
 		return
 
 	if(QDELETED(src))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3582,6 +3582,7 @@
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
+#include "code\modules\client\preferences\init_stats.dm"
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\language.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const show_init_stats: FeatureToggle = {
+  name: 'Enable Lobby Game Stats',
+  category: 'UI',
+  description:
+    'When enabled, the lobby screen will report how long game set up is taking.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
Or "Why I did #656" 

Rather than needing to use OOC to talk pre-round, there is now a bespoke lobby chat

You talk in it as you would expect: Using the say box/verb (`say "Hey I'm in the lobby"`)

This offers people (me) who disable OOC (or move it to another tab) an easier and more visible way to communicate with people pre-round, without needing to mess with their settings


Additionally, this chat persists after roundstart, so it gives people a way to coordinate prior to late-joining. 
(Admins are relayed messages from this chat while in game, so any pre-latejoin metagaming can be finger-wagged)

Color not final, OOC still exists

![image](https://github.com/user-attachments/assets/46a8ad0b-4363-41d1-a0e9-e5ebff97831a)
