### PR TITLE
The alt job title thing + Honorifics

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -36,3 +36,28 @@
 )
 /// Wildcard slot define for admin/debug/weird, special abstract cards. Can hold infinite of any access.
 #define WILDCARD_LIMIT_ADMIN list(WILDCARD_NAME_ALL = list(limit = -1, usage = list()))
+
+/**
+ * x1, y1, x2, y2 - Represents the bounding box for the ID card's non-transparent portion of its various icon_states.
+ * Used to crop the ID card's transparency away when chaching the icon for better use in tgui chat.
+ */
+#define ID_ICON_BORDERS 1, 9, 32, 24
+
+///Honorific will display next to the first name.
+#define HONORIFIC_POSITION_FIRST (1<<0)
+///Honorific will display next to the last name.
+#define HONORIFIC_POSITION_LAST (1<<1)
+///Honorific will not be displayed.
+#define HONORIFIC_POSITION_DISABLED (1<<2)
+///Honorific will be appended to the full name at the start.
+#define HONORIFIC_POSITION_FIRST_FULL (1<<3)
+///Honorific will be appended to the full name at the end.
+#define HONORIFIC_POSITION_LAST_FULL (1<<4)
+
+#define HONORIFIC_POSITION_BITFIELDS(...) list( \
+	"Honorific + First Name" = HONORIFIC_POSITION_FIRST, \
+	"Honorific + Last Name" = HONORIFIC_POSITION_LAST, \
+	"Honorific + Full Name" = HONORIFIC_POSITION_FIRST_FULL, \
+	"Full Name + Honorific" = HONORIFIC_POSITION_LAST_FULL, \
+	"Disable Honorific" = HONORIFIC_POSITION_DISABLED, \
+)

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -84,6 +84,7 @@
 #define JOB_BARTENDER "Bartender"
 #define JOB_BOTANIST "Botanist"
 #define JOB_COOK "Cook"
+#define JOB_CHEF "Chef" // Alternate cook title.
 #define JOB_JANITOR "Janitor"
 #define JOB_CLOWN "Clown"
 #define JOB_MIME "Mime"

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -218,21 +218,32 @@
 
 	return atom_to_find.loc
 
-///Send a message in common radio when a player arrives
-/proc/announce_arrival(mob/living/carbon/human/character, rank)
+/**
+ * Send a message in common radio when a player arrives
+ *
+ * * character - The mob of the player who arrived
+ * * backup_job_title - We try to infer the job title based on ID, but if we fail, we use this.
+ * * try_queue - If TRUE, we'll queue the announcement if the shuttle is still docking.
+ */
+/proc/announce_arrival(mob/living/carbon/human/character, backup_job_title, try_queue = FALSE)
 	if(!SSticker.IsRoundInProgress() || QDELETED(character))
 		return
+	var/datum/record/crew/crew_record = find_record(character.real_name)
+	var/obj/item/card/id/crew_id = character.get_idcard(hand_first = FALSE)
+	var/job_title = crew_record?.rank || crew_id?.assignment || crew_id?.trim?.assignment || backup_job_title
+	if(try_queue && SSshuttle.arrivals)
+		// queue announcement basically just calls this proc again, but with the try_queue flag set to false, after the shuttle has finished docking
+		SSshuttle.arrivals.QueueAnnounce(character, job_title)
+		return
 	var/area/player_area = get_area(character)
-	deadchat_broadcast("<span class='game'> has arrived at the station at <span class='name'>[player_area.name]</span>.</span>", "<span class='game'><span class='name'>[character.real_name]</span> ([rank])</span>", follow_target = character, message_type=DEADCHAT_ARRIVALRATTLE)
-	if(!character.mind)
+	deadchat_broadcast("<span class='game'> has arrived at the station at <span class='name'>[player_area.name]</span>.</span>", "<span class='game'><span class='name'>[character.real_name]</span> ([job_title])</span>", follow_target = character, message_type = DEADCHAT_ARRIVALRATTLE)
+	if(!length(GLOB.announcement_systems))
 		return
-	if(!GLOB.announcement_systems.len)
-		return
-	if(!(character.mind.assigned_role.job_flags & JOB_ANNOUNCE_ARRIVAL))
+	if(!(character.mind?.assigned_role.job_flags & JOB_ANNOUNCE_ARRIVAL))
 		return
 
 	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-	announcer.announce("ARRIVAL", character.real_name, rank, list()) //make the list empty to make it announce it in common
+	announcer.announce("ARRIVAL", character.real_name, job_title, list()) //make the list empty to make it announce it in common
 
 ///Check if the turf pressure allows specialized equipment to work
 /proc/lavaland_equipment_pressure_check(turf/turf_to_check)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1062,7 +1062,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 	if(prefs)
 		prefs.apply_prefs_to(body, TRUE)
 
-	var/datum/outfit/outfit = outfit_override || job?.outfit
+	var/datum/outfit/outfit = outfit_override || job?.base_outfit
 	if(job)
 		body.dna.species.pre_equip_species_outfit(job, body, TRUE)
 	if(outfit)

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -374,3 +374,22 @@ GLOBAL_DATUM(syndicate_code_response_regex, /regex)
 			return "a rolling pin"
 		else
 			return "something... but the gods didn't set this up right (Please report this bug)"
+
+///Find the first name of a mob from a passed string with regex
+/proc/first_name(given_name)
+	var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace or "-"
+	firstname.Find(given_name)
+	return firstname.match
+
+/// Find the last name of a mob from a passed string with regex
+/proc/last_name(given_name)
+	var/static/regex/lasttname = new("\[^\\s-\]+$") //First word before whitespace or "-"
+	lasttname.Find(given_name)
+	return lasttname.match
+
+/// Find whitespace or dashes in the passed string with regex and returns TRUE if found
+/proc/is_mononym(given_name)
+	var/static/regex/breaks = regex(@"\s")
+	if(breaks.Find(given_name))
+		return FALSE
+	return TRUE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -159,7 +159,8 @@ SUBSYSTEM_DEF(job)
 			log_job_debug("Removed [job.title] due to map config")
 			continue
 		new_all_occupations += job
-		name_occupations[job.title] = job
+		for(var/alt_title in job.get_titles())
+			name_occupations[alt_title] = job
 		type_occupations[job_type] = job
 		if(job.job_flags & JOB_NEW_PLAYER_JOINABLE)
 			new_joinable_occupations += job

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -23,3 +23,7 @@
 	var/list/access = list()
 	/// Accesses that this trim unlocks on a card that require wildcard slots to apply. If a card cannot accept all a trim's wildcard accesses, the card is incompatible with the trim.
 	var/list/wildcard_access = list()
+	/// What honorifics, if any, will we set our wearer's name to when worn?
+	var/list/honorifics
+	/// What positions can our honorific take? To prevent names like "Peter Dr."
+	var/honorific_positions = NONE

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -20,6 +20,8 @@
 	trim_state = "trim_janitor"
 	department_color = COLOR_CENTCOM_BLUE
 	subdepartment_color = COLOR_SERVICE_LIME
+	honorifics = list("Custodian")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /// Trim for Centcom Thunderdome Overseers.
 /datum/id_trim/centcom/thunderdome_overseer
@@ -35,10 +37,14 @@
 /datum/id_trim/centcom/intern
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_WEAPONS)
 	assignment = "CentCom Intern"
+	honorifics = list("Intern")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /// Trim for Centcom Head Interns. Different assignment, common station access added on.
 /datum/id_trim/centcom/intern/head
 	assignment = "CentCom Head Intern"
+	honorifics = list("Head Intern")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/intern/head/New()
 	. = ..()
@@ -59,6 +65,8 @@
 /datum/id_trim/centcom/medical_officer
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_MEDICAL)
 	assignment = JOB_CENTCOM_MEDICAL_DOCTOR
+	honorifics = list("Doctor", "Dr.")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /// Trim for Centcom Research Officers.
 /datum/id_trim/centcom/research_officer
@@ -86,6 +94,8 @@
 /// Trim for Centcom Commanders. All Centcom and Station Access.
 /datum/id_trim/centcom/commander
 	assignment = JOB_CENTCOM_COMMANDER
+	honorifics = list("Commander", "CMDR.")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/commander/New()
 	. = ..()
@@ -97,6 +107,9 @@
 	assignment = JOB_ERT_DEATHSQUAD
 	trim_state = "trim_deathcommando"
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
+	honorifics = list("Commando")
+	honorific_positions = HONORIFIC_POSITION_LAST
+
 
 /datum/id_trim/centcom/deathsquad/New()
 	. = ..()
@@ -106,6 +119,8 @@
 /// Trim for generic ERT interns. No universal ID card changing access.
 /datum/id_trim/centcom/ert
 	assignment = "Emergency Response Team Intern"
+	honorifics = list("Intern")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/New()
 	. = ..()
@@ -129,6 +144,8 @@
 	trim_state = "trim_securityofficer"
 	subdepartment_color = COLOR_SECURITY_RED
 	sechud_icon_state = SECHUD_SECURITY_RESPONSE_OFFICER
+	honorifics = list("Officer")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/security/New()
 	. = ..()
@@ -153,6 +170,8 @@
 	trim_state = "trim_medicaldoctor"
 	subdepartment_color = COLOR_MEDICAL_BLUE
 	sechud_icon_state = SECHUD_MEDICAL_RESPONSE_OFFICER
+	honorifics = list("Doctor", "Dr.")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/medical/New()
 	. = ..()
@@ -165,6 +184,8 @@
 	trim_state = "trim_chaplain"
 	subdepartment_color = "#58C800"
 	sechud_icon_state = SECHUD_RELIGIOUS_RESPONSE_OFFICER
+	honorifics = list("Chaplain")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/chaplain/New()
 	. = ..()
@@ -177,6 +198,8 @@
 	trim_state = "trim_ert_janitor"
 	subdepartment_color = COLOR_SERVICE_LIME
 	sechud_icon_state = SECHUD_JANITORIAL_RESPONSE_OFFICER
+	honorifics = list("Custodian")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/janitor/New()
 	. = ..()
@@ -197,6 +220,10 @@
 
 /datum/id_trim/centcom/ert/militia
 	assignment = "Frontier Militia"
+	honorifics = list("Minuteman")
+	honorific_positions = HONORIFIC_POSITION_LAST
 
 /datum/id_trim/centcom/ert/militia/general
 	assignment = "Frontier Militia General"
+	honorifics = list("Minuteman General", "General")
+	honorific_positions = HONORIFIC_POSITION_LAST

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -738,6 +738,12 @@
 		)
 	job = /datum/job/doctor
 
+/datum/id_trim/job/medical_doctor/nurse
+	assignment = "Nurse"
+
+/datum/id_trim/job/medical_doctor/surgeon
+	assignment = "Surgeon"
+
 /datum/id_trim/job/mime
 	assignment = "Mime"
 	trim_state = "trim_mime"

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -131,6 +131,8 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
+	honorifics = list("Technician")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/bartender
 	assignment = "Bartender"
@@ -224,6 +226,8 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/bridge_assistant
+	honorifics = list("Underling", "Assistant", "Mate")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/captain
 	assignment = "Captain"
@@ -238,6 +242,8 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/captain
+	honorifics = list("Captain", "Cpt.")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
 /datum/id_trim/job/captain/New()
@@ -272,6 +278,9 @@
 		ACCESS_QM,
 		)
 	job = /datum/job/cargo_technician
+	honorifics = list("Courier")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
+
 
 /datum/id_trim/job/chaplain
 	assignment = "Chaplain"
@@ -294,6 +303,34 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/chaplain
+	honorifics = list(
+		// Christian
+		"Abbot", "Archbishop", "Bishop", "Cardinal", "Deacon", "Friar", "Monk", "Nun",
+		"Pastor", "Pilgrim", "Prior", "Prioress", "Reverend", "Vicar",
+		// Jewish
+		"Rabbi",
+		// Hindu
+		"Guru",
+		// Buddhist
+		"Lama",
+		// Sikh
+		"Gyani",
+		// Shinto
+		"Kannushi",
+		// Muslim
+		"Imam",
+		// Generic / Ancient
+		"Acolyte", "Adept", "Brother", "Father", "Heirophant", "Luminary", "Mother",
+		"Priest", "Priestess", "Prophet", "Sage", "Seer", "Shaman", "Sister",
+	)
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
+
+/datum/id_trim/job/chaplain/New()
+	. = ..()
+	// add in any titles from the job itself
+	honorifics |= job.get_titles(TRUE)
+	// sort alphabetically (makes it easier to parse), but keep the main chaplain title at the top
+	honorifics = list(JOB_CHAPLAIN) | sortTim(honorifics, GLOBAL_PROC_REF(cmp_text_asc))
 
 /datum/id_trim/job/chemist
 	assignment = "Chemist"
@@ -360,6 +397,8 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/chief_engineer
+	honorifics = list("Chief")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST
 
 /datum/id_trim/job/chief_medical_officer
 	assignment = "Chief Medical Officer"
@@ -399,6 +438,8 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/chief_medical_officer
+	honorifics = list(", PhD.", ", MD.")
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL
 
 /datum/id_trim/job/clown
 	assignment = "Clown"
@@ -441,10 +482,14 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/cook
+	honorifics = list("Cook")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/cook/chef
 	assignment = "Chef"
 	sechud_icon_state = SECHUD_CHEF
+	honorifics = list("Chef")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/coroner
 	assignment = "Coroner"
@@ -521,6 +566,8 @@
 		ACCESS_HOS,
 	)
 	job = /datum/job/detective
+	honorifics = list("Detective", "Investigator")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/detective/refresh_trim_access()
 	. = ..()
@@ -661,6 +708,8 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/head_of_security
+	honorifics = list("Chief Officer", "Chief", "Officer")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
 	. = ..()
@@ -691,6 +740,8 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/janitor
+	honorifics = list("Custodian")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/lawyer
 	assignment = "Lawyer"
@@ -712,6 +763,8 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/lawyer
+	honorifics = list(", Esq.")
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL
 
 /datum/id_trim/job/medical_doctor
 	assignment = "Medical Doctor"
@@ -737,6 +790,8 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/doctor
+	honorifics = list("Doctor", "Dr.")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/medical_doctor/nurse
 	assignment = "Nurse"
@@ -794,6 +849,8 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/paramedic
+	honorifics = list("EMT")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/prisoner
 	assignment = "Prisoner"
@@ -809,6 +866,8 @@
 		)
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
+	honorifics = list("Convict")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/prisoner/one
 	trim_state = "trim_prisoner_1"
@@ -861,6 +920,8 @@
 		ACCESS_HOP,
 	)
 	job = /datum/job/psychologist
+	honorifics = list(", PhD.")
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL
 
 /datum/id_trim/job/quartermaster
 	assignment = "Quartermaster"
@@ -899,6 +960,8 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/quartermaster
+	honorifics = list("Manager", "Quartermaster")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/research_director
 	assignment = "Research Director"
@@ -947,6 +1010,8 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/research_director
+	honorifics = list("Director", "Dir.")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/roboticist
 	assignment = "Roboticist"
@@ -1004,6 +1069,8 @@
 		ACCESS_RD,
 		)
 	job = /datum/job/scientist
+	honorifics = list("Researcher")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
 /datum/id_trim/job/security_officer
@@ -1032,6 +1099,8 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/security_officer
+	honorifics = list("Officer")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
 	/// List of bonus departmental accesses that departmental security officers can in relation to how many overall security officers there are if the scaling system is set up. These can otherwise be granted via config settings.
@@ -1110,6 +1179,7 @@
 		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
 	)
+	honorifics = list("Orderly", "Officer")
 
 /datum/id_trim/job/security_officer/science
 	assignment = "Security Officer (Science)"
@@ -1192,6 +1262,8 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/station_engineer
+	honorifics = list("Engineer")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/virologist
 	assignment = "Virologist"
@@ -1245,6 +1317,8 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/warden
+	honorifics = list("Officer", "Watchman", "Lieutenant", "Lt.")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
 
 /datum/id_trim/job/warden/refresh_trim_access()
 	. = ..()

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -70,6 +70,8 @@
 	department_color = COLOR_BLACK
 	subdepartment_color = COLOR_GREEN
 	threat_modifier = -1 // Cops recognise cops
+	honorifics = list("CISO")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST
 
 /datum/id_trim/cyber_police/New()
 	. = ..()

--- a/code/datums/id_trim/syndicate.dm
+++ b/code/datums/id_trim/syndicate.dm
@@ -14,6 +14,10 @@
 	access = list(ACCESS_SYNDICATE, ACCESS_ROBOTICS)
 
 /// Interdyne medical Staff
+/datum/id_trim/syndicom/Interdyne
+	honorifics = list(", PhD.")
+	honorific_positions = HONORIFIC_POSITION_LAST_FULL
+
 /datum/id_trim/syndicom/Interdyne/pharmacist
 	assignment = "Interdyne Pharmacist"
 	trim_state = "trim_medicaldoctor"
@@ -37,6 +41,9 @@
 	subdepartment_color = COLOR_COMMAND_BLUE
 	sechud_icon_state = SECHUD_DEATH_COMMANDO
 	access = list(ACCESS_SYNDICATE, ACCESS_MAINT_TUNNELS)
+	honorifics = list("Auditor")
+	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL
+
 
 /datum/id_trim/syndicom/irs/auditor
 	assignment = "Internal Revenue Service Head Auditor"

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -102,7 +102,9 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
 
-	var/assignment = person.mind.assigned_role.title
+	// Attempt to get assignment from ID, otherwise default to mind.
+	var/obj/item/card/id/id_card = person.get_idcard(hand_first = FALSE)
+	var/assignment = id_card?.assignment || id_card?.trim?.assignment || person.mind.assigned_role.title
 	var/mutable_appearance/character_appearance = new(person.appearance)
 	var/person_gender = "Other"
 	if(person.gender == "male")

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -52,12 +52,12 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 			listeners += candidate
 
 			//Let's ensure the listener's name is not matched within another word or command (and viceversa). e.g. "Saul" in "somersault"
-			var/their_first_name = candidate.first_name()
+			var/their_first_name = first_name(candidate.name)
 			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[their_first_name](\\L|$)", "i")))
 				specific_listeners += candidate //focus on those with the specified name
 				to_remove_string += "[to_remove_string ? "|" : null][their_first_name]"
 				continue
-			var/their_last_name = candidate.last_name()
+			var/their_last_name = last_name(candidate.name)
 			if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[their_last_name](\\L|$)", "i")))
 				specific_listeners += candidate // Ditto
 				to_remove_string += "[to_remove_string ? "|" : null][their_last_name]"

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 /obj/machinery/computer/arcade/orion_trail/proc/newgame()
 	// Set names of settlers in crew
 	var/mob/living/player = usr
-	var/player_crew_name = player.first_name()
+	var/player_crew_name = first_name(player.name)
 	settlers = list()
 	for(var/i in 1 to ORION_STARTING_CREW_COUNT - 1) //one reserved to be YOU
 		add_crewmember(update = FALSE)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -94,16 +94,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	/// Map of job to ID for sorting purposes
 	var/list/jobs = list(
 		// Note that jobs divisible by 10 are considered heads of staff, and bolded
-		// 00: Captain
-		JOB_CAPTAIN = 00,
+		// 01: Captain
+		JOB_CAPTAIN = 01,
 		// 10-19: Security
 		JOB_HEAD_OF_SECURITY = 10,
 		JOB_WARDEN = 11,
 		JOB_SECURITY_OFFICER = 12,
-		JOB_SECURITY_OFFICER_MEDICAL = 13,
-		JOB_SECURITY_OFFICER_ENGINEERING = 14,
-		JOB_SECURITY_OFFICER_SCIENCE = 15,
-		JOB_SECURITY_OFFICER_SUPPLY = 16,
 		JOB_DETECTIVE = 17,
 		// 20-29: Medbay
 		JOB_CHIEF_MEDICAL_OFFICER = 20,
@@ -159,6 +155,22 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// ANYTHING ELSE = UNKNOWN_JOB_ID, Unknowns/custom jobs will appear after civilians, and before assistants
 		JOB_ASSISTANT = 999,
 	)
+
+/datum/crewmonitor/New()
+	setup_jobs()
+
+/datum/crewmonitor/proc/setup_jobs()
+	for(var/datum/job/jobtype as anything in subtypesof(/datum/job))
+		var/datum/job/job = SSjob.GetJobType(jobtype)
+		if(isnull(job))
+			continue
+		var/job_prio = isnum(job.crewmonitor_priority) ? job.crewmonitor_priority : jobs[job.title]
+		if(!isnum(job_prio))
+			continue
+
+		var/list/all_titles = job.get_titles()
+		for(var/i in 1 to length(all_titles))
+			jobs[all_titles[i]] = job_prio + (0.1 * (i - 1))
 
 /datum/crewmonitor/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -157,9 +157,14 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	)
 
 /datum/crewmonitor/New()
-	setup_jobs()
+	if(SSjob.initialized)
+		setup_jobs()
+	else
+		RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, PROC_REF(setup_jobs))
 
 /datum/crewmonitor/proc/setup_jobs()
+	SIGNAL_HANDLER
+
 	for(var/datum/job/jobtype as anything in subtypesof(/datum/job))
 		var/datum/job/job = SSjob.GetJobType(jobtype)
 		if(isnull(job))
@@ -171,6 +176,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		var/list/all_titles = job.get_titles()
 		for(var/i in 1 to length(all_titles))
 			jobs[all_titles[i]] = job_prio + (0.1 * (i - 1))
+
+	UnregisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 
 /datum/crewmonitor/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1,9 +1,3 @@
-/**
- * x1, y1, x2, y2 - Represents the bounding box for the ID card's non-transparent portion of its various icon_states.
- * Used to crop the ID card's transparency away when chaching the icon for better use in tgui chat.
- */
-#define ID_ICON_BORDERS 1, 9, 32, 24
-
 /// Fallback time if none of the config entries are set for USE_LOW_LIVING_HOUR_INTERN
 #define INTERN_THRESHOLD_FALLBACK_HOURS 15
 
@@ -37,6 +31,8 @@
 
 	/// Cached icon that has been built for this card. Intended to be displayed in chat. Cardboards IDs and actual IDs use it.
 	var/icon/cached_flat_icon
+	///What is our honorific name/title combo to be displayed?
+	var/honorific_title
 
 /obj/item/card/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins to swipe [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -111,6 +107,11 @@
 	/// Boolean value. If TRUE, the [Intern] tag gets prepended to this ID card when the label is updated.
 	var/is_intern = FALSE
 
+	/// Will this ID card use the first or last name as the name displayed with the honorific?
+	var/honorific_position = HONORIFIC_POSITION_DISABLED
+	/// What is our selected honorific?
+	var/chosen_honorific
+
 /datum/armor/card_id
 	fire = 100
 	acid = 100
@@ -151,6 +152,19 @@
 	if (my_store)
 		QDEL_NULL(my_store)
 	return ..()
+
+/obj/item/card/id/proc/get_message_name_part(mob/living/carbon/carbon_human, list/stored_name)
+	var/voice_name = carbon_human.GetVoice()
+	var/end_string = ""
+	var/return_string = ""
+	if(carbon_human.name != voice_name)
+		end_string += " (as [registered_name])"
+	if(trim && honorific_position != HONORIFIC_POSITION_DISABLED && (carbon_human.name == voice_name)) //The voice and name are the same, so we display the title.
+		return_string += honorific_title
+	else
+		return_string += voice_name //Name on the ID ain't the same as the speaker, so we display their real name with no title.
+	return_string += end_string
+	stored_name[NAME_PART_INDEX] = return_string
 
 /obj/item/card/id/get_id_examine_strings(mob/user)
 	. = ..()
@@ -450,6 +464,8 @@
 		context[SCREENTIP_CONTEXT_ALT_RMB] = "Assign account"
 	if(!registered_account.replaceable || registered_account.account_balance > 0)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
+	if(trim && length(trim.honorifics))
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle honorific"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/proc/try_project_paystand(mob/user, turf/target)
@@ -752,7 +768,7 @@
 	for(var/mob/living/carbon/human/viewing_mob in viewers(user, 2))
 		if(viewing_mob.stat || viewing_mob == user)
 			continue
-		viewing_mob.say("Is something wrong? [user.first_name()]... you're sweating.", forced = "psycho")
+		viewing_mob.say("Is something wrong? [first_name(user.name)]... you're sweating.", forced = "psycho")
 		break
 
 /obj/item/card/id/examine_more(mob/user)
@@ -809,7 +825,16 @@
 
 /// Updates the name based on the card's vars and state.
 /obj/item/card/id/proc/update_label()
-	var/name_string = registered_name ? "[registered_name]'s ID Card" : initial(name)
+	var/name_string
+	if(registered_name)
+		update_honorific()
+		if(honorific_title)
+			name_string = "[honorific_title]'s ID Card"
+		else
+			name_string = "[registered_name]'s ID Card"
+	else
+		name_string = initial(name)
+
 	var/assignment_string
 
 	if(is_intern)
@@ -822,6 +847,27 @@
 
 	name = "[name_string] ([assignment_string])"
 
+/// Re-generates the honorific title.
+/obj/item/card/id/proc/update_honorific()
+	honorific_title = null
+	if(trim && (!chosen_honorific || !(chosen_honorific in trim.honorifics)))
+		if(!length(trim.honorifics))
+			chosen_honorific = null
+			return
+		chosen_honorific = trim.honorifics[1]
+
+	switch(honorific_position)
+		if(HONORIFIC_POSITION_DISABLED)
+			return
+		if(HONORIFIC_POSITION_FIRST)
+			honorific_title = "[chosen_honorific] [first_name(registered_name)]"
+		if(HONORIFIC_POSITION_LAST)
+			honorific_title = "[chosen_honorific] [last_name(registered_name)]"
+		if(HONORIFIC_POSITION_FIRST_FULL)
+			honorific_title = "[chosen_honorific] [registered_name]"
+		if(HONORIFIC_POSITION_LAST_FULL)
+			honorific_title += "[registered_name][chosen_honorific]"
+
 /// Returns the trim assignment name.
 /obj/item/card/id/proc/get_trim_assignment()
 	return trim?.assignment || assignment
@@ -829,6 +875,62 @@
 /// Returns the trim sechud icon state.
 /obj/item/card/id/proc/get_trim_sechud_icon_state()
 	return trim?.sechud_icon_state || SECHUD_UNKNOWN
+
+/obj/item/card/id/CtrlClick(mob/user)
+	. = ..()
+	if(. == FALSE)
+		return
+	if(!in_contents_of(user) || user.incapacitated()) //Check if the ID is in the ID slot, so it can be changed from there too.
+		return
+
+	if(!trim)
+		balloon_alert(user, "card has no trim!")
+		return
+
+	if(!length(trim.honorifics))
+		balloon_alert(user, "card has no honorific to use!")
+		return
+
+	var/list/choices = list()
+	var/list/readable_names = HONORIFIC_POSITION_BITFIELDS()
+	var/default_honorific
+	var/possible_positions = trim.honorific_positions | initial(honorific_position)
+	for(var/i in readable_names) //Filter out the options you don't have on your ID.
+		if(possible_positions & readable_names[i])
+			choices += i
+		if(initial(honorific_position) & readable_names[i])
+			default_honorific = i
+
+	var/chosen_position = tgui_input_list(user, "What position do you want your honorific in?", "Flair!", choices, default_honorific)
+	if(user.incapacitated() || !in_contents_of(user) || !chosen_position)
+		return
+
+	var/honorific_position_to_use = readable_names[chosen_position]
+	if(honorific_position_to_use == HONORIFIC_POSITION_DISABLED)
+		honorific_position = HONORIFIC_POSITION_DISABLED
+		balloon_alert(user, "honorific disabled")
+		update_label()
+		return
+
+	var/new_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics, chosen_honorific || trim.honorifics[1])
+	if(!new_honorific || user.incapacitated() || !in_contents_of(user))
+		return
+	chosen_honorific = new_honorific
+	switch(honorific_position_to_use)
+		if(HONORIFIC_POSITION_FIRST)
+			honorific_position = HONORIFIC_POSITION_FIRST
+			balloon_alert(user, "honorific set: display first name")
+		if(HONORIFIC_POSITION_LAST)
+			honorific_position = HONORIFIC_POSITION_LAST
+			balloon_alert(user, "honorific set: display last name")
+		if(HONORIFIC_POSITION_FIRST_FULL)
+			honorific_position = HONORIFIC_POSITION_FIRST_FULL
+			balloon_alert(user, "honorific set: start of full name")
+		if(HONORIFIC_POSITION_LAST_FULL)
+			honorific_position = HONORIFIC_POSITION_LAST_FULL
+			balloon_alert(user, "honorific set: end of full name")
+
+	update_label()
 
 /obj/item/card/id/away
 	name = "\proper a perfectly generic identification card"
@@ -1687,7 +1789,6 @@
 	icon_state = "ctf_green"
 
 #undef INTERN_THRESHOLD_FALLBACK_HOURS
-#undef ID_ICON_BORDERS
 #undef HOLOPAY_PROJECTION_INTERVAL
 
 #define INDEX_NAME_COLOR 1

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -119,7 +119,15 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//Speaker name
 	var/namepart
 	var/list/stored_name = list(null)
-	SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+
+	if(ishuman(speaker)) //First, try to pull the modified title from a carbon's ID. This will override both visual and audible names.
+		var/mob/living/carbon/human/huspeaker = speaker
+		var/obj/item/card/id/id = huspeaker.get_idcard(hand_first = FALSE)
+		id?.get_message_name_part(huspeaker, stored_name)
+
+	if(!stored_name[NAME_PART_INDEX]) //Otherwise, we just use whatever the name signal gives us.
+		SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
+
 	namepart = stored_name[NAME_PART_INDEX] || "[speaker.GetVoice()]"
 
 	//End name span.

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -291,7 +291,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(tgui_alert(new_character,"Warning: No data core entry detected. Would you like to announce the arrival of this character by adding them to various databases, such as medical records?",,list("No","Yes")) == "Yes")
 			GLOB.manifest.inject(new_character)
 
-		if(tgui_alert(new_character,"Would you like an active AI to announce this character?",,list("No","Yes")) == "Yes")
+		if(tgui_alert(new_character,"Would you like the announcement system to announce this character?",,list("No","Yes")) == "Yes")
 			announce_arrival(new_character, new_character.mind.assigned_role.title)
 
 	var/msg = span_adminnotice("[admin] has respawned [player_key] as [new_character.real_name].")

--- a/code/modules/bitrunning/job.dm
+++ b/code/modules/bitrunning/job.dm
@@ -8,7 +8,7 @@
 	supervisors = SUPERVISOR_QM
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BITRUNNER"
-	outfit = /datum/outfit/job/bitrunner
+	base_outfit = /datum/outfit/job/bitrunner
 	plasmaman_outfit = /datum/outfit/plasmaman/bitrunner
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_CAR

--- a/code/modules/clothing/chameleon/chameleon_action_subtypes.dm
+++ b/code/modules/clothing/chameleon/chameleon_action_subtypes.dm
@@ -164,7 +164,7 @@
 	agent_card.forged = TRUE
 
 	// job_outfit is going to be a path.
-	var/datum/outfit/job/job_outfit = job_datum.outfit
+	var/datum/outfit/job/job_outfit = job_datum.base_outfit
 	if(isnull(job_outfit))
 		return
 

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -50,7 +50,7 @@
 			chosen = pick(list("Help!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "people")] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] in [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]",
-				"[pick("Where's [hallucinator.first_name()]?", "Set [hallucinator.first_name()] to arrest!")]",
+				"[pick("Where's [first_name(hallucinator.name)]?", "Set [first_name(hallucinator.name)] to arrest!")]",
 				"[pick("C","Ai, c","Someone c","Rec")]all the shuttle!",
 				"AI [pick("rogue", "is dead")]!!",
 				"Borgs rogue!",
@@ -58,7 +58,7 @@
 		else
 			chosen = pick(list("[pick_list_replacements(HALLUCINATION_FILE, "suspicion")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "conversation")]",
-				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][hallucinator.first_name()]!",
+				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator.name)]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "getout")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "weird")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "didyouhearthat")]",
@@ -71,7 +71,7 @@
 
 		chosen = capitalize(chosen)
 
-	chosen = replacetext(chosen, "%TARGETNAME%", hallucinator.first_name())
+	chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator.name))
 
 	// Log the message
 	feedback_details += "Type: [is_radio ? "Radio" : "Talk"], Source: [speaker.real_name], Message: [chosen]"

--- a/code/modules/hallucination/fake_death.dm
+++ b/code/modules/hallucination/fake_death.dm
@@ -59,7 +59,7 @@
 				"FUCK",
 				"git gud",
 				"god damn it",
-				"hey [hallucinator.first_name()]",
+				"hey [first_name(hallucinator.name)]",
 				"i[prob(50) ? " fucking" : ""] hate [pick(things_to_hate)]",
 				"is the AI rogue?",
 				"rip",

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -83,12 +83,9 @@
 				return TRUE
 	return FALSE
 
-
 /datum/job/ai/announce_job(mob/living/joining_mob)
-	. = ..()
 	if(SSticker.HasRoundStarted())
 		minor_announce("[joining_mob] has been downloaded to an empty bluespace-networked AI core at [AREACOORD(joining_mob)].")
-
 
 /datum/job/ai/config_check()
 	return CONFIG_GET(flag/allow_ai)

--- a/code/modules/jobs/job_types/assistant/assistant.dm
+++ b/code/modules/jobs/job_types/assistant/assistant.dm
@@ -11,7 +11,7 @@ Assistant
 	spawn_positions = 5
 	supervisors = "absolutely everyone"
 	exp_granted_type = EXP_TYPE_CREW
-	outfit = /datum/outfit/job/assistant
+	base_outfit = /datum/outfit/job/assistant
 	plasmaman_outfit = /datum/outfit/plasmaman
 	paycheck = PAYCHECK_LOWER // Get a job. Job reassignment changes your paycheck now. Get over it.
 
@@ -37,7 +37,7 @@ Assistant
 	rpg_title = "Lout"
 	config_tag = "ASSISTANT"
 
-/datum/job/assistant/get_outfit(consistent)
+/datum/job/assistant/get_outfit(consistent, title)
 	if(consistent)
 		return /datum/outfit/job/assistant/always_grey
 	if(!HAS_TRAIT(SSstation, STATION_TRAIT_ASSISTANT_GIMMICKS))

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -11,7 +11,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "ATMOSPHERIC_TECHNICIAN"
 
-	outfit = /datum/outfit/job/atmos
+	base_outfit = /datum/outfit/job/atmos
 	plasmaman_outfit = /datum/outfit/plasmaman/atmospherics
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -1,5 +1,8 @@
 /datum/job/bartender
 	title = JOB_BARTENDER
+	title_options = list(
+		"Barista",
+	)
 	description = "Serve booze, mix drinks, keep the crew drunk."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
@@ -9,7 +12,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BARTENDER"
 
-	outfit = /datum/outfit/job/bartender
+	base_outfit = /datum/outfit/job/bartender
 	plasmaman_outfit = /datum/outfit/plasmaman/bar
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -9,7 +9,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BOTANIST"
 
-	outfit = /datum/outfit/job/botanist
+	base_outfit = /datum/outfit/job/botanist
 	plasmaman_outfit = /datum/outfit/plasmaman/botany
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -17,7 +17,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CAPTAIN"
 
-	outfit = /datum/outfit/job/captain
+	base_outfit = /datum/outfit/job/captain
 	plasmaman_outfit = /datum/outfit/plasmaman/captain
 
 	paycheck = PAYCHECK_COMMAND

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -11,7 +11,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CARGO_TECHNICIAN"
 
-	outfit = /datum/outfit/job/cargo_tech
+	base_outfit = /datum/outfit/job/cargo_tech
 	plasmaman_outfit = /datum/outfit/plasmaman/cargo
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -35,6 +35,9 @@
 	rpg_title = "Merchantman"
 	job_flags = STATION_JOB_FLAGS
 
+	title_options = list(
+		"Mail Carrier",
+	)
 
 /datum/outfit/job/cargo_tech
 	name = "Cargo Technician"

--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -36,6 +36,9 @@
 
 	job_tone = "holy"
 
+	title_options = list(
+		"Magister",
+	)
 
 /datum/job/chaplain/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()

--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -10,7 +10,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CHAPLAIN"
 
-	outfit = /datum/outfit/job/chaplain
+	base_outfit = /datum/outfit/job/chaplain
 	plasmaman_outfit = /datum/outfit/plasmaman/chaplain
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -37,6 +37,9 @@
 	rpg_title = "Alchemist"
 	job_flags = STATION_JOB_FLAGS
 
+	title_options = list(
+		"Pharmacist",
+	)
 
 /datum/outfit/job/chemist
 	name = "Chemist"

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -12,7 +12,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CHEMIST"
 
-	outfit = /datum/outfit/job/chemist
+	base_outfit = /datum/outfit/job/chemist
 	plasmaman_outfit = /datum/outfit/plasmaman/chemist
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -17,7 +17,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CHIEF_ENGINEER"
 
-	outfit = /datum/outfit/job/ce
+	base_outfit = /datum/outfit/job/ce
 	plasmaman_outfit = /datum/outfit/plasmaman/chief_engineer
 	departments_list = list(
 		/datum/job_department/engineering,

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -17,7 +17,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CHIEF_MEDICAL_OFFICER"
 
-	outfit = /datum/outfit/job/cmo
+	base_outfit = /datum/outfit/job/cmo
 	plasmaman_outfit = /datum/outfit/plasmaman/chief_medical_officer
 	departments_list = list(
 		/datum/job_department/medical,

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -9,7 +9,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CLOWN"
 
-	outfit = /datum/outfit/job/clown
+	base_outfit = /datum/outfit/job/clown
 	plasmaman_outfit = /datum/outfit/plasmaman/clown
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -10,7 +10,7 @@
 	config_tag = "COOK"
 	var/cooks = 0 //Counts cooks amount
 
-	outfit = /datum/outfit/job/cook
+	base_outfit = /datum/outfit/job/cook
 	plasmaman_outfit = /datum/outfit/plasmaman/chef
 
 	paycheck = PAYCHECK_CREW
@@ -58,6 +58,10 @@
 		award_score -= award_status
 	winner.give_award(/datum/award/score/chef_tourist_score, winner.mob, award_score)
 
+/datum/job/cook/get_titles(only_selectable = FALSE)
+	. = ..()
+	if(!only_selectable)
+		. += list(JOB_CHEF)
 
 /datum/outfit/job/cook
 	name = "Cook"

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -10,7 +10,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CORONER"
 
-	outfit = /datum/outfit/job/coroner
+	base_outfit = /datum/outfit/job/coroner
 	plasmaman_outfit = /datum/outfit/plasmaman/coroner
 
 	mind_traits = list(TRAIT_MORBID)

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -10,7 +10,7 @@
 	config_tag = "CURATOR"
 	exp_granted_type = EXP_TYPE_CREW
 
-	outfit = /datum/outfit/job/curator
+	base_outfit = /datum/outfit/job/curator
 	plasmaman_outfit = /datum/outfit/plasmaman/curator
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -36,6 +36,11 @@
 	voice_of_god_silence_power = 3
 	rpg_title = "Veteran Adventurer"
 
+	title_options = list(
+		"Journalist",
+		"Librarian",
+	)
+
 /datum/outfit/job/curator
 	name = "Curator"
 	jobtype = /datum/job/curator

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -14,7 +14,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "DETECTIVE"
 
-	outfit = /datum/outfit/job/detective
+	base_outfit = /datum/outfit/job/detective
 	plasmaman_outfit = /datum/outfit/plasmaman/detective
 	departments_list = list(
 		/datum/job_department/security,

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -11,7 +11,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "GENETICIST"
 
-	outfit = /datum/outfit/job/geneticist
+	base_outfit = /datum/outfit/job/geneticist
 	plasmaman_outfit = /datum/outfit/plasmaman/genetics
 	departments_list = list(
 		/datum/job_department/science,

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -17,7 +17,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "HEAD_OF_PERSONNEL"
 
-	outfit = /datum/outfit/job/hop
+	base_outfit = /datum/outfit/job/hop
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_personnel
 	departments_list = list(
 		/datum/job_department/service,

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -17,7 +17,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "HEAD_OF_SECURITY"
 
-	outfit = /datum/outfit/job/hos
+	base_outfit = /datum/outfit/job/hos
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_security
 	departments_list = list(
 		/datum/job_department/security,

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -9,7 +9,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "JANITOR"
 
-	outfit = /datum/outfit/job/janitor
+	base_outfit = /datum/outfit/job/janitor
 	plasmaman_outfit = /datum/outfit/plasmaman/janitor
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -10,7 +10,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "LAWYER"
 
-	outfit = /datum/outfit/job/lawyer
+	base_outfit = /datum/outfit/job/lawyer
 	plasmaman_outfit = /datum/outfit/plasmaman/bar
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -1,5 +1,9 @@
 /datum/job/doctor
 	title = JOB_MEDICAL_DOCTOR
+	title_options = list(
+		"Surgeon" = /datum/outfit/job/doctor/surgeon,
+		"Nurse" = /datum/outfit/job/doctor/nurse,
+	)
 	description = "Save lives, run around the station looking for victims, \
 		scan everyone in sight"
 	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
@@ -10,7 +14,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "MEDICAL_DOCTOR"
 
-	outfit = /datum/outfit/job/doctor
+	base_outfit = /datum/outfit/job/doctor
 	plasmaman_outfit = /datum/outfit/plasmaman/medical
 
 	paycheck = PAYCHECK_CREW
@@ -44,12 +48,11 @@
 	jobtype = /datum/job/doctor
 
 	id_trim = /datum/id_trim/job/medical_doctor
-	uniform = /obj/item/clothing/under/rank/medical/scrubs/blue
+	uniform = /obj/item/clothing/under/rank/medical/doctor
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	suit_store = /obj/item/flashlight/pen
 	belt = /obj/item/modular_computer/pda/medical
 	ears = /obj/item/radio/headset/headset_med
-	head = /obj/item/clothing/head/utility/surgerycap
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	l_hand = /obj/item/storage/medkit/surgery
 
@@ -61,6 +64,24 @@
 	box = /obj/item/storage/box/survival/medical
 	chameleon_extras = /obj/item/gun/syringe
 	skillchips = list(/obj/item/skillchip/entrails_reader)
+
+/datum/outfit/job/doctor/nurse
+	name = "Nurse"
+
+	suit = null
+	suit_store = null
+	id_trim = /datum/id_trim/job/medical_doctor/nurse
+	backpack_contents = list(/obj/item/flashlight/pen)
+
+/datum/outfit/job/doctor/surgeon
+	name = "Surgeon"
+
+	uniform = /obj/item/clothing/under/rank/medical/scrubs/blue
+	id_trim = /datum/id_trim/job/medical_doctor/surgeon
+	head = /obj/item/clothing/head/utility/surgerycap
+	suit = /obj/item/clothing/suit/apron/surgical
+	suit_store = null
+	backpack_contents = list(/obj/item/flashlight/pen)
 
 /datum/outfit/job/doctor/mod
 	name = "Medical Doctor (MODsuit)"

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -9,7 +9,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "MIME"
 
-	outfit = /datum/outfit/job/mime
+	base_outfit = /datum/outfit/job/mime
 	plasmaman_outfit = /datum/outfit/plasmaman/mime
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -10,7 +10,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "PARAMEDIC"
 
-	outfit = /datum/outfit/job/paramedic
+	base_outfit = /datum/outfit/job/paramedic
 	plasmaman_outfit = /datum/outfit/plasmaman/paramedic
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -10,7 +10,7 @@
 	paycheck = PAYCHECK_LOWER
 	config_tag = "PRISONER"
 
-	outfit = /datum/outfit/job/prisoner
+	base_outfit = /datum/outfit/job/prisoner
 	plasmaman_outfit = /datum/outfit/plasmaman/prisoner
 
 	display_order = JOB_DISPLAY_ORDER_PRISONER

--- a/code/modules/jobs/job_types/psychologist.dm
+++ b/code/modules/jobs/job_types/psychologist.dm
@@ -1,5 +1,8 @@
 /datum/job/psychologist
 	title = JOB_PSYCHOLOGIST
+	title_options = list(
+		"Psychiatrist",
+	)
 	description = "Advocate sanity, self-esteem, and teamwork in a station \
 		staffed with headcases."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
@@ -10,7 +13,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "PSYCHOLOGIST"
 
-	outfit = /datum/outfit/job/psychologist
+	base_outfit = /datum/outfit/job/psychologist
 	plasmaman_outfit = /datum/outfit/plasmaman/psychologist
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -14,7 +14,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "QUARTERMASTER"
 
-	outfit = /datum/outfit/job/quartermaster
+	base_outfit = /datum/outfit/job/quartermaster
 	plasmaman_outfit = /datum/outfit/plasmaman/cargo
 
 	paycheck = PAYCHECK_COMMAND

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -18,7 +18,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "RESEARCH_DIRECTOR"
 
-	outfit = /datum/outfit/job/rd
+	base_outfit = /datum/outfit/job/rd
 	plasmaman_outfit = /datum/outfit/plasmaman/research_director
 	departments_list = list(
 		/datum/job_department/science,

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -12,7 +12,7 @@
 	bounty_types = CIV_JOB_ROBO
 	config_tag = "ROBOTICIST"
 
-	outfit = /datum/outfit/job/roboticist
+	base_outfit = /datum/outfit/job/roboticist
 	plasmaman_outfit = /datum/outfit/plasmaman/robotics
 	departments_list = list(
 		/datum/job_department/science,

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -11,7 +11,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "SCIENTIST"
 
-	outfit = /datum/outfit/job/scientist
+	base_outfit = /datum/outfit/job/scientist
 	plasmaman_outfit = /datum/outfit/plasmaman/science
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -14,7 +14,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "SECURITY_OFFICER"
 
-	outfit = /datum/outfit/job/security
+	base_outfit = /datum/outfit/job/security
 	plasmaman_outfit = /datum/outfit/plasmaman/security
 
 	paycheck = PAYCHECK_CREW
@@ -40,6 +40,15 @@
 	rpg_title = "Guard"
 	job_flags = STATION_JOB_FLAGS
 
+/datum/job/security_officer/get_titles(only_selectable = FALSE)
+	. = ..()
+	if(!only_selectable)
+		. += list(
+			JOB_SECURITY_OFFICER_MEDICAL,
+			JOB_SECURITY_OFFICER_ENGINEERING,
+			JOB_SECURITY_OFFICER_SUPPLY,
+			JOB_SECURITY_OFFICER_SCIENCE,
+		)
 
 GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, SEC_DEPT_SCIENCE, SEC_DEPT_SUPPLY))
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -10,7 +10,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "SHAFT_MINER"
 
-	outfit = /datum/outfit/job/miner
+	base_outfit = /datum/outfit/job/miner
 	plasmaman_outfit = /datum/outfit/plasmaman/mining
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -12,7 +12,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "STATION_ENGINEER"
 
-	outfit = /datum/outfit/job/engineer
+	base_outfit = /datum/outfit/job/engineer
 	plasmaman_outfit = /datum/outfit/plasmaman/engineering
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
+++ b/code/modules/jobs/job_types/station_trait/bridge_assistant.dm
@@ -13,7 +13,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BRIDGE_ASSISTANT"
 
-	outfit = /datum/outfit/job/bridge_assistant
+	base_outfit = /datum/outfit/job/bridge_assistant
 	plasmaman_outfit = /datum/outfit/plasmaman/bridge_assistant
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -12,7 +12,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "VIROLOGIST"
 
-	outfit = /datum/outfit/job/virologist
+	base_outfit = /datum/outfit/job/virologist
 	plasmaman_outfit = /datum/outfit/plasmaman/viro
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -15,7 +15,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "WARDEN"
 
-	outfit = /datum/outfit/job/warden
+	base_outfit = /datum/outfit/job/warden
 	plasmaman_outfit = /datum/outfit/plasmaman/warden
 
 	paycheck = PAYCHECK_CREW

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -216,10 +216,7 @@
 
 	if(humanc) //These procs all expect humans
 		GLOB.manifest.inject(humanc)
-		if(SSshuttle.arrivals)
-			SSshuttle.arrivals.QueueAnnounce(humanc, rank)
-		else
-			announce_arrival(humanc, rank)
+		announce_arrival(humanc, rank, try_queue = TRUE)
 		AddEmploymentContract(humanc)
 
 		humanc.increment_scar_slot()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -187,18 +187,6 @@
 			return M
 	return 0
 
-///Find the first name of a mob from the real name with regex
-/mob/proc/first_name()
-	var/static/regex/firstname = new("^\[^\\s-\]+") //First word before whitespace or "-"
-	firstname.Find(real_name)
-	return firstname.match
-
-/// Find the last name of a mob from the real name with regex
-/mob/proc/last_name()
-	var/static/regex/lasttname = new("\[^\\s-\]+$") //First word before whitespace or "-"
-	lasttname.Find(real_name)
-	return lasttname.match
-
 ///Returns a mob's real name between brackets. Useful when you want to display a mob's name alongside their real name
 /mob/proc/get_realname_string()
 	if(real_name && real_name != name)

--- a/code/modules/unit_tests/traitor.dm
+++ b/code/modules/unit_tests/traitor.dm
@@ -17,7 +17,7 @@
 		var/datum/mind/mind = player.mind
 		if(ishuman(player))
 			var/mob/living/carbon/human/human = player
-			human.equipOutfit(job.outfit)
+			human.equipOutfit(job.base_outfit)
 		mind.set_assigned_role(job)
 		var/datum/antagonist/traitor/traitor = mind.add_antag_datum(/datum/antagonist/traitor)
 		if(!traitor.uplink_handler)

--- a/maplestation_modules/code/modules/jobs/job_types/_job.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/_job.dm
@@ -3,15 +3,3 @@
 	/// Bitflags of factions this job itself can be associated with.
 	/// Alternative to checking for faction on the mind, since faction isn't very consistent
 	var/faction_alignment
-	/// Priority for the job on the crew monitor.
-	var/crewmonitor_priority = -1
-
-// Update crew monitor with new jobs
-/datum/crewmonitor/New()
-	. = ..()
-	for(var/datum/job/jobtype as anything in subtypesof(/datum/job))
-		if(!(initial(jobtype.job_flags) & JOB_NEW_PLAYER_JOINABLE))
-			continue
-		if(jobtype.crewmonitor_priority < 0)
-			continue
-		jobs[jobtype.title] = jobtype.crewmonitor_priority

--- a/maplestation_modules/code/modules/jobs/job_types/asset_protection.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/asset_protection.dm
@@ -18,7 +18,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "ASSET_PROTECTION"
 
-	outfit = /datum/outfit/job/asset_protection
+	base_outfit = /datum/outfit/job/asset_protection
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_security // lazy reuse
 
 	paycheck = PAYCHECK_COMMAND

--- a/maplestation_modules/code/modules/jobs/job_types/bridge_officer.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/bridge_officer.dm
@@ -23,7 +23,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BRIDGE_OFFICER"
 
-	outfit = /datum/outfit/job/bridge_officer
+	base_outfit = /datum/outfit/job/bridge_officer
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_personnel // lazy reuse
 
 	paycheck = PAYCHECK_COMMAND

--- a/maplestation_modules/code/modules/jobs/job_types/noble_ambassador.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/noble_ambassador.dm
@@ -19,7 +19,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "NOBLE_AMBASSADOR"
 
-	outfit = /datum/outfit/job/noble_ambassador
+	base_outfit = /datum/outfit/job/noble_ambassador
 	plasmaman_outfit = /datum/outfit/plasmaman // no outfit yet
 
 	paycheck = PAYCHECK_COMMAND

--- a/maplestation_modules/code/modules/jobs/job_types/ordnance_tech.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/ordnance_tech.dm
@@ -17,7 +17,7 @@
 
 //most likely can be subtyped later
 
-	outfit = /datum/outfit/job/scientist/ordnance_tech
+	base_outfit = /datum/outfit/job/scientist/ordnance_tech
 	plasmaman_outfit = /datum/outfit/plasmaman/science
 
 	paycheck = PAYCHECK_CREW

--- a/maplestation_modules/code/modules/jobs/job_types/stowaway.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/stowaway.dm
@@ -12,7 +12,7 @@
 	config_tag = "STOWAWAY"
 	faction = FACTION_STATION
 
-	outfit = /datum/outfit/job/stowaway
+	base_outfit = /datum/outfit/job/stowaway
 	plasmaman_outfit = /datum/outfit/job/stowaway/plasmaman
 
 	paycheck = PAYCHECK_ZERO
@@ -101,7 +101,7 @@
 			backstory_gist = "You are a former [old_job.title], [reasons]. You've snuck on board to get your old position back."
 			backstory_suggested_goal = "Get your job as [old_job.title] back, and prove yourself - or find a new calling."
 
-			var/datum/outfit/job/job_outfit = old_job.outfit
+			var/datum/outfit/job/job_outfit = old_job.base_outfit
 			backstory_equipment_items = list(
 				initial(job_outfit.uniform) = ITEM_SLOT_BACKPACK,
 				initial(job_outfit.head) = ITEM_SLOT_BACKPACK,

--- a/maplestation_modules/code/modules/jobs/job_types/xenobiologist.dm
+++ b/maplestation_modules/code/modules/jobs/job_types/xenobiologist.dm
@@ -12,7 +12,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "XENOBIO"
 
-	outfit = /datum/outfit/job/scientist/xenobiologist
+	base_outfit = /datum/outfit/job/scientist/xenobiologist
 	plasmaman_outfit = /datum/outfit/plasmaman/science
 
 	paycheck = PAYCHECK_CREW

--- a/tgui/packages/tgui/interfaces/CrewConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.jsx
@@ -17,10 +17,10 @@ const HEALTH_COLOR_BY_LEVEL = [
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
 
-const jobIsHead = (jobId) => jobId % 10 === 0;
+const jobIsHead = (jobId) => jobId === 1 || jobId % 10 === 0;
 
 const jobToColor = (jobId) => {
-  if (jobId === 0) {
+  if (jobId === 1) {
     return COLORS.department.captain;
   }
   if (jobId >= 10 && jobId < 20) {

--- a/tgui/packages/tgui/interfaces/JobSelection.tsx
+++ b/tgui/packages/tgui/interfaces/JobSelection.tsx
@@ -109,11 +109,10 @@ export const JobSelection = (props) => {
     data.departments_static,
   );
 
+  act('ui_mounted_with_no_bluescreen');
+
   return (
-    <Window
-      width={1012}
-      height={data.shuttle_status ? 690 : 666 /* Hahahahahaha */}
-    >
+    <Window width={1012} height={data.shuttle_status ? 790 : 766}>
       <Window.Content scrollable>
         <StyleableSection
           title={

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
@@ -174,7 +174,7 @@ const PriorityButtons = (props: {
 };
 
 const JobRow = (props: { className?: string; job: Job; name: string }) => {
-  const { data } = useBackend<PreferencesMenuData>();
+  const { data, act } = useBackend<PreferencesMenuData>();
   const { className, job, name } = props;
 
   const isOverflow = data.overflow_role === name;
@@ -226,17 +226,31 @@ const JobRow = (props: { className?: string; job: Job; name: string }) => {
   }
 
   return (
-    <Stack.Item className={className} height="100%" mt={0}>
+    <Box className={className} height="25px" mt={0}>
       <Stack fill align="center">
         <Tooltip content={job.description} position="bottom-start">
           <Stack.Item
             className="job-name"
-            width="50%"
+            width="63%"
             style={{
               paddingLeft: '0.3em',
             }}
           >
-            {name}
+            {job.title_options.length > 1 ? (
+              <Dropdown
+                width="100%"
+                options={job.title_options}
+                selected={data.job_titles[name] || name}
+                onSelected={(value) =>
+                  act('set_title_preference', {
+                    base_title: name,
+                    new_title: value,
+                  })
+                }
+              />
+            ) : (
+              name
+            )}
           </Stack.Item>
         </Tooltip>
 
@@ -244,7 +258,7 @@ const JobRow = (props: { className?: string; job: Job; name: string }) => {
           {rightSide}
         </Stack.Item>
       </Stack>
-    </Stack.Item>
+    </Box>
   );
 };
 
@@ -277,21 +291,19 @@ const Department = (props: { department: string } & PropsWithChildren) => {
 
         return (
           <Box>
-            <Stack vertical fill>
-              {jobsForDepartment.map(([name, job]) => {
-                return (
-                  <JobRow
-                    className={classes([
-                      className,
-                      name === department.head && 'head',
-                    ])}
-                    key={name}
-                    job={job}
-                    name={name}
-                  />
-                );
-              })}
-            </Stack>
+            {jobsForDepartment.map(([name, job]) => {
+              return (
+                <JobRow
+                  className={classes([
+                    className,
+                    name === department.head && 'head',
+                  ])}
+                  key={name}
+                  job={job}
+                  name={name}
+                />
+              );
+            })}
 
             {children}
           </Box>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -79,6 +79,7 @@ export type Department = {
 export type Job = {
   description: string;
   department: string;
+  title_options: string[];
 };
 
 export type Quirk = {
@@ -169,6 +170,7 @@ export type PreferencesMenuData = {
     }
   >;
   job_preferences: Record<string, JobPriority>;
+  job_titles: Record<string, string>;
 
   keybindings: Record<string, string[]>;
   overflow_role: string;


### PR DESCRIPTION
UX was inspired by that seen on insert-furry-server-of-choice, but implementation is my own. 

Specifically it lets different titles have different roundstart outfits, inspired by a conversation in coderbus I saw. So "Surgeons" start in full scrubs while "Nurses" start in a normal jumpsuit. 

![image](https://github.com/user-attachments/assets/f0d63b76-c72d-4208-86d7-5039c985f49b)

Maybe we move Xenobiologist and Ordnance to this system, maybe not.
Conceptually I still like having specialist job types, like Virologist, Xenobiologist, Atmospheric Technician. I think so long as a job has a defined workspace it should be its own job rather than an alt title. ("Surgeon", for example, works in the same space as Medical Doctors do, ultimately.) 

Also I don't want to spam this with a bunch of super niche titles. Like titles that are just "a more fancy or less fancy way of saying the same thing". 