### PR TITLE
Captain's Beret is brought up to the modern captain's palette colors, captain's clothes get a protection lookover.

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -130,7 +130,7 @@
 	icon_state = "beret_badge"
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
-	greyscale_colors = "#0070B7#FFCE5B"
+	greyscale_colors = "#41579A#F0CC8F"
 
 //Head of Personnel
 /obj/item/clothing/head/hats/hopcap

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -59,20 +59,17 @@
 	icon_state = "capjacket"
 	inhand_icon_state = "bio_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
-	allowed = list(
-		/obj/item/assembly/flash/handheld,
-		/obj/item/clothing/mask/cigarette,
-		/obj/item/disk,
-		/obj/item/lighter,
-		/obj/item/melee,
-		/obj/item/reagent_containers/cup/glass/flask,
-		/obj/item/stamp,
-		/obj/item/storage/box/matches,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/storage/lockbox/medal,
-		/obj/item/tank/internals/emergency_oxygen,
-		/obj/item/tank/internals/plasmaman,
-	)
+	armor_type = /datum/armor/vest_capcarapace
+	resistance_flags = FIRE_PROOF
+	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
+	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
+	strip_delay = 60
+	equip_delay_other = 40
+	max_integrity = 250
+
+/obj/item/clothing/suit/jacket/capjacket/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 //Chef
 /obj/item/clothing/suit/toggle/chef

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -171,13 +171,15 @@
 	armor_type = /datum/armor/wintercoat_captain
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
-/datum/armor/wintercoat_captain
-	melee = 25
+/datum/armor/wintercoat_captain //modular edit to make it closer to the carapace values, but less because of the bonus of being a winter coat
+	melee = 40
 	bullet = 30
-	laser = 30
+	laser = 40
 	energy = 40
-	bomb = 25
-	acid = 50
+	bomb = 20
+	fire = 100
+	acid = 90
+	wound = 10
 
 /obj/item/clothing/suit/hooded/wintercoat/captain/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -171,7 +171,7 @@
 	armor_type = /datum/armor/wintercoat_captain
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
-/datum/armor/wintercoat_captain //modular edit to make it closer to the carapace values, but less because of the bonus of being a winter coat
+/datum/armor/wintercoat_captain //downstream edit to make it closer to the carapace values, but less because of the bonus of being a winter coat
 	melee = 40
 	bullet = 30
 	laser = 40


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ec85350e-2448-4824-97e6-353c61a26dbf)
the new beret colors

In addition, the Captain's Parade Vest (not to be confused with the parade jacket) now has the stats of captain's armor, aswell as the same equipment allowance. It previously didn't even have any armor. This means you can combine drip and protection, how neat! Felt off anyway that the jacket is so flaunty and yet the austere vest is unusable as armor.

The captain's winter coat has also been brought up in armor. The original values seem to have been copied beforehand from security armor and not captain armor, making it have very off armor values compared to everything else the cap has. Now it's using captain's armor values as a base, but slightly lowered to compensate for winter coats having additional effects.