### PR TITLE
Quick equip from active storage, as well as a hotkey to close storage interfaces, and open equipped/held storage items

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -502,17 +502,21 @@
 			. += item
 
 ///proc extender of [/mob/verb/quick_equip] used to make the verb queuable if the server is overloaded
+
+// NON-MODULE CHANGE START : quick equip to active storage if available
 /mob/proc/execute_quick_equip()
 	var/obj/item/I = get_active_held_item()
 	if(!I)
-		to_chat(src, span_warning("You are not holding anything to equip!"))
-		return
-	if (temporarilyRemoveItemFromInventory(I) && !QDELETED(I))
-		if(I.equip_to_best_slot(src))
-			return
-		if(put_in_active_hand(I))
-			return
-		I.forceMove(drop_location())
+		var/datum/storage/storage = src.active_storage
+		if(storage.real_location.contents.len)
+			var/obj/item/stored = storage.real_location.contents[storage.real_location.contents.len]
+			if(!stored || stored.on_found(src))
+				to_chat(src, span_warning("You are not holding anything to equip!"))
+				return
+			stored.attack_hand(src) // take out thing from item in storage slot
+	if(!QDELETED(I))
+		I.equip_to_best_slot(src)
+// NON-MODULE CHANGE END
 
 //used in code for items usable by both carbon and drones, this gives the proper back slot for each mob.(defibrillator, backpack watertank, ...)
 /mob/proc/getBackSlot()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -494,6 +494,7 @@
 // NON-MODULE CHANGE END
 	var/list/obj/item/possible = list(
 		user.get_inactive_held_item(),
+		user.get_item_by_slot(ITEM_SLOT_SUITSTORE), // NON-MODULE CHANGE : holsters, *maybe* some other things?
 		user.get_item_by_slot(ITEM_SLOT_BELT),
 		user.get_item_by_slot(ITEM_SLOT_DEX_STORAGE),
 		user.get_item_by_slot(ITEM_SLOT_BACK),

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -458,16 +458,40 @@
 
 /// Tries to equip an item, store it in open storage, or in next best storage
 /obj/item/proc/equip_to_best_slot(mob/user)
+// NON-MODULE CHANGE START : prioritize active storage over suit storage and pockets
+	var/slot_priority = src.slot_equipment_priority
+
+	if(!slot_priority)
+		slot_priority = list( \
+			ITEM_SLOT_BACK, ITEM_SLOT_ID,\
+			ITEM_SLOT_ICLOTHING, ITEM_SLOT_OCLOTHING,\
+			ITEM_SLOT_MASK, ITEM_SLOT_HEAD, ITEM_SLOT_NECK,\
+			ITEM_SLOT_FEET, ITEM_SLOT_GLOVES,\
+			ITEM_SLOT_EARS, ITEM_SLOT_EYES,\
+			ITEM_SLOT_BELT\
+		)
+
+	var/can_equip = FALSE
+
+	for(var/slot in slot_priority)
+		if(src.mob_can_equip(user, slot, TRUE, TRUE))
+			can_equip = TRUE
+			break
+
+	if(!can_equip && user.active_storage?.attempt_insert(src, user, messages = FALSE))
+		return TRUE
+
 	if(user.equip_to_appropriate_slot(src))
 		user.update_held_items()
 		return TRUE
 	else
 		if(equip_delay_self)
 			return
-
+/*
 	if(user.active_storage?.attempt_insert(src, user, messages = FALSE))
 		return TRUE
-
+*/
+// NON-MODULE CHANGE END
 	var/list/obj/item/possible = list(
 		user.get_inactive_held_item(),
 		user.get_item_by_slot(ITEM_SLOT_BELT),

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -508,7 +508,7 @@
 	var/obj/item/I = get_active_held_item()
 	if(!I)
 		var/datum/storage/storage = src.active_storage
-		if(storage.real_location.contents.len)
+		if(storage?.real_location.contents.len)
 			var/obj/item/stored = storage.real_location.contents[storage.real_location.contents.len]
 			if(!stored || stored.on_found(src))
 				to_chat(src, span_warning("You are not holding anything to equip!"))

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6506,6 +6506,7 @@
 #include "maplestation_modules\code\modules\projectiles\projectile\bullets\shotgun.dm"
 #include "maplestation_modules\code\modules\projectiles\projectile\energy\laser.dm"
 #include "maplestation_modules\code\modules\projectiles\projectile\energy\ppc.dm"
+#include "maplestation_modules\code\modules\quick_store\open_close_storage.dm"
 #include "maplestation_modules\code\modules\radio_emote_helper\emote_helper.dm"
 #include "maplestation_modules\code\modules\reagents\machines.dm"
 #include "maplestation_modules\code\modules\reagents\chemistry\reagents\drink_reagents.dm"

--- a/maplestation_modules/code/__DEFINES/keybinding.dm
+++ b/maplestation_modules/code/__DEFINES/keybinding.dm
@@ -2,3 +2,4 @@
 #define COMSIG_KB_CLIENT_LOOC_DOWN "keybinding_client_looc_down"
 #define COMSIG_KB_MOB_PIXEL_SHIFT_DOWN "keybinding_mob_pixel_shift_down"
 #define COMSIG_KB_MOB_PIXEL_SHIFT_UP "keybinding_mob_pixel_shift_up"
+#define COMSIG_KB_HUMAN_OPENCLOSESTORAGE_DOWN "keybinding_human_opencclosestorage_down"

--- a/maplestation_modules/code/modules/quick_store/open_close_storage.dm
+++ b/maplestation_modules/code/modules/quick_store/open_close_storage.dm
@@ -20,6 +20,7 @@
 	user.get_inactive_held_item(),
 	user.get_item_by_slot(ITEM_SLOT_BACK),
 	user.get_item_by_slot(ITEM_SLOT_BELT),
+	user.get_item_by_slot(ITEM_SLOT_SUITSTORE),
 	)
 	for(var/thing in possible)
 		if(isnull(thing))

--- a/maplestation_modules/code/modules/quick_store/open_close_storage.dm
+++ b/maplestation_modules/code/modules/quick_store/open_close_storage.dm
@@ -1,0 +1,43 @@
+/datum/keybinding/human/open_close_storage
+	hotkey_keys = list("ShiftR")
+	name = "open_close_storage"
+	full_name = "Open or close storage"
+	description = "Close the current storage interface, or open worn storage if available"
+	keybind_signal = COMSIG_KB_HUMAN_OPENCLOSESTORAGE_DOWN
+
+/datum/keybinding/human/open_close_storage/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/human/human = user.mob
+	human.open_close_storage()
+	return TRUE
+
+/mob/living/carbon/human/proc/open_best_storage(mob/user)
+
+	var/list/obj/item/possible = list(
+	user.get_active_held_item(),
+	user.get_inactive_held_item(),
+	user.get_item_by_slot(ITEM_SLOT_BACK),
+	user.get_item_by_slot(ITEM_SLOT_BELT),
+	)
+	for(var/thing in possible)
+		if(isnull(thing))
+			continue
+		var/obj/item/gear = thing
+		if(gear.atom_storage?.open_storage(user))
+			return TRUE
+
+/mob/living/carbon/human/verb/open_close_storage()
+	set name = "open-close-storage"
+	set hidden = TRUE
+
+	DEFAULT_QUEUE_OR_CALL_VERB(VERB_CALLBACK(src, PROC_REF(execute_open_close_storage)))
+
+/mob/living/carbon/human/proc/execute_open_close_storage()
+	var/datum/storage/storage = src.active_storage
+	if(storage)
+		storage.hide_contents(src)
+		return
+	open_best_storage(src)
+	return

--- a/maplestation_modules/code/modules/quick_store/open_close_storage.dm
+++ b/maplestation_modules/code/modules/quick_store/open_close_storage.dm
@@ -2,7 +2,7 @@
 	hotkey_keys = list("ShiftR")
 	name = "open_close_storage"
 	full_name = "Open or close storage"
-	description = "Close the current storage interface, or open worn storage if available"
+	description = "Close the current storage interface, or open equipped storage if available"
 	keybind_signal = COMSIG_KB_HUMAN_OPENCLOSESTORAGE_DOWN
 
 /datum/keybinding/human/open_close_storage/down(client/user)

--- a/maplestation_modules/code/modules/quick_store/open_close_storage.dm
+++ b/maplestation_modules/code/modules/quick_store/open_close_storage.dm
@@ -1,7 +1,7 @@
 /datum/keybinding/human/open_close_storage
 	hotkey_keys = list("ShiftR")
 	name = "open_close_storage"
-	full_name = "Open or close storage"
+	full_name = "Open/Close storage"
 	description = "Close the current storage interface, or open equipped storage if available"
 	keybind_signal = COMSIG_KB_HUMAN_OPENCLOSESTORAGE_DOWN
 


### PR DESCRIPTION
As it says on the tin, this PR makes it so if you have a storage open and an empty hand, pressing quick equip (E by default) will try to pull items from it, this PR also adds a new hotkey (defaulting to Shift+R) to close open storage, or open storage on your person (in order from held storage items, then the backpack, then the belt, if higher priority slots are empty.)

this PR also makes it so active storage is prioritized over suit storage/pockets when quick equipping something into storage.

also if anyone can think of a better name for the new hotkey than "open/close storage" I'd also appreciate that.
