### PR TITLE
Security Cameras indicate if an AI or a security console is seeing through them

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -421,12 +421,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 					above = GET_TURF_ABOVE(above)
 	return see
 
-/obj/machinery/camera/proc/Togglelight(on=0)
-	for(var/mob/living/silicon/ai/A in GLOB.ai_list)
-		for(var/obj/machinery/camera/cam in A.lit_cameras)
-			if(cam == src)
-				return
-	if(on)
+/obj/machinery/camera/proc/toggle_ai_light(mob/ai_source, on = FALSE)
+	// don't turf off if another ai is also using the camera
+	for(var/mob/living/silicon/ai/other_ai as anything in GLOB.ai_list - ai_source)
+		if(other_ai.camera_light_on && (src in other_ai.eyeobj?.cameras_near_eye))
+			return
+	if(on && internal_light)
 		set_light(AI_CAMERA_LUMINOSITY)
 	else
 		set_light(0)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -108,13 +108,8 @@
 
 	if(action == "switch_camera")
 		var/obj/machinery/camera/selected_camera = locate(params["camera"]) in GLOB.cameranet.cameras
-		active_camera = selected_camera
+		set_active_camera(selected_camera)
 		playsound(src, SFX_TERMINAL_TYPE, 25, FALSE)
-
-		if(isnull(active_camera))
-			return TRUE
-
-		update_active_camera_screen()
 
 		return TRUE
 
@@ -161,9 +156,33 @@
 	cam_screen.hide_from(user)
 	// Turn off the console
 	if(length(concurrent_users) == 0 && is_living)
-		active_camera = null
-		last_camera_turf = null
+		clear_active_camera()
 		playsound(src, 'sound/machines/terminal_off.ogg', 25, FALSE)
+
+/obj/machinery/computer/security/proc/set_active_camera(obj/machinery/camera/new_cam)
+	if(active_camera)
+		clear_active_camera()
+
+	if(isnull(new_cam))
+		return
+
+	active_camera = new_cam
+	active_camera.in_use_lights++
+	active_camera.update_appearance()
+	RegisterSignal(new_cam, COMSIG_QDELETING, PROC_REF(clear_active_camera))
+	update_active_camera_screen()
+
+/obj/machinery/computer/security/proc/clear_active_camera()
+	SIGNAL_HANDLER
+	if(isnull(active_camera))
+		return
+	active_camera.in_use_lights--
+	active_camera.update_appearance()
+	active_camera = null
+	last_camera_turf = null
+	if(QDELING(src))
+		return
+	update_active_camera_screen()
 
 /atom/movable/screen/map_view/camera
 	/// All the plane masters that need to be applied.

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -210,24 +210,27 @@
 	return null
 
 /mob/camera/ai_eye/remote/setLoc(turf/destination, force_update = FALSE)
-	if(eye_user)
-		destination = get_turf(destination)
-		if (destination)
-			abstract_move(destination)
-		else
-			moveToNullspace()
+	if(isnull(eye_user))
+		return
+	destination = get_turf(destination)
+	if (destination)
+		abstract_move(destination)
+	else
+		moveToNullspace()
 
-		update_ai_detect_hud()
+	update_ai_detect_hud()
 
-		if(use_static)
-			GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
+	if(use_static)
+		GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
 
-		if(visible_icon)
-			if(eye_user.client)
-				eye_user.client.images -= user_image
-				user_image = image(icon,loc,icon_state, FLY_LAYER)
-				SET_PLANE(user_image, ABOVE_GAME_PLANE, destination)
-				eye_user.client.images += user_image
+	if(visible_icon)
+		if(eye_user.client)
+			eye_user.client.images -= user_image
+			user_image = image(icon,loc,icon_state, FLY_LAYER)
+			SET_PLANE(user_image, ABOVE_GAME_PLANE, destination)
+			eye_user.client.images += user_image
+
+	update_cameras()
 
 /mob/camera/ai_eye/remote/relaymove(mob/living/user, direction)
 	var/initial = initial(sprint)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -24,6 +24,8 @@
 	///Should we supress any view changes?
 	var/should_supress_view_changes = TRUE
 
+	var/alerts_cameras = TRUE
+
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_REQUIRES_SIGHT
 
 /obj/machinery/computer/camera_advanced/Initialize(mapload)
@@ -58,6 +60,7 @@
 /obj/machinery/computer/camera_advanced/syndie
 	icon_keyboard = "syndie_key"
 	circuit = /obj/item/circuitboard/computer/advanced_camera
+	alerts_cameras = FALSE
 
 /obj/machinery/computer/camera_advanced/syndie/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	return //For syndie nuke shuttle, to spy for station.
@@ -65,6 +68,7 @@
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()
 	eyeobj.origin = src
+	eyeobj.set_telegraph(alerts_cameras)
 
 /obj/machinery/computer/camera_advanced/proc/GrantActions(mob/living/user)
 	for(var/datum/action/to_grant as anything in actions)

--- a/code/game/objects/structures/construction_console/construction_console.dm
+++ b/code/game/objects/structures/construction_console/construction_console.dm
@@ -17,6 +17,7 @@
 	icon_screen = "mining"
 	icon_keyboard = "rd_key"
 	light_color = LIGHT_COLOR_PINK
+	alerts_cameras = FALSE
 	///Area that the eyeobj will be constrained to. If null, eyeobj will be able to build and move anywhere.
 	var/area/allowed_area
 	///Assoc. list ("structure_name" : count) that keeps track of the number of special structures that can't be built with an RCD, for example, tiny fans or turrets.
@@ -63,6 +64,7 @@
 		return FALSE
 	eyeobj = new /mob/camera/ai_eye/remote/base_construction(spawn_spot, src)
 	eyeobj.origin = src
+	eyeobj.set_telegraph(alerts_cameras)
 	return TRUE
 
 /obj/machinery/computer/camera_advanced/base_construction/attackby(obj/item/W, mob/user, params)

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -7,6 +7,7 @@
 	/// So we instead do it on the first call to GrantActions
 	var/abduct_created = FALSE
 	lock_override = TRUE
+	alerts_cameras = FALSE
 
 	icon = 'icons/obj/antags/abductor.dmi'
 	icon_state = "camera"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -60,7 +60,6 @@
 
 	var/mob/living/silicon/ai/parent
 	var/camera_light_on = FALSE
-	var/list/obj/machinery/camera/lit_cameras = list()
 
 	///The internal tool used to track players visible through cameras.
 	var/datum/trackable/ai_tracking_tool
@@ -798,40 +797,18 @@
 	camera_light_on = !camera_light_on
 
 	if (!camera_light_on)
-		to_chat(src, "Camera lights deactivated.")
+		to_chat(src, span_info("Camera lights deactivated."))
 
-		for (var/obj/machinery/camera/C in lit_cameras)
-			C.set_light(0)
-			lit_cameras = list()
-
+		for (var/obj/machinery/camera/cam as anything in eyeobj?.cameras_near_eye)
+			cam.toggle_ai_light(src, FALSE)
 		return
 
-	light_cameras()
+	for (var/obj/machinery/camera/cam as anything in eyeobj?.cameras_near_eye)
+		cam.toggle_ai_light(src, TRUE)
 
-	to_chat(src, "Camera lights activated.")
+	to_chat(src, span_info("Camera lights activated."))
 
 //AI_CAMERA_LUMINOSITY
-
-/mob/living/silicon/ai/proc/light_cameras()
-	var/list/obj/machinery/camera/add = list()
-	var/list/obj/machinery/camera/remove = list()
-	var/list/obj/machinery/camera/visible = list()
-	for (var/datum/camerachunk/chunk as anything in eyeobj.visibleCameraChunks)
-		for (var/z_key in chunk.cameras)
-			for(var/obj/machinery/camera/camera as anything in chunk.cameras[z_key])
-				if(isnull(camera) || !camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
-					continue
-				visible |= camera
-
-	add = visible - lit_cameras
-	remove = lit_cameras - visible
-
-	for (var/obj/machinery/camera/C in remove)
-		lit_cameras -= C //Removed from list before turning off the light so that it doesn't check the AI looking away.
-		C.Togglelight(0)
-	for (var/obj/machinery/camera/C in add)
-		C.Togglelight(1)
-		lit_cameras |= C
 
 /mob/living/silicon/ai/proc/control_integrated_radio()
 	set name = "Transceiver Settings"
@@ -967,8 +944,7 @@
 
 /mob/living/silicon/ai/reset_perspective(atom/new_eye)
 	SHOULD_CALL_PARENT(FALSE) // I hate you all
-	if(camera_light_on)
-		light_cameras()
+	eyeobj?.update_cameras()
 	if(istype(new_eye, /obj/machinery/camera))
 		current = new_eye
 	if(!client)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -166,6 +166,20 @@
 		return ai.client
 	return null
 
+/mob/camera/ai_eye/proc/set_telegraph(state)
+	if(telegraph_cameras == state)
+		return
+
+	telegraph_cameras = state
+	if(telegraph_cameras)
+		for(var/obj/machinery/camera/cam as anything in cameras_near_eye)
+			cam.in_use_lights++
+			cam.update_appearance()
+	else
+		for(var/obj/machinery/camera/cam as anything in cameras_near_eye)
+			cam.in_use_lights--
+			cam.update_appearance()
+
 /mob/camera/ai_eye/Destroy()
 	for(var/obj/machinery/camera/cam as anything in cameras_near_eye)
 		if(ai?.camera_light_on && cam.internal_light)

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -133,8 +133,6 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 	icon_state = "ai_pip_camera"
 	var/atom/movable/screen/movable/pic_in_pic/ai/screen
 	var/list/cameras_telegraphed = list()
-	var/telegraph_cameras = TRUE
-	var/telegraph_range = 7
 	ai_detector_color = COLOR_ORANGE
 
 /mob/camera/ai_eye/pic_in_pic/GetViewerClient()
@@ -150,53 +148,11 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 		screen.ai.camera_visibility(src)
 	else
 		GLOB.cameranet.visibility(src)
-	update_camera_telegraphing()
+	update_cameras()
 	update_ai_detect_hud()
 
 /mob/camera/ai_eye/pic_in_pic/get_visible_turfs()
 	return screen ? screen.get_visible_turfs() : list()
-
-/mob/camera/ai_eye/pic_in_pic/proc/update_camera_telegraphing()
-	if(!telegraph_cameras)
-		return
-	var/list/obj/machinery/camera/add = list()
-	var/list/obj/machinery/camera/remove = list()
-	var/list/obj/machinery/camera/visible = list()
-	for (var/datum/camerachunk/chunk as anything in visibleCameraChunks)
-		for (var/z_key in chunk.cameras)
-			for(var/obj/machinery/camera/camera as anything in chunk.cameras[z_key])
-				if (!camera.can_use() || (get_dist(camera, src) > telegraph_range))
-					continue
-				visible |= camera
-
-	add = visible - cameras_telegraphed
-	remove = cameras_telegraphed - visible
-
-	for (var/obj/machinery/camera/C as anything in remove)
-		if(QDELETED(C))
-			continue
-		cameras_telegraphed -= C
-		C.in_use_lights--
-		C.update_appearance()
-	for (var/obj/machinery/camera/C as anything in add)
-		if(QDELETED(C))
-			continue
-		cameras_telegraphed |= C
-		C.in_use_lights++
-		C.update_appearance()
-
-/mob/camera/ai_eye/pic_in_pic/proc/disable_camera_telegraphing()
-	telegraph_cameras = FALSE
-	for (var/obj/machinery/camera/C as anything in cameras_telegraphed)
-		if(QDELETED(C))
-			continue
-		C.in_use_lights--
-		C.update_appearance()
-	cameras_telegraphed.Cut()
-
-/mob/camera/ai_eye/pic_in_pic/Destroy()
-	disable_camera_telegraphing()
-	return ..()
 
 //AI procs
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -29,6 +29,7 @@
 	desc = "A computer used for remotely handling slimes."
 	networks = list(CAMERANET_NETWORK_SS13)
 	circuit = /obj/item/circuitboard/computer/xenobiology
+	alerts_cameras = FALSE
 
 	///The recycler connected to the camera console
 	var/obj/machinery/monkey_recycler/connected_recycler
@@ -89,6 +90,7 @@
 	eyeobj.visible_icon = TRUE
 	eyeobj.icon = 'icons/mob/silicon/cameramob.dmi'
 	eyeobj.icon_state = "generic_camera"
+	eyeobj.set_telegraph(alerts_cameras)
 
 /obj/machinery/computer/camera_advanced/xenobio/GrantActions(mob/living/user)
 	. = ..()

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -8,6 +8,8 @@
 	move_up_action = null
 	move_down_action = null
 
+	alerts_cameras = FALSE
+
 	var/shuttleId = ""
 	var/shuttlePortId = ""
 	var/shuttlePortName = "custom location"
@@ -92,6 +94,7 @@
 		return
 
 	eyeobj = new /mob/camera/ai_eye/remote/shuttle_docker(null, src)
+	eyeobj.set_telegraph(alerts_cameras)
 	var/mob/camera/ai_eye/remote/shuttle_docker/the_eye = eyeobj
 	the_eye.setDir(shuttle_port.dir)
 	var/turf/origin = locate(shuttle_port.x + x_offset, shuttle_port.y + y_offset, shuttle_port.z)


### PR DESCRIPTION
The following now show an indicator on security cameras when in use:

- All AI vision (rather than just multicam vision)
- Security camera consoles 
   - Exception: TV console, telescreens, laptop app
- Advanced camera consoles
   - Exceptions: shuttle consoles, xenobio console, syndie camera console, construction console, abductor console

![image](https://github.com/user-attachments/assets/87c7d892-7246-4554-8523-183d142d89c3)
