### PR TITLE
Portal beams only manifest on same Z

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -154,7 +154,8 @@
 		new /obj/effect/temp_visual/portal_animation(start_turf, src, M)
 		playsound(start_turf, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		playsound(real_target, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		Beam(real_target, icon_state = "portal", icon = 'maplestation_modules/icons/effects/beam.dmi', time = 0.5 SECONDS) //NON-MODULAR CHANGE
+		if(start_turf.z == real_target.z)
+			Beam(real_target, icon_state = "portal", icon = 'maplestation_modules/icons/effects/beam.dmi', time = 0.5 SECONDS) //NON-MODULAR CHANGE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Beams don't work across z-levels, so people teleporting vertically results in some... jank. Shooting beams off to the corner of the map, that kinda stuff.

We might need to think of an indicator specifically for multi-z. Beam to the midpoint on z1, then from the midpoint to the end on z2, maybe?