### PR TITLE
Holo bariers check for sneak, not walk

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -76,7 +76,7 @@
 		var/mob/living/carbon/C = mover
 		if(C.stat) // Lets not prevent dragging unconscious/dead people.
 			return TRUE
-		if(allow_walk && C.move_intent == MOVE_INTENT_WALK)
+		if(allow_walk && C.move_intent == MOVE_INTENT_SNEAK) // NON-MODULE CHANGE
 			return TRUE
 
 /obj/structure/holosign/barrier/wetsign


### PR DESCRIPTION
Oops. Maybe it should check for both sneak AND walk, but I figure sneaking is more deliberate, so it's more sensible.