### PR TITLE
Bar RP QOL (drink messages indicate how full the bottle is) 

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -86,14 +86,10 @@
 		var/post_volume_percent = (reagents.total_volume - gulp_size) / reagents.maximum_volume
 		if(post_volume_percent <= 0)
 			to_chat(user, span_notice("You swallow a gulp of [src]. It's empty."))
-		else if(post_volume_percent <= 0.1 && pre_volume_percent > 0.1)
+		else if(post_volume_percent <= 0.2 && pre_volume_percent > 0.2)
 			to_chat(user, span_notice("You swallow a gulp of [src]. It's almost empty."))
-		else if(post_volume_percent <= 0.25 && pre_volume_percent > 0.25)
-			to_chat(user, span_notice("You swallow a gulp of [src]. It's still about a quarter full."))
 		else if(post_volume_percent <= 0.5 && pre_volume_percent > 0.5)
 			to_chat(user, span_notice("You swallow a gulp of [src]. It's about half full."))
-		else if(post_volume_percent <= 0.75 && pre_volume_percent > 0.75)
-			to_chat(user, span_notice("You swallow a gulp of [src]. It's about three-quarters full."))
 		else
 			to_chat(user, span_notice("You swallow a gulp of [src]."))
 	// NON-MODULE CHANGE END

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -89,7 +89,7 @@
 		else if(post_volume_percent <= 0.2 && pre_volume_percent > 0.2)
 			to_chat(user, span_notice("You swallow a gulp of [src]. It's almost empty."))
 		else if(post_volume_percent <= 0.5 && pre_volume_percent > 0.5)
-			to_chat(user, span_notice("You swallow a gulp of [src]. It's about half full."))
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's about [(HAS_TRAIT(user, TRAIT_JOLLY) || (prob(50) && !HAS_TRAIT(user, TRAIT_DEPRESSION))) ? "half full" : "half empty"]."))
 		else
 			to_chat(user, span_notice("You swallow a gulp of [src]."))
 	// NON-MODULE CHANGE END

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -80,6 +80,23 @@
 		target_mob.visible_message(span_danger("[user] feeds [target_mob] something from [src]."), \
 					span_userdanger("[user] feeds you something from [src]."))
 		log_combat(user, target_mob, "fed", reagents.get_reagent_log_string())
+	// NON-MODULE CHANGE
+	else if(isGlass || (reagent_flags & OPENCONTAINER))
+		var/pre_volume_percent = reagents.total_volume / reagents.maximum_volume
+		var/post_volume_percent = (reagents.total_volume - gulp_size) / reagents.maximum_volume
+		if(post_volume_percent <= 0)
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's empty."))
+		else if(post_volume_percent <= 0.1 && pre_volume_percent > 0.1)
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's almost empty."))
+		else if(post_volume_percent <= 0.25 && pre_volume_percent > 0.25)
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's still about a quarter full."))
+		else if(post_volume_percent <= 0.5 && pre_volume_percent > 0.5)
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's about half full."))
+		else if(post_volume_percent <= 0.75 && pre_volume_percent > 0.75)
+			to_chat(user, span_notice("You swallow a gulp of [src]. It's about three-quarters full."))
+		else
+			to_chat(user, span_notice("You swallow a gulp of [src]."))
+	// NON-MODULE CHANGE END
 	else
 		to_chat(user, span_notice("You swallow a gulp of [src]."))
 


### PR DESCRIPTION
When drinking from a glass or open container, your character will take notice on how empty the glass is getting.

<img width="483" height="121" alt="image" src="https://github.com/user-attachments/assets/6bb8e5a5-e1f7-48e9-8577-2a6cd320adf6" />

RN if you're drinking from a bottle that has no filled sprite, you have no way to tell how much is left outside of examining it. 
I like the flavor of this, but I also thought this could just be integrated into the "drink action" to make it a bit more seamless. 