### PR TITLE
[CHERRY-PICK] Buffs Various Drink Qualities

### DIFF
--- a/code/game/objects/items/food/martian.dm
+++ b/code/game/objects/items/food/martian.dm
@@ -976,7 +976,7 @@
 		/datum/reagent/consumable/garlic = 1,
 	)
 	tastes = list("yoghurt" = 1, "garlic" = 1, "lemon" = 1, "egg" = 1, "chilli heat" = 1)
-	foodtypes = DAIRY | VEGETABLES | FRUIT | BREAKFAST
+	foodtypes = DAIRY | VEGETABLES | MEAT | BREAKFAST
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
 

--- a/code/game/objects/items/food/moth.dm
+++ b/code/game/objects/items/food/moth.dm
@@ -757,7 +757,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 5,
 	)
 	tastes = list("crust" = 1, "pesto" = 1, "cheese" = 1)
-	foodtypes = GRAIN | VEGETABLES | DAIRY | NUTS | RAW
+	foodtypes = GRAIN | VEGETABLES | DAIRY | NUTS
 	slice_type = /obj/item/food/pizzaslice/mothic_pesto
 	boxtag = "Presto Pesto"
 	crafting_complexity = FOOD_COMPLEXITY_5

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -2759,7 +2759,7 @@
 	description = "A drink glorifying Cybersun's enduring business."
 	boozepwr = 20
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_FANTASTIC
 	taste_description = "betrayal"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2768,7 +2768,7 @@
 	description = "A variation on the Long Island Iced Tea, made with yuyake for an alternative flavour that's hard to place."
 	boozepwr = 40
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "an asian twist on the liquor cabinet"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2777,7 +2777,7 @@
 	description = "It's a melon cream soda, except with alcohol- what's not to love? Well... possibly the hangovers."
 	boozepwr = 6
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "creamy melon soda"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2786,7 +2786,7 @@
 	description = "A new take on a classic cocktail, the Kumicho takes the Godfather formula and adds shochu for an Asian twist."
 	boozepwr = 62
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "rice and rye"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2795,7 +2795,7 @@
 	description = "Made in celebration of the Martian Concession, the Red Planet is based on the classic El Presidente, and is as patriotic as it is bright crimson."
 	boozepwr = 45
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "the spirit of freedom"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2804,7 +2804,7 @@
 	description = "Named for Amaterasu, the Shinto Goddess of the Sun, this cocktail embodies radiance- or something like that, anyway."
 	boozepwr = 54 //1 part bitters is a lot
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "sweet nectar of the gods"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2813,7 +2813,7 @@
 	description = "An overly sweet cocktail, made with melon liqueur, melon juice, and champagne (which contains no melon, unfortunately)."
 	boozepwr = 17
 	color = "#FF0C8D"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "MELON"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2822,7 +2822,7 @@
 	description = "Based on the galaxy-famous \"Kyūkyoku no Ninja Pawā Sentai\", the Sentai Quencha is a favourite at anime conventions and weeb bars."
 	boozepwr = 28
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "ultimate ninja power"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2831,7 +2831,7 @@
 	description = "A simple summer drink from Mars, made from a 1:1 mix of rice beer and lemonade."
 	boozepwr = 6
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "bittersweet lemon"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2840,7 +2840,7 @@
 	description = "Sweet, bitter, spicy- that's a great combination."
 	boozepwr = 6
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "spicy pineapple beer"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2858,7 +2858,7 @@
 	description = "A stiff, bitter drink with an odd name and odder recipe."
 	boozepwr = 26
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "bitter raspberry"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2867,7 +2867,7 @@
 	description = "A drink to power your typing hands."
 	boozepwr = 26
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "cyberspace"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2876,7 +2876,7 @@
 	description = "A take on the classic White Russian, subbing out the classics for some tropical flavours."
 	boozepwr = 16
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_GOOD
 	taste_description = "COCONUT"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2885,7 +2885,7 @@
 	description = "Behind this drink's red facade lurks a sharp, complex flavour."
 	boozepwr = 15
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "sunrise over the pacific"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2894,7 +2894,7 @@
 	description = "For when orgeat is in short supply, do as the spacers do- make do and mend."
 	boozepwr = 52
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "spicy nutty rum"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2903,7 +2903,7 @@
 	description = "Coconut rum, coffee liqueur, and espresso- an odd combination, to be sure, but a welcomed one."
 	boozepwr = 20
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "coconut coffee"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -2912,7 +2912,7 @@
 	description = "Sweet, sharp and coconutty."
 	boozepwr = 30
 	color = "#F54040"
-	quality = DRINK_NICE
+	quality = DRINK_VERYGOOD
 	taste_description = "the aloha state"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 

--- a/html/changelogs/AutoChangeLog-pr-92217.yml
+++ b/html/changelogs/AutoChangeLog-pr-92217.yml
@@ -1,6 +1,0 @@
-author: "SyncIt21"
-delete-after: True
-changes:
-  - code_imp: "moved designs & circuitboards for bitrunning into their correct files"
-  - qol: "adds examines & screentips for bitrunning netpod, bitforge & server on how to deconstruct them"
-  - bugfix: "bitforge can be deconstructed with a screwdriver & crowbar"

--- a/html/changelogs/AutoChangeLog-pr-92217.yml
+++ b/html/changelogs/AutoChangeLog-pr-92217.yml
@@ -1,0 +1,6 @@
+author: "SyncIt21"
+delete-after: True
+changes:
+  - code_imp: "moved designs & circuitboards for bitrunning into their correct files"
+  - qol: "adds examines & screentips for bitrunning netpod, bitforge & server on how to deconstruct them"
+  - bugfix: "bitforge can be deconstructed with a screwdriver & crowbar"

--- a/maplestation_modules/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/maplestation_modules/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -391,7 +391,7 @@
 	description = "A subtly sweet coffee seemingly out of this world."
 	nutriment_factor = 8
 	color = "#361329"
-	quality = DRINK_GOOD
+	quality = DRINK_VERYGOOD
 	taste_description = "hauntingly familiar allure"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -407,7 +407,7 @@
 	description = "A delightful shake made with a rare starfruit."
 	color = "#a551be"
 	nutriment_factor = 0
-	quality = DRINK_GOOD
+	quality = DRINK_VERYGOOD
 	taste_description = "smooth starlight"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -423,7 +423,7 @@
 	description = "A cosmic cry of a bygone era."
 	boozepwr = 55
 	color = "#434294"
-	quality = DRINK_GOOD
+	quality = DRINK_FANTASTIC
 	taste_description = "dreamy, tropical starlit sweetness"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
@@ -439,7 +439,7 @@
 	description = "Enticing flames."
 	boozepwr = 55
 	color = "#6b3481"
-	quality = DRINK_GOOD
+	quality = DRINK_VERYGOOD
 	taste_description = "enticing warmth"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 


### PR DESCRIPTION
Martian drinks in our version didn't get a 2024 PR that made them not all `DRINK_NICE` quality, so this adds that PR
I also took the liberty of making the starfruit drinks not exclusively `DRINK_GOOD` quality as well
the new tiers are as follows

Unchanged:
-Starfruit Lubricant
-Starfruit Soda
-Space Muse

Very Good:
-Starfruit Latte (same quality as Pumpkin Latte)
-Astral Flame

Fantastic: 
-Forgotten Star
-Starbeam Shake (Requires vanilla as well)

