### PR TITLE
Wellcheers only makes you sleep in specific circumstances.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -657,7 +657,8 @@
 		if (SANITY_UNSTABLE to SANITY_DISTURBED)
 			affected_mob.add_mood_event("wellcheers", /datum/mood_event/wellcheers)
 		if (SANITY_NEUTRAL to SANITY_GREAT)
-			need_mob_update = affected_mob.adjustBruteLoss(-1.5 * REM * seconds_per_tick, updating_health = FALSE)
+			//need_mob_update = affected_mob.adjustBruteLoss(-1.5 * REM * seconds_per_tick, updating_health = FALSE)
+			need_mob_update = affected_mob.adjustBruteLoss(-0.5 * REM * seconds_per_tick, updating_health = FALSE) // NON-MODULE CHANGE
 	if(need_mob_update)
 		return UPDATE_MOB_HEALTH
 


### PR DESCRIPTION
Wellcheers juice now makes you sleep only when you have INSANE to CRAZY sanity (so very low) and are at maximum stamina loss. This should make it actually drinkable for fun and not be one of the best and most easily accessible non-lethal poisons in the entire game.

and yes we switched from stamina to pain so right now this is like one of the only "stamcrit" effects in the entire game. it's an abnormality i guess