### PR TITLE
Pubby fixes and makes cargo shuttle entrance not 1 tile wide

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -166,10 +166,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"aaz" = (
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/grimy,
-/area/station/security/detectives_office)
 "aaA" = (
 /obj/structure/table/reinforced,
 /obj/item/relic,
@@ -334,6 +330,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "abc" = (
@@ -1087,13 +1086,9 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
 "aef" = (
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_ap)
-"aeh" = (
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
 "aej" = (
 /obj/machinery/porta_turret/ai{
 	installation = /obj/item/gun/energy/e_gun
@@ -1101,7 +1096,7 @@
 /turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aek" = (
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
 "ael" = (
@@ -2029,6 +2024,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/structure/tank_holder/extinguisher,
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "ahd" = (
@@ -2294,7 +2290,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ahX" = (
@@ -2813,26 +2808,29 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ajx" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "supplybridge"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ajy" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "supplybridge"
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge";
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ajz" = (
 /obj/machinery/door/poddoor/shutters{
-	id = "supplybridge"
+	id = "supplybridge";
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3439,6 +3437,9 @@
 	name = "Hideout"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "alj" = (
@@ -4097,6 +4098,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "anp" = (
@@ -5466,6 +5470,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ase" = (
@@ -7304,6 +7311,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "axB" = (
@@ -8263,6 +8276,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -8272,6 +8286,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -8574,6 +8589,7 @@
 "aCo" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/hand_labeler,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "aCq" = (
@@ -10203,18 +10219,6 @@
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"aHu" = (
-/obj/structure/table,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "ShuttleUnload";
-	name = "Shuttle Unload";
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "aHz" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -10563,14 +10567,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"aJN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
 "aJU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -10815,6 +10811,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aKV" = (
@@ -12883,18 +12880,10 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"aTx" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/space/basic,
-/area/space)
 "aTy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"aTz" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/space/basic,
-/area/space)
 "aTA" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/smooth_half,
@@ -13519,9 +13508,13 @@
 /turf/open/floor/iron/half,
 /area/station/cargo/storage)
 "aVI" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
 /area/station/cargo/storage)
 "aVM" = (
 /obj/machinery/door/firedoor,
@@ -14871,7 +14864,11 @@
 	dir = 8;
 	id = "ShuttleUnload"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/half,
+/turf/open/floor/iron/smooth_half,
 /area/station/cargo/bitrunning/den)
 "baJ" = (
 /obj/machinery/light/directional/west,
@@ -15439,11 +15436,6 @@
 	dir = 1
 	},
 /area/station/cargo/warehouse)
-"bcK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/station/cargo/storage)
 "bcL" = (
 /obj/item/toy/plush/lizard_plushie,
 /turf/open/floor/plating,
@@ -16035,6 +16027,7 @@
 "bfu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bfv" = (
@@ -16793,6 +16786,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -18396,7 +18390,6 @@
 /turf/closed/wall/r_wall,
 /area/station/security/processing/cremation)
 "bqa" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -18743,6 +18736,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "bqV" = (
@@ -20007,6 +20001,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "bwq" = (
@@ -22510,6 +22505,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bFr" = (
@@ -22844,7 +22842,7 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	layer = 2.9
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
 /turf/open/floor/plating/airless,
 /area/station/service/chapel/dock)
 "bGH" = (
@@ -23460,6 +23458,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bJO" = (
@@ -27566,6 +27565,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bZt" = (
@@ -30198,6 +30198,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"coC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/station/cargo/storage)
 "coF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30236,6 +30245,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -31745,7 +31755,9 @@
 	space_dir = null
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron/half,
+/obj/effect/turf_decal/tile/brown/full,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "cxK" = (
 /obj/machinery/duct,
@@ -32432,6 +32444,16 @@
 "cDa" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
+"cDw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/large,
+/area/station/hallway/primary/fore)
 "cDB" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -32475,7 +32497,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "cIe" = (
@@ -33704,6 +33727,11 @@
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"dJz" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dJA" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -34293,9 +34321,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/library/artgallery)
 "ema" = (
-/obj/structure/plasticflaps/opaque,
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/storage)
 "emB" = (
 /obj/effect/turf_decal/tile/red{
@@ -34308,7 +34335,6 @@
 /turf/open/floor/iron/edge,
 /area/station/security/brig)
 "emV" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -35489,7 +35515,6 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "fcQ" = (
-/obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/edge{
 	dir = 4
@@ -35545,6 +35570,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "feh" = (
@@ -35665,6 +35691,22 @@
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
+"fhb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Docking Arm Maintenance"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "fhc" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -36474,6 +36516,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "fKw" = (
@@ -36848,11 +36893,6 @@
 	dir = 4
 	},
 /area/station/commons/dorms)
-"fYY" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/space/basic,
-/area/space)
 "fZV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/hangover,
@@ -36934,6 +36974,19 @@
 	},
 /turf/open/floor/iron/half,
 /area/station/cargo/storage)
+"gcO" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/camera{
+	c_tag = "Cargo Docking Arm";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "gcV" = (
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
@@ -37006,14 +37059,13 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
 "gfC" = (
-/obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "CargoUnload";
 	name = "Cargo Unload";
-	pixel_y = 8
+	pixel_y = 3
 	},
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/large,
 /area/station/cargo/storage)
 "ggW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -37142,6 +37194,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "gld" = (
@@ -37470,6 +37525,17 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
+"gyt" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/sign/warning/vacuum/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/cargo/storage)
 "gzy" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/cable,
@@ -38355,6 +38421,9 @@
 	dir = 1
 	},
 /area/station/commons/fitness/recreation)
+"hjx" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "hjy" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/red/half{
@@ -38533,6 +38602,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/disposal/incinerator)
+"hrk" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sink/kitchen/directional/south{
+	name = "utility sink"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "hrI" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white/smooth_corner,
@@ -38549,6 +38625,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"htq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hua" = (
 /obj/machinery/conveyor{
 	dir = 9;
@@ -38959,6 +39039,20 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/virology)
+"hIO" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "hIQ" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39285,9 +39379,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 4;
-	name = "Outlet Injector"
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/chapel/monastery)
@@ -39579,7 +39672,8 @@
 	dir = 8;
 	id = "ShuttleUnload"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/bitrunning/den)
 "ihj" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
@@ -39799,6 +39893,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "irZ" = (
@@ -40208,11 +40305,6 @@
 "iHu" = (
 /turf/closed/wall,
 /area/centcom/asteroid/nearstation/bomb_site)
-"iIB" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/space/basic,
-/area/space)
 "iIY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green/half,
@@ -40293,6 +40385,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"iLM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half,
+/area/station/cargo/storage)
 "iMH" = (
 /obj/machinery/door/window/left/directional/south{
 	base_state = "right";
@@ -40315,6 +40413,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -40717,14 +40816,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "jdr" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/status_display/supply{
-	dir = 4;
-	layer = 4;
-	pixel_y = 32
-	},
-/turf/open/floor/iron/half,
+/turf/open/floor/iron/smooth_half,
 /area/station/cargo/storage)
 "jdA" = (
 /obj/structure/cable,
@@ -41434,6 +41526,19 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jPT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/half{
+	dir = 8
+	},
+/area/station/cargo/storage)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/effect/mapping_helpers/broken_floor,
@@ -42138,7 +42243,8 @@
 	dir = 4;
 	id = "ShuttleLoad"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/drone_bay)
 "kvj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -42380,7 +42486,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -42547,7 +42652,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "kJU" = (
@@ -42627,7 +42733,8 @@
 	id = "ShuttleLoad"
 	},
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/drone_bay)
 "kNE" = (
 /obj/machinery/holopad/secure,
@@ -42701,6 +42808,18 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/xenobiology)
+"kSb" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/closet/emcloset,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/cargo/storage)
 "kSD" = (
 /obj/effect/turf_decal/tile/bar/half{
 	dir = 4
@@ -42895,6 +43014,7 @@
 	layer = 4;
 	pixel_x = 33
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/half{
 	dir = 8
 	},
@@ -43322,7 +43442,8 @@
 "lot" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
-	name = "Mech Bay"
+	name = "Mech Bay";
+	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -43360,9 +43481,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
 "lpX" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 8;
-	name = "Outlet Injector"
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -43671,6 +43791,24 @@
 	dir = 1
 	},
 /area/station/science/research)
+"lBC" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/brown,
+/obj/effect/turf_decal/trimline/brown/mid_joiner,
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/storage)
 "lBP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -43881,11 +44019,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"lJM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "lJR" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
@@ -43945,7 +44078,8 @@
 	id = "ShuttleUnload"
 	},
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/bitrunning/den)
 "lMM" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -44376,9 +44510,8 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "mdk" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 4;
-	name = "AI Sat Waste"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_sat_ext_as)
@@ -45133,6 +45266,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "mEW" = (
@@ -45429,12 +45563,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"mRD" = (
-/obj/structure/closet/firecloset,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
+"mRy" = (
+/obj/machinery/duct,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "mRX" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/library/artgallery)
@@ -46252,6 +46385,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nti" = (
@@ -46857,6 +46993,9 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nSz" = (
@@ -46892,6 +47031,7 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nTx" = (
@@ -47067,6 +47207,9 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "nZX" = (
@@ -47340,6 +47483,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "old" = (
@@ -47362,6 +47508,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"oll" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/cargo/storage)
 "oln" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -47512,6 +47668,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "orc" = (
@@ -47713,6 +47870,15 @@
 	dir = 4
 	},
 /area/station/service/chapel/office)
+"owU" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -48009,6 +48175,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
+"oGX" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "ShuttleUnload";
+	name = "Shuttle Unload";
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "oGZ" = (
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
@@ -48270,17 +48451,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"oSC" = (
-/obj/structure/table,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/conveyor_switch/oneway{
-	id = "ShuttleLoad";
-	name = "Shuttle Load";
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "oSI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -48587,6 +48757,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pfF" = (
@@ -48614,12 +48785,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/xenobiology)
-"pgk" = (
-/obj/structure/sink/kitchen/directional/south{
-	name = "utility sink"
-	},
-/turf/closed/wall,
-/area/station/maintenance/department/science)
 "pgn" = (
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/ai_monitored/turret_protected/aisat_interior)
@@ -48688,6 +48853,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"phM" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pif" = (
 /obj/structure/hoop{
 	dir = 8
@@ -48840,6 +49010,15 @@
 /obj/item/kirbyplants/organic/plant8,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"pnP" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/sign/warning/doors/directional/south,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -49499,6 +49678,16 @@
 	dir = 4
 	},
 /area/station/science/research)
+"pRs" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "Skynet_launch";
+	name = "Mech Bay";
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
+/area/station/science/robotics/mechbay)
 "pRR" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -49563,6 +49752,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "pTG" = (
@@ -50224,12 +50416,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"qof" = (
-/obj/structure/closet/emcloset,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/storage)
 "qoh" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -50254,6 +50440,19 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/main)
+"qoX" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/status_display/supply{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/cargo/storage)
 "qph" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -50759,6 +50958,16 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"qJA" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "qJB" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -51423,13 +51632,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "rng" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/camera{
-	c_tag = "Cargo Docking Arm";
-	dir = 4
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/conveyor_switch/oneway{
+	id = "ShuttleLoad";
+	name = "Shuttle Load";
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/station/cargo/storage)
 "rnm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron,
@@ -52521,6 +52738,14 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
+"rUf" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/cargo/storage)
 "rUS" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53164,18 +53389,19 @@
 	dir = 1
 	},
 /area/station/ai_monitored/turret_protected/ai)
-"stt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
+"stx" = (
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/large,
-/area/station/hallway/primary/central)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "stG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54116,7 +54342,11 @@
 	dir = 4;
 	id = "ShuttleLoad"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half,
 /area/station/cargo/drone_bay)
 "sZt" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -55088,24 +55318,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
-"tAm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/status_display/supply{
-	dir = 4;
-	layer = 4;
-	pixel_x = 33
-	},
-/turf/open/floor/iron/half{
-	dir = 8
-	},
-/area/station/cargo/storage)
 "tAK" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/module_duplicator,
@@ -55327,7 +55539,6 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -55343,6 +55554,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"tJg" = (
+/obj/structure/sign/directions/evac{
+	pixel_x = -32
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
 "tJS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -55431,7 +55651,6 @@
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central)
 "tNv" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -56604,6 +56823,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/tank_holder/oxygen/yellow,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uAg" = (
@@ -57150,6 +57370,19 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"uTQ" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "uUh" = (
 /turf/open/floor/iron/stairs{
 	dir = 4
@@ -57285,6 +57518,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
+"uXw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/service/bar/atrium)
 "uXG" = (
 /obj/machinery/door/airlock/research{
 	name = "Containment Pen Access"
@@ -57636,6 +57876,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "vji" = (
@@ -58136,7 +58377,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "vHr" = (
@@ -58430,11 +58674,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"vRk" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/space/basic,
-/area/space/nearstation)
 "vRm" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -58907,7 +59146,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/xenobiology)
 "wfA" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -59717,6 +59955,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/atmos/experiment_room)
+"wHv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half,
+/area/station/cargo/storage)
 "wHD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -59748,9 +59992,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"wIq" = (
-/turf/open/floor/iron/half,
-/area/station/cargo/storage)
 "wIt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -59925,6 +60166,7 @@
 /obj/machinery/computer/records/security{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/checkpoint/medical)
 "wNG" = (
@@ -60089,7 +60331,11 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "wRC" = (
@@ -60107,7 +60353,6 @@
 "wRG" = (
 /obj/structure/closet/lasertag/red,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -60720,6 +60965,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "xhE" = (
@@ -60774,6 +61022,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xjl" = (
@@ -60971,6 +61222,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"xnU" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "xog" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -61120,11 +61379,16 @@
 	name = "Cargo Bay"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/general,
-/turf/open/floor/iron/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown/full,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/storage)
 "xur" = (
 /obj/machinery/door/window/left/directional/north{
@@ -61285,6 +61549,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xyl" = (
@@ -83539,7 +83806,7 @@ uUY
 mCg
 lzt
 aAe
-abb
+hIO
 xxS
 eQZ
 eQZ
@@ -85131,7 +85398,7 @@ bva
 wXk
 bva
 bva
-sqG
+mRy
 bBX
 uko
 sSl
@@ -85597,7 +85864,7 @@ qNG
 coP
 aBd
 aCo
-aaz
+aCl
 bae
 sEX
 bef
@@ -86115,7 +86382,7 @@ aZf
 aEs
 aFr
 oOy
-rvS
+tJg
 gAK
 wtZ
 gAK
@@ -86366,13 +86633,13 @@ uUY
 mCg
 ayN
 aAk
-nTx
+cDw
 nTx
 nTx
 nTx
 nTx
 fFF
-yiR
+ble
 isC
 aHF
 vsm
@@ -86623,7 +86890,7 @@ awN
 axL
 ayO
 aAm
-aBh
+qJA
 aXR
 aDv
 wDC
@@ -90251,7 +90518,7 @@ bcc
 xNU
 bem
 tps
-aJN
+tps
 tps
 ble
 mwo
@@ -94882,7 +95149,7 @@ tps
 bhO
 bio
 ble
-yiR
+ble
 vsm
 ble
 ble
@@ -95067,9 +95334,9 @@ adl
 adx
 adX
 adX
-aeh
-aeh
-aeh
+agq
+agq
+agq
 adX
 adX
 afe
@@ -95581,9 +95848,9 @@ adn
 adz
 adX
 adX
-aeh
-aeh
-aeh
+agq
+agq
+agq
 adX
 adX
 afg
@@ -96160,7 +96427,7 @@ ban
 bbt
 bcr
 alp
-cpg
+uXw
 ajX
 bgx
 iHl
@@ -97434,7 +97701,7 @@ aOJ
 anX
 kVO
 aKT
-xhB
+stx
 aKT
 aKT
 aUf
@@ -97937,7 +98204,7 @@ xHq
 xHq
 xHq
 xHq
-stt
+xHq
 qQD
 xHq
 ugM
@@ -98194,7 +98461,7 @@ byj
 pSd
 byj
 byj
-xnl
+byj
 xvO
 aJd
 tKZ
@@ -99246,7 +99513,7 @@ aEj
 pTF
 aEj
 beI
-lot
+pRs
 lot
 beI
 bit
@@ -99978,7 +100245,7 @@ ajv
 ajv
 aiS
 aiS
-asc
+uTQ
 aiS
 aiS
 avf
@@ -103322,7 +103589,7 @@ aiS
 enI
 fVJ
 lFK
-lJM
+lFK
 duC
 rrM
 pcg
@@ -105391,7 +105658,7 @@ atn
 aFP
 aGM
 aFi
-bfu
+xnU
 lru
 aEj
 aLl
@@ -106426,11 +106693,11 @@ mdx
 mdx
 mdx
 mdx
-vHj
+fhb
 mXc
 saR
-tAm
 tvy
+jPT
 eCB
 ahW
 kXZ
@@ -106687,9 +106954,9 @@ aEj
 afh
 afO
 tko
-bbG
+aTy
 xud
-bbG
+aTy
 sPc
 ieg
 tvK
@@ -106944,9 +107211,9 @@ aet
 afj
 ecR
 tko
-bGI
+kSb
 aVI
-sut
+owU
 sPc
 phu
 rax
@@ -107201,9 +107468,9 @@ aev
 afl
 aha
 tko
-bGI
-aVI
-sut
+oll
+coC
+rUf
 sPc
 luA
 gtC
@@ -107458,9 +107725,9 @@ aey
 bxV
 tko
 tko
-bGI
-aVI
-sut
+gyt
+lBC
+pnP
 sPc
 sPc
 ovf
@@ -107715,9 +107982,9 @@ lcz
 ktQ
 rWE
 aht
-aYE
-aVI
-rWE
+oll
+iLM
+rUf
 aht
 aYE
 igX
@@ -107971,11 +108238,11 @@ ofR
 qfa
 sZh
 sut
-bVp
-cqU
-aVI
-fYY
-aTx
+aaa
+oll
+iLM
+rUf
+aaa
 bGI
 baG
 wSz
@@ -108228,11 +108495,11 @@ lao
 ndd
 sZh
 sut
-aTy
-qof
-wIq
-mRD
-aTy
+aaa
+oll
+lBC
+rUf
+aaa
 bGI
 baG
 sut
@@ -108485,11 +108752,11 @@ adO
 nkE
 sZh
 sut
-bcK
-oSC
-wIq
-aHu
-aTy
+aaa
+oll
+iLM
+rUf
+aaa
 bGI
 baG
 sut
@@ -108742,11 +109009,11 @@ uOe
 uOe
 sZh
 sut
-crO
-vRk
-aVI
-iIB
-aTz
+aaa
+oll
+iLM
+rUf
+aaa
 bGI
 baG
 sut
@@ -109000,9 +109267,9 @@ bGI
 sZh
 rWE
 aht
-aYE
-aVI
-rWE
+oll
+lBC
+rUf
 aht
 aYE
 baG
@@ -109258,8 +109525,8 @@ sZh
 sut
 aaa
 rng
-aVI
-sut
+wHv
+oGX
 aaa
 bGI
 baG
@@ -109512,13 +109779,13 @@ aaa
 aaa
 bGI
 sZh
-sut
+phM
 aaa
-dUZ
+qoX
 jdr
-dUZ
+gcO
 aaa
-bGI
+dJz
 baG
 sut
 aaa
@@ -109769,13 +110036,13 @@ aht
 aht
 aYE
 kNb
-rWE
-aht
+hjx
+htq
 dUZ
 cxJ
 dUZ
-aht
-aYE
+htq
+hjx
 lLS
 rWE
 aht
@@ -110574,7 +110841,7 @@ yhB
 pDf
 pDf
 jYN
-pgk
+bwm
 bwm
 bwm
 bwm
@@ -111088,7 +111355,7 @@ blX
 blX
 blX
 jYN
-efU
+hrk
 efU
 cDB
 cDB


### PR DESCRIPTION
Fixes various issues with Pubby, namely broken disposals

Makes the cargo shuttle entrance not 1 tile wide