### PR TITLE
Refactor title screen and music spinner 

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -7,6 +7,7 @@
 	///Whether the menu is currently on the client's screen or not
 	var/menu_hud_status = TRUE
 
+
 /datum/hud/new_player/New(mob/owner)
 	. = ..()
 
@@ -29,6 +30,9 @@
 		if (istype(lobbyscreen, /atom/movable/screen/lobby/button))
 			var/atom/movable/screen/lobby/button/lobby_button = lobbyscreen
 			lobby_button.owner = REF(owner)
+
+	static_inventory += new /atom/movable/screen/lobby_init_text(our_hud = src)
+	static_inventory += new /atom/movable/screen/lobby_music(our_hud = src)
 	add_station_trait_buttons()
 
 /// Display buttons for relevant station traits
@@ -585,3 +589,64 @@
 #undef SHUTTER_MOVEMENT_DURATION
 #undef SHUTTER_WAIT_DURATION
 #undef MAX_STATION_TRAIT_BUTTONS_VERTICAL
+
+/atom/movable/screen/lobby_init_text
+	maptext_height = 500
+	maptext_width = 225
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	plane = SPLASHSCREEN_PLANE
+	screen_loc = "LEFT+0.25,BOTTOM+0.25"
+
+/atom/movable/screen/lobby_init_text/New(loc, datum/hud/our_hud, ...)
+	src.hud = our_hud
+	return ..()
+
+/atom/movable/screen/lobby_init_text/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(SStitle.stats_faded || !hud?.mymob?.client?.prefs?.read_preference(/datum/preference/toggle/show_init_stats))
+		alpha = 0 // we still need to init it incase they turn it back on
+
+/atom/movable/screen/lobby_music
+	icon = 'maplestation_modules/icons/hud/lobby_spinner.dmi'
+	icon_state = "spinner"
+	maptext_height = 100
+	maptext_width = 225
+	maptext_y = -10
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	plane = SPLASHSCREEN_PLANE
+	screen_loc = "LEFT+0.25,TOP-0.25"
+	/// World time when the current song started playing for this player
+	var/start_time
+	/// World time when the current song will stop playing for this player
+	var/end_time
+
+/atom/movable/screen/lobby_music/New(loc, datum/hud/our_hud, ...)
+	src.hud = our_hud
+	return ..()
+
+/atom/movable/screen/lobby_music/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(!hud?.mymob?.client?.prefs?.read_preference(/datum/preference/toggle/sound_lobby))
+		alpha = 0 // we still need to init it incase they turn it back on
+
+/atom/movable/screen/lobby_music/proc/start_tracking()
+	animate(src)
+	alpha = 255
+	start_time = world.time
+	end_time = start_time + SSticker.login_length
+	START_PROCESSING(SSlobby_music_player, src)
+
+/atom/movable/screen/lobby_music/process(seconds_per_tick)
+	maptext = "[SStitle.music_maptext]<br>[MAPTEXT("\u25B6 [time2text(min(world.time - start_time, SSticker.login_length), "mm:ss", 0)] / [time2text(SSticker.login_length, "mm:ss", 0)]s")]"
+	if(world.time >= end_time)
+		animate(src, alpha = 0, time = 5 SECONDS)
+		return PROCESS_KILL
+
+/atom/movable/screen/lobby_music/proc/cancel_tracking()
+	maptext = SStitle.music_maptext
+	STOP_PROCESSING(SSlobby_music_player, src)
+	animate(src, alpha = 0, time = 1 SECONDS)
+
+/atom/movable/screen/lobby_music/Destroy()
+	STOP_PROCESSING(SSlobby_music_player, src)
+	return ..()

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -444,7 +444,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 			Master.StartProcessing(0)
 
 	var/time = (REALTIMEOFDAY - start_timeofday) / (1 SECONDS)
-	SStitle.total_init_time = time
+	SStitle.total_init_time = round(time, 0.01)
 	log_world("Initializations complete within [time] second\s!")
 
 	if(world.system_type == MS_WINDOWS && CONFIG_GET(flag/toast_notification_on_init) && !length(GLOB.clients))
@@ -1021,4 +1021,3 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, "Controller Overview", "Vie
 		return FALSE
 	last_profiled = REALTIMEOFDAY
 	SSprofiler.DumpFile(allow_yield = FALSE)
-

--- a/code/controllers/subsystem/processing/lobby_music_player.dm
+++ b/code/controllers/subsystem/processing/lobby_music_player.dm
@@ -1,0 +1,6 @@
+/// Updates lobby music hud elements
+PROCESSING_SUBSYSTEM_DEF(lobby_music_player)
+	name = "Lobby Music Player"
+	flags = SS_NO_INIT|SS_BACKGROUND|SS_KEEP_TIMING
+	runlevels = ALL
+	wait = 1 SECONDS

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -18,7 +18,11 @@ SUBSYSTEM_DEF(ticker)
 	/// Boolean to track and check if our subsystem setup is done.
 	var/setup_done = FALSE
 
-	var/login_music //music played in pregame lobby
+	/// Music played in pregame lobby
+	var/login_music
+	/// Length of the music in deciseconds
+	var/login_length
+
 	var/round_end_sound //music/jingle played when the world reboots
 	var/round_end_sound_sent = TRUE //If all clients have loaded it
 
@@ -782,6 +786,7 @@ SUBSYSTEM_DEF(ticker)
 		return
 
 	login_music = new_music
+	login_length = rustg_sound_length(new_music)
 	var/list/music_file_components = splittext(new_music, "/")
 	var/music_file_name = length(music_file_components) && music_file_components[length(music_file_components)] || new_music
 	var/list/music_name_components = splittext(music_file_name, "+")

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -10,10 +10,12 @@ SUBSYSTEM_DEF(title)
 	var/icon/previous_icon
 	/// Reference to the turf in the lobby, which is where we hold the title screen
 	var/turf/closed/indestructible/splashscreen/splash_turf
-	/// A holder for maptext that displays initialization information on the title screen
-	var/obj/effect/abstract/maptext_holder/init/init_stat_holder
-	/// A holder for maptext that displays the playing music on the title screen
-	var/obj/effect/abstract/maptext_holder/music/music_holder
+	/// Holds the maptext that displays initialization information on the title screen
+	var/init_stat_maptext
+	/// Tracks when stats have been faded out for everyone
+	var/stats_faded = FALSE
+	/// Holds the maptext that displays the playing music on the title screen
+	var/music_maptext
 
 	/// A list of initialization information
 	var/list/init_infos = list()
@@ -89,18 +91,13 @@ SUBSYSTEM_DEF(title)
 		return
 	if(!music_string)
 		return
-	if(!music_holder)
-		if(!splash_turf)
-			return
-		music_holder = new(splash_turf)
 
-	music_holder.pixel_x = initial(music_holder.pixel_x) - (length(music_string) * 8)
-	music_holder.maptext = ""
-	music_holder.maptext += "<span class='maptext'>"
-	music_holder.maptext += "<span class='big'>"
-	music_holder.maptext += "Now playing: [music_string]"
-	music_holder.maptext += "</span>"
-	music_holder.maptext += "</span>"
+	music_maptext = ""
+	music_maptext += "<span class='maptext'>"
+	music_maptext += "<span class='big'>"
+	music_maptext += "Now playing: [music_string]"
+	music_maptext += "</span>"
+	music_maptext += "</span>"
 
 /// Max number of init entries to display
 /// If this is exceeded, the oldest entry will be removed (but it generally should not be exceeded)
@@ -119,6 +116,8 @@ SUBSYSTEM_DEF(title)
  * * major_update: Indicates this init text is a major update, which will update a "dot" animation.
  */
 /datum/controller/subsystem/title/proc/add_init_text(init_category, name, stage, seconds, override = FALSE, major_update = FALSE)
+	if(isnum(seconds))
+		seconds = round(seconds, 0.1)
 	if(override || !init_infos[init_category])
 		init_infos[init_category] = list(name, stage, seconds)
 	else
@@ -139,13 +138,8 @@ SUBSYSTEM_DEF(title)
 
 /// Updates the displayed initialization text according to all initialization information
 /datum/controller/subsystem/title/proc/update_init_text()
-	if(!init_stat_holder)
-		if(!splash_turf)
-			return
-		init_stat_holder = new(splash_turf)
-
-	init_stat_holder.maptext = "<span class='maptext'>"
-	init_stat_holder.maptext += "<span class='big'>"
+	init_stat_maptext = "<span class='maptext'>"
+	init_stat_maptext += "<span class='big'>"
 	if(SSticker?.current_state == GAME_STATE_PREGAME)
 		var/total_time_formatted = "[total_init_time]s"
 		switch(total_init_time)
@@ -156,83 +150,26 @@ SUBSYSTEM_DEF(title)
 			if(120 to INFINITY)
 				total_time_formatted = "<font color='red'>[total_init_time]s</font>"
 
-		init_stat_holder.maptext += "Game Ready! ([total_time_formatted])"
+		init_stat_maptext += "Game Ready! ([total_time_formatted])"
 	else
-		init_stat_holder.maptext += "Initializing game"
+		init_stat_maptext += "Initializing game"
 		for(var/i in 1 to num_dots)
-			init_stat_holder.maptext += "."
-	init_stat_holder.maptext += "</span><br>"
+			init_stat_maptext += "."
+	init_stat_maptext += "</span><br>"
 	for(var/sstype in init_infos)
 		var/list/init_data = init_infos[sstype]
 		var/init_name = init_data[1]
 		var/init_stage = init_data[2]
 		var/init_time = isnum(init_data[3]) ? "([init_data[3]]s)" : ""
-		init_stat_holder.maptext += "<br>[init_name] [init_stage] [init_time]"
-	init_stat_holder.maptext += "<br></span>"
+		init_stat_maptext += "<br>[init_name] [init_stage] [init_time]"
+	init_stat_maptext += "<br></span>"
+	for(var/mob/dead/new_player/lobbyguy as anything in GLOB.new_player_list)
+		for(var/atom/movable/screen/lobby_init_text/text in lobbyguy.hud_used?.static_inventory)
+			text.maptext = SStitle.init_stat_maptext
 
 /// Simply fades out the initialization text
 /datum/controller/subsystem/title/proc/fade_init_text()
-	update_init_text()
-	animate(init_stat_holder, alpha = 0, time = 8 SECONDS)
-
-/// Abstract holder for maptext on the lobby screen
-/obj/effect/abstract/maptext_holder
-	icon = null
-	icon_state = null
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	plane = SPLASHSCREEN_PLANE
-	/// Conceals the holder from clients who don't want to see it
-	var/image/hide_me
-
-/obj/effect/abstract/maptext_holder/Initialize(mapload)
-	. = ..()
-	for(var/mob/dead/new_player/lobby_goer as anything in GLOB.new_player_list)
-		check_client(lobby_goer.client)
-
-/// Check if the client should see or should not see the initialization information. Updates accordingly.
-/obj/effect/abstract/maptext_holder/proc/check_client(client/seer)
-	if(isnull(seer))
-		return
-	if(!check_preferences(seer))
-		hide_from_client(seer)
-		return
-	show_to_client(seer)
-
-/// Return TRUE if this maptext holder should be visible to the client
-/obj/effect/abstract/maptext_holder/proc/check_preferences(client/seer)
-	// default check for widescreen, because elements at the edge of the screen are cut off and i'm too lazy to fix it
-	return seer.prefs.read_preference(/datum/preference/toggle/widescreen)
-
-/// Hides the initialization information from the client
-/obj/effect/abstract/maptext_holder/proc/hide_from_client(client/seer)
-	if(isnull(hide_me))
-		hide_me = image(loc = src)
-		hide_me.override = TRUE
-	seer?.images |= hide_me
-
-/// Shows the initialization information to the client (if already hidden, otherwise nothing happens)
-/obj/effect/abstract/maptext_holder/proc/show_to_client(client/seer)
-	seer?.images -= hide_me
-
-/obj/effect/abstract/maptext_holder/init
-	maptext_height = 500
-	maptext_width = 200
-	maptext_x = 12
-	maptext_y = 12
-	pixel_x = -64
-
-/obj/effect/abstract/maptext_holder/init/check_preferences(client/seer)
-	return ..() && seer.prefs.read_preference(/datum/preference/toggle/show_init_stats)
-
-/obj/effect/abstract/maptext_holder/music
-	icon = 'maplestation_modules/icons/hud/lobby_spinner.dmi'
-	icon_state = "spinner"
-	maptext_height = 64
-	maptext_width = 200
-	maptext_x = 36
-	maptext_y = 6
-	pixel_y = 6
-	pixel_x = 420
-
-/obj/effect/abstract/maptext_holder/music/check_preferences(client/seer)
-	return ..() && seer.prefs.read_preference(/datum/preference/toggle/sound_lobby)
+	for(var/mob/dead/new_player/lobbyguy as anything in GLOB.new_player_list)
+		for(var/atom/movable/screen/lobby_init_text/text in lobbyguy.hud_used?.static_inventory)
+			animate(text, alpha = 0, time = 8 SECONDS)
+	stats_faded = TRUE

--- a/code/game/machinery/digital_clock.dm
+++ b/code/game/machinery/digital_clock.dm
@@ -9,6 +9,7 @@
 	density = FALSE
 	layer = ABOVE_WINDOW_LAYER
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 7, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 4)
+	subsystem_type = /datum/controller/subsystem/processing/digital_clock
 
 /obj/item/wallframe/digital_clock
 	name = "digital clock frame"
@@ -79,12 +80,7 @@
 
 /obj/machinery/digital_clock/Initialize(mapload)
 	. = ..()
-	START_PROCESSING(SSdigital_clock, src)
 	find_and_hang_on_wall()
-
-/obj/machinery/digital_clock/Destroy()
-	STOP_PROCESSING(SSdigital_clock, src)
-	return ..()
 
 /obj/machinery/digital_clock/process(seconds_per_tick)
 	if(machine_stat & NOPOWER)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -194,6 +194,13 @@
 
 	if(prefs && (prefs.read_preference(/datum/preference/toggle/sound_lobby)) && !CONFIG_GET(flag/disallow_title_music))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+		for(var/atom/movable/screen/lobby_music/text in mob.hud_used?.static_inventory)
+			text.start_tracking()
+
+/client/proc/stoptitlemusic()
+	mob.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	for(var/atom/movable/screen/lobby_music/text in mob.hud_used?.static_inventory)
+		text.cancel_tracking()
 
 ///get a random frequency.
 /proc/get_rand_frequency()

--- a/code/modules/client/preferences/init_stats.dm
+++ b/code/modules/client/preferences/init_stats.dm
@@ -5,5 +5,8 @@
 	default_value = TRUE
 
 /datum/preference/toggle/show_init_stats/apply_to_client_updated(client/client, value)
-	if(isnewplayer(client.mob))
-		SStitle?.init_stat_holder?.check_client(client)
+	for(var/atom/movable/screen/lobby_init_text/text in client.mob?.hud_used?.static_inventory)
+		if(!value)
+			text.alpha = 0 // go away instantly
+		else if(!SStitle.stats_faded)
+			text.alpha = 255 // show instantly if possible

--- a/code/modules/client/preferences/sounds.dm
+++ b/code/modules/client/preferences/sounds.dm
@@ -89,7 +89,7 @@
 	if (value && isnewplayer(client.mob))
 		client.playtitlemusic()
 	else
-		client.mob.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+		client.stoptitlemusic()
 
 /// Controls hearing admin music
 /datum/preference/toggle/sound_midi

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -53,6 +53,5 @@
 		return
 
 	if(SSticker.current_state < GAME_STATE_SETTING_UP)
-		SStitle?.init_stat_holder?.check_client(client)
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -98,7 +98,7 @@
 		observer.client.init_verbs()
 		observer.client.player_details.time_of_death = world.time
 	observer.update_appearance()
-	observer.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	observer.client?.stoptitlemusic()
 	deadchat_broadcast(" has observed.", "<b>[observer.real_name]</b>", follow_target = observer, turf_target = get_turf(observer), message_type = DEADCHAT_DEATHRATTLE)
 	QDEL_NULL(mind)
 	qdel(src)
@@ -278,7 +278,7 @@
 	if(!.)
 		return
 	new_character.key = key //Manually transfer the key to log them in,
-	new_character.stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	new_character.client?.stoptitlemusic()
 	var/area/joined_area = get_area(new_character.loc)
 	if(joined_area)
 		joined_area.on_joining_game(new_character)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -107,8 +107,7 @@
 		message_admins("Could not find ai landmark for [src]. Yell at a mapper! We are spawning them at their current location.")
 		landmark_loc += loc
 
-	if(client)
-		stop_sound_channel(CHANNEL_LOBBYMUSIC)
+	client?.stoptitlemusic()
 
 	var/mob/living/silicon/ai/our_AI = new /mob/living/silicon/ai(pick(landmark_loc), null, src)
 	. = our_AI

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -758,6 +758,7 @@
 #include "code\controllers\subsystem\processing\fishing.dm"
 #include "code\controllers\subsystem\processing\greyscale.dm"
 #include "code\controllers\subsystem\processing\instruments.dm"
+#include "code\controllers\subsystem\processing\lobby_music_player.dm"
 #include "code\controllers\subsystem\processing\obj.dm"
 #include "code\controllers\subsystem\processing\plumbing.dm"
 #include "code\controllers\subsystem\processing\processing.dm"


### PR DESCRIPTION
1. Works when widescreen is off now, because they're hud elements. yippee
2. Music spinner is in the top left of the screen, rather than bottom right
3. Music spinner now shows time left in the song, and fades out when the song is done