### PR TITLE
Replaces some door + shutter combinations with access panels

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2602,14 +2602,15 @@
 "anw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Tech Storage"
+	name = "Tech Storage";
+	id_tag = "TECH_STORAGE_PASSWORD_PANEL"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage/tech)
 "anx" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -6609,7 +6610,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "aLD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6928,6 +6930,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central/fore)
@@ -7639,6 +7644,9 @@
 	dir = 10
 	},
 /obj/structure/sign/departments/telecomms/alt/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central/fore)
 "aRp" = (
@@ -7688,6 +7696,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central/fore)
@@ -11826,15 +11837,6 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/item/multitool,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/north{
-	id = "evashutter";
-	name = "E.V.A. Storage Shutter Toggle";
-	pixel_x = -24;
-	req_access = list("command")
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "boR" = (
@@ -15203,14 +15205,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bPI" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/security{
-	name = "Armoury"
+	name = "Armoury";
+	id_tag = "ARMORY_PASSWORD_PANEL"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "bPK" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -17504,10 +17509,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"caB" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "caD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17639,13 +17640,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cbx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cby" = (
@@ -17654,10 +17655,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cbz" = (
@@ -17715,6 +17714,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/password_id_panel/tech_storage/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cbG" = (
@@ -20704,13 +20704,9 @@
 /turf/open/misc/asteroid,
 /area/station/maintenance/department/security)
 "csX" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security{
-	name = "Armoury"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/ai_monitored/security/armory)
 "ctf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -24045,6 +24041,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cZn" = (
@@ -24299,22 +24298,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
-"ddA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/command/teleporter)
 "ddM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26619,6 +26602,7 @@
 /area/station/security/courtroom)
 "dVC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "dVH" = (
@@ -29053,9 +29037,6 @@
 "eMc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
@@ -33729,10 +33710,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/button/door/directional/south{
-	id = "evashutter";
-	name = "E.V.A. Storage Shutter Toggle";
-	req_access = list("command")
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -34113,6 +34092,10 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "gvk" = (
+/obj/effect/turf_decal/siding/yellow/corner,
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "gvD" = (
@@ -35703,7 +35686,6 @@
 "gVG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -35711,6 +35693,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/password_id_panel/teleporter/directional/north,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -36619,6 +36605,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
+"hli" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/password_id_panel/eva/directional/south,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "hlo" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -36660,11 +36658,8 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "hnt" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "teleshutter";
-	name = "Teleporter Access Shutter"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "hnz" = (
@@ -43741,6 +43736,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/bridge)
+"jFZ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/storage/tech)
 "jGb" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/ash{
@@ -47338,7 +47339,9 @@
 "kOH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "kPl" = (
@@ -50783,15 +50786,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"lYi" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "evashutter";
-	name = "E.V.A. Storage Shutter"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/command/storage/eva)
 "lYm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51226,6 +51220,8 @@
 	},
 /obj/item/stock_parts/power_store/cell/high,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "mio" = (
@@ -51794,14 +51790,7 @@
 	c_tag = "Central Hallway Teleporter Access";
 	name = "central camera"
 	},
-/obj/machinery/button/door/directional/north{
-	id = "teleshutter";
-	name = "Teleporter Shutter Toggle";
-	req_access = list("command")
-	},
-/obj/item/radio/intercom/directional/north{
-	pixel_y = 35
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "msd" = (
@@ -52508,13 +52497,19 @@
 "mBN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
-	name = "E.V.A. Storage"
+	name = "E.V.A. Storage";
+	id_tag = "EVA_PASSWORD_PANEL"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/access/all/command/eva{
+	id_tag = "EVA_PASSWORD_PANEL"
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "mBV" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -55533,6 +55528,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "nFm" = (
@@ -56084,6 +56080,9 @@
 "nRg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
@@ -56666,7 +56665,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/secure_safe/directional/north,
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = -3;
@@ -58565,7 +58563,7 @@
 	name = "Tech Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage/tech)
 "oIH" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -59688,6 +59686,7 @@
 /obj/item/kirbyplants/organic/plant21,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/password_id_panel/armory/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
 "pcX" = (
@@ -60590,6 +60589,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table,
+/obj/structure/secure_safe/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "psB" = (
@@ -61578,6 +61578,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"pHK" = (
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/storage/tech)
 "pHU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -61811,6 +61817,9 @@
 "pMi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
@@ -63370,10 +63379,6 @@
 /obj/item/storage/box/shipping,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
-"qmS" = (
-/obj/structure/secure_safe/hos,
-/turf/open/floor/carpet/red,
-/area/station/command/heads_quarters/hos)
 "qmV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63715,9 +63720,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "qth" = (
@@ -64448,6 +64450,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
+"qGv" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "qGC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -67967,9 +67978,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "rLk" = (
@@ -68528,7 +68536,7 @@
 	name = "E.V.A. Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "rTI" = (
 /obj/machinery/door/airlock/security/glass{
@@ -70536,11 +70544,6 @@
 	},
 /obj/machinery/computer/teleporter{
 	dir = 8
-	},
-/obj/machinery/button/door/directional/east{
-	id = "teleshutter";
-	name = "Teleporter Shutter Toggle";
-	req_access = list("command")
 	},
 /obj/effect/turf_decal/bot_red/right,
 /turf/open/floor/iron/dark,
@@ -72553,6 +72556,12 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"tpR" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/storage/tech)
 "tpU" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -74529,11 +74538,13 @@
 "tVX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
-	name = "Teleporter Access"
+	name = "Teleporter Access";
+	id_tag = "TELEPORTER_PASSWORD_PANEL"
 	},
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "tWb" = (
 /obj/item/grenade/barrier{
@@ -74966,7 +74977,13 @@
 "ucC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ucF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -83040,24 +83057,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"wTg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "wTh" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/blue{
@@ -83933,10 +83932,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"xeC" = (
-/obj/machinery/status_display/shuttle,
-/turf/closed/wall,
-/area/station/engineering/storage/tech)
 "xeI" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -84540,7 +84535,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/storage/tech)
 "xqK" = (
 /obj/effect/turf_decal/tile/brown{
@@ -107321,7 +107316,7 @@ lKu
 cVv
 dyT
 kyD
-qmS
+pXV
 qoX
 dkE
 aeU
@@ -116555,7 +116550,7 @@ oTs
 cbq
 fwx
 tUl
-gvk
+tpR
 vHK
 nFj
 ucC
@@ -116812,7 +116807,7 @@ bZG
 maW
 sQQ
 ixs
-gvk
+jFZ
 gvk
 pMi
 maU
@@ -117066,11 +117061,11 @@ prS
 prS
 czK
 bZG
-cbq
-xeC
+qGv
+fwx
 jiV
 mTX
-gvk
+pHK
 mNE
 piT
 mTD
@@ -118095,7 +118090,7 @@ prS
 pwS
 bZG
 cbv
-kTq
+qsb
 boN
 rAr
 rFg
@@ -118348,11 +118343,11 @@ dbl
 sqr
 jHu
 lSR
-jKf
-rel
+lih
+iPY
 bZG
-caB
-lYi
+cbq
+kTq
 rKN
 lyT
 wjm
@@ -118604,9 +118599,9 @@ big
 kBo
 vyM
 gYq
-ddA
+kBo
 hnt
-nSd
+iPY
 bZG
 cby
 kTq
@@ -118863,7 +118858,7 @@ rmY
 rFe
 qtb
 jKf
-wTg
+rel
 bZU
 cbx
 mBN
@@ -119122,8 +119117,8 @@ vtw
 tVX
 cZi
 bZG
-cbs
-kTq
+hli
+qsb
 rDe
 whm
 iSG
@@ -119376,7 +119371,7 @@ ogO
 mXv
 frw
 sCo
-jKf
+lih
 gVG
 bZG
 cbz

--- a/code/__HELPERS/memory_helpers.dm
+++ b/code/__HELPERS/memory_helpers.dm
@@ -71,14 +71,15 @@
 		if(new_memory_flags & MEMORY_CHECK_DEAFNESS && HAS_TRAIT(current, TRAIT_DEAF))
 			return
 
-	var/datum/memory/replaced_memory = memories[memory_type]
+	memory_args[1] = src
+	var/datum/memory/created_memory = new memory_type(arglist(memory_args))
+	var/memory_key = created_memory.memory_key()
+
+	var/datum/memory/replaced_memory = memories[memory_key]
 	if(replaced_memory)
 		qdel(replaced_memory)
 
-	memory_args[1] = src
-	var/datum/memory/created_memory = new memory_type(arglist(memory_args))
-
-	memories[memory_type] = created_memory
+	memories[memory_key] = created_memory
 	return created_memory
 
 /**
@@ -119,4 +120,4 @@
 /datum/mind/proc/quick_copy_all_memories(datum/mind/new_memorizer)
 	for(var/memory_path in memories)
 		var/datum/memory/prime_memory = memories[memory_path]
-		new_memorizer.memories[memory_path] = prime_memory.quick_copy_memory(new_memorizer)
+		new_memorizer.memories[prime_memory.memory_key()] = prime_memory.quick_copy_memory(new_memorizer)

--- a/code/datums/components/lockable_storage.dm
+++ b/code/datums/components/lockable_storage.dm
@@ -169,6 +169,7 @@
 	. = ..()
 	if(action != "keypad")
 		return TRUE
+	playsound(src, SFX_TERMINAL_TYPE, 40, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	var/digit = params["digit"]
 	switch(digit)
 		//locking it back up

--- a/code/datums/memory/_memory.dm
+++ b/code/datums/memory/_memory.dm
@@ -408,11 +408,17 @@
 	var/datum/memory/copy/new_copy = new(new_memorizer, protagonist_name, deuteragonist_name, antagonist_name, where, memory_flags)
 	new_copy.name = name
 	new_copy.story_value = story_value
+	new_copy.original_key = memory_key()
 	return new_copy
+
+/// Returns the key to use in memories, for determining duplicates
+/datum/memory/proc/memory_key()
+	return type
 
 // To only be used by quick copies of memories
 /datum/memory/copy
 	memory_flags = MEMORY_NO_STORY
+	var/original_key
 
 /datum/memory/copy/New(datum/mind/memorizer_mind, atom/protagonist, atom/deuteragonist, atom/antagonist, where, new_memory_flags)
 	src.where = where
@@ -422,3 +428,6 @@
 /datum/memory/copy/generate_memory_name()
 	// We just copy the original memory's name anyways
 	return
+
+/datum/memory/copy/memory_key()
+	return original_key

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -31,6 +31,9 @@
 		"[remembered_id]. The numbers mason, what do they mean!?",
 	)
 
+/datum/memory/key/account/memory_key()
+	return "[type]-[remembered_id]"
+
 /// The code to the captain's spare ID, ONLY give to the real captain.
 /datum/memory/key/captains_spare_code
 	var/safe_code
@@ -54,6 +57,8 @@
 		"[safe_code][rand(0,9)]. The numbers mason, what do they mean!?", // Same as the account code
 	)
 
+/datum/memory/key/captains_spare_code/memory_key()
+	return "[type]-[safe_code]"
 
 /// The nuclear bomb code, for nuke ops
 /datum/memory/key/nuke_code
@@ -78,6 +83,9 @@
 		"A piece of paper with the number [nuclear_code] being handed to [protagonist_name] from a figure in a blood-red MODsuit.",
 	)
 
+/datum/memory/key/nuke_code/memory_key()
+	return "[type]-[nuclear_code]"
+
 /// Tracks what medicines someone with the "allergies" quirk is allergic to
 /datum/memory/key/quirk_allergy
 	memory_flags = MEMORY_FLAG_NOMOOD|MEMORY_FLAG_NOLOCATION|MEMORY_FLAG_NOPERSISTENCE|MEMORY_SKIP_UNCONSCIOUS|MEMORY_NO_STORY // No story for this
@@ -98,6 +106,9 @@
 
 /datum/memory/key/quirk_allergy/get_starts()
 	return list("[protagonist_name] sneezing after coming into contact with [allergy_string].")
+
+/datum/memory/key/quirk_allergy/memory_key()
+	return type
 
 /// Tracks what brand a smoker quirk user likes
 /datum/memory/key/quirk_smoker
@@ -127,6 +138,9 @@
 /datum/memory/key/quirk_smoker/get_moods()
 	return list("[memorizer] [mood_verb] as they light another up.")
 
+/datum/memory/key/quirk_smoker/memory_key()
+	return type
+
 /// Tracks what beverage an alcoholic quirk user likes
 /datum/memory/key/quirk_alcoholic
 	memory_flags = MEMORY_FLAG_NOLOCATION|MEMORY_FLAG_NOPERSISTENCE|MEMORY_SKIP_UNCONSCIOUS // Does not have nomood
@@ -155,6 +169,9 @@
 /datum/memory/key/quirk_alcoholic/get_moods()
 	return list("[memorizer] [mood_verb] as they drink some [preferred_brandy].")
 
+/datum/memory/key/quirk_alcoholic/memory_key()
+	return type
+
 /// Where our traitor uplink is, and what is its code
 /datum/memory/key/traitor_uplink
 	var/uplink_loc
@@ -180,6 +197,9 @@
 		"[protagonist_name] punching in [uplink_code] into their [uplink_loc].",
 		"[protagonist_name] writing down [uplink_code] with their [uplink_loc] besides them, so as to not forget it.",
 	)
+
+/datum/memory/key/traitor_uplink/memory_key()
+	return "[type]-[uplink_loc]-[uplink_code]"
 
 /datum/memory/key/traitor_uplink/implant
 
@@ -214,6 +234,9 @@
 		"[protagonist_name] committing the crimes of [crimes].",
 	)
 
+/datum/memory/key/permabrig_crimes/memory_key()
+	return "[type]-[crimes]"
+
 /datum/memory/key/message_server_key
 	var/decrypt_key
 
@@ -236,3 +259,36 @@
 		"Poly the parrot screaming \"[decrypt_key]!\" over and over again.",
 		"[protagonist_name] spilling coffee over the message monitor while typing [decrypt_key].",
 	)
+
+/datum/memory/key/message_server_key/memory_key()
+	return "[type]-[decrypt_key]"
+
+/// Generic password memory
+/datum/memory/key/important_password
+	var/location
+	var/password
+
+/datum/memory/key/important_password/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	location,
+	password,
+)
+	src.location = location
+	src.password = password
+	return ..()
+
+/datum/memory/key/important_password/get_names()
+	return list("The password to [location]: [password].")
+
+/datum/memory/key/important_password/get_starts()
+	return list(
+		"[protagonist_name] writing down the password [password] for [location] on a sticky note.",
+		"[protagonist_name] typing in [password] to access [location].",
+		"[protagonist_name] being told the password [password] to access [location].",
+	)
+
+/datum/memory/key/important_password/memory_key()
+	return "[type]-[location]-[password]"

--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -9,25 +9,18 @@
 /// Forces the airlock to unbolt and open
 /obj/machinery/door/airlock/proc/secure_open()
 	set waitfor = FALSE
-	locked = FALSE
-	update_appearance()
-
+	unbolt()
 	stoplag(0.2 SECONDS)
 	open(FORCING_DOOR_CHECKS)
-
-	locked = TRUE
-	update_appearance()
+	bolt()
 
 /// Forces the airlock to close and bolt
 /obj/machinery/door/airlock/proc/secure_close(force_crush = FALSE)
 	set waitfor = FALSE
-
-	locked = FALSE
+	unbolt()
 	close(forced = TRUE, force_crush = force_crush)
-
-	locked = TRUE
+	bolt()
 	stoplag(0.2 SECONDS)
-	update_appearance()
 
 /obj/machinery/door/airlock/on_magic_unlock(datum/source, datum/action/cooldown/spell/aoe/knock/spell, mob/living/caster)
 	// Airlocks should unlock themselves when knock is casted, THEN open up.

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6375,6 +6375,7 @@
 #include "maplestation_modules\code\game\objects\spawners\random\contraband.dm"
 #include "maplestation_modules\code\game\objects\structures\item_dispensers.dm"
 #include "maplestation_modules\code\game\objects\structures\operating_computer.dm"
+#include "maplestation_modules\code\game\objects\structures\pass_id_panel.dm"
 #include "maplestation_modules\code\game\objects\structures\stasis.dm"
 #include "maplestation_modules\code\game\objects\structures\static_plaques.dm"
 #include "maplestation_modules\code\game\objects\structures\surgery_table.dm"

--- a/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
+++ b/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
@@ -1,0 +1,266 @@
+GLOBAL_LIST_INIT(important_passwords, list())
+
+GLOBAL_LIST_INIT(passwords_to_jobs, list())
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel, 32)
+
+/obj/machinery/password_id_panel
+	name = "access panel"
+	desc = "A panel that controls an airlock. It can be opened via ID card or password, if you know it."
+	icon = 'icons/obj/machines/wallmounts.dmi'
+	icon_state = "keycardpad0"
+	base_icon_state = "keycardpad"
+	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
+	/// Password to open the door rather than having access from an ID card.
+	var/password = "00000"
+	/// What the user has currently inputted.
+	var/current_input
+	/// The door this panel is linked to.
+	var/obj/machinery/door/airlock/linked_door
+	/// If TRUE, password is saved to a global list so other places can reference it.
+	var/save_password = FALSE
+
+	/// These job datums spawn with the memory of this password.
+	var/list/password_jobs
+	/// The location to use in the memory for this password.
+	var/password_location
+
+/obj/machinery/password_id_panel/post_machine_initialize()
+	. = ..()
+	if(password == "00000")
+		password = randomize_password()
+	if(save_password)
+		GLOB.important_passwords[id_tag] ||= password // first come first serve
+	for(var/job_type in password_jobs)
+		GLOB.passwords_to_jobs[job_type] ||= list()
+		GLOB.passwords_to_jobs[job_type][id_tag] = password_location
+
+	linked_door = find_by_id_tag(SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/airlock), id_tag)
+	if(isnull(linked_door))
+		stack_trace("No door found with ID tag [id_tag] for password panel!")
+		return
+
+	RegisterSignal(linked_door, COMSIG_QDELETING, PROC_REF(on_linked_door_deleted))
+	req_access = linked_door.req_access?.Copy()
+	req_one_access = linked_door.req_one_access?.Copy()
+	linked_door.can_open_with_hands = FALSE
+	linked_door.safe = FALSE
+	linked_door.autoclose = FALSE
+	linked_door.secure_close()
+	update_appearance()
+
+/obj/machinery/password_id_panel/Destroy()
+	if(!QDELETED(linked_door))
+		linked_door.can_open_with_hands = initial(linked_door.can_open_with_hands)
+		linked_door.safe = initial(linked_door.safe)
+		linked_door.autoclose = initial(linked_door.autoclose)
+		UnregisterSignal(linked_door, COMSIG_QDELETING)
+	linked_door = null
+	return ..()
+
+/obj/machinery/password_id_panel/examine(mob/user)
+	. = ..()
+	if(user.mind?.assigned_role.type in password_jobs)
+		. += span_green("You know the password: [password].")
+
+/obj/machinery/password_id_panel/proc/on_linked_door_deleted(...)
+	SIGNAL_HANDLER
+
+	UnregisterSignal(linked_door, COMSIG_QDELETING)
+	linked_door = null
+
+	if(QDELING(src))
+		return
+	update_appearance()
+
+/obj/machinery/password_id_panel/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	var/obj/item/card/id/id = tool.GetID()
+	if(isnull(id))
+		return NONE
+
+	playsound(src, 'sound/machines/card_slide.ogg', 45, TRUE)
+	if(!valid_id(user, id))
+		access_denied(user)
+		return ITEM_INTERACT_BLOCKING
+
+	access_granted(user)
+	return ITEM_INTERACT_SUCCESS
+
+/// Returns a random 5 digit password.
+/obj/machinery/password_id_panel/proc/randomize_password()
+	return "[rand(0, 9)][rand(0, 9)][rand(0, 9)][rand(0, 9)][rand(0, 9)]"
+
+/// Verifies the passed ID card can open this door.
+/obj/machinery/password_id_panel/proc/valid_id(mob/living/user, obj/item/card/id/id)
+	return valid_state() && check_access(id)
+
+/// Verifies the current input is the correct password and the panel is in a valid state.
+/obj/machinery/password_id_panel/proc/valid_code(mob/living/user)
+	return valid_state() && current_input == password
+
+/// Additional checks that need to be true for the panel to work.
+/obj/machinery/password_id_panel/proc/valid_state()
+	return TRUE
+
+/// Called when access is denied, either by ID or password.
+/obj/machinery/password_id_panel/proc/access_denied(mob/user)
+	balloon_alert(user, "access denied")
+
+/// Called when access is granted, either by ID or password.
+/obj/machinery/password_id_panel/proc/access_granted(mob/user)
+	balloon_alert(user, "access granted")
+	if(linked_door)
+		if(linked_door.density)
+			linked_door.secure_open()
+		else
+			linked_door.secure_close()
+	update_appearance()
+	current_input = ""
+
+/// Checks if the door is "locked", ie, shut and not actively opening
+/obj/machinery/password_id_panel/proc/is_locked()
+	return !!linked_door && linked_door.density && !linked_door.operating
+
+/obj/machinery/password_id_panel/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state][is_locked()]"
+
+/obj/machinery/password_id_panel/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "LockedSafe", "Access Panel")
+		ui.open()
+
+/obj/machinery/password_id_panel/ui_data(mob/user)
+	var/list/data = list()
+	data["input_code"] = current_input || "*****"
+	data["locked"] = is_locked()
+	data["lock_code"] = TRUE
+	return data
+
+/obj/machinery/password_id_panel/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(. || action != "keypad")
+		return TRUE
+
+	playsound(src, SFX_TERMINAL_TYPE, 40, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	var/digit = params["digit"]
+	switch(digit)
+		if("C")
+			current_input = ""
+			if(linked_door && !linked_door.density && !linked_door.operating)
+				linked_door.secure_close()
+			return TRUE
+		if("E")
+			if(valid_code(usr))
+				access_granted(usr)
+			else
+				access_denied(usr)
+				current_input = ""
+			return TRUE
+		if("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
+			if(length(current_input) == 5)
+				return
+			current_input += digit
+			return TRUE
+
+/datum/job/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	for(var/password_id in GLOB.passwords_to_jobs[type])
+		var/password_location = GLOB.passwords_to_jobs[type][password_id]
+		var/password_real = GLOB.important_passwords[password_id]
+		spawned.add_mob_memory(/datum/memory/key/important_password, location = password_location, password = password_real)
+
+/obj/machinery/password_id_panel/armory
+	id_tag = "ARMORY_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_ARMORY)
+	password_jobs = list(
+		/datum/job/head_of_security,
+		/datum/job/warden,
+	)
+	password_location = "the Armory"
+
+/obj/machinery/password_id_panel/armory/valid_state()
+	return SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_BLUE
+
+/obj/machinery/password_id_panel/armory/examine(mob/user)
+	. = ..()
+	. += span_notice("All access attempts are denied unless the station is at [/datum/security_level/blue::name] alert or higher.")
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/armory, 32)
+
+/obj/machinery/password_id_panel/teleporter
+	id_tag = "TELEPORTER_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_TELEPORTER)
+	password_jobs = list(
+		/datum/job/captain,
+		/datum/job/chief_engineer,
+		/datum/job/research_director,
+	)
+	password_location = "the Teleporter Room"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/teleporter, 32)
+
+/obj/machinery/password_id_panel/eva
+	id_tag = "EVA_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_EVA)
+	password_jobs = list(
+		/datum/job/chief_engineer,
+		/datum/job/paramedic,
+	)
+	password_location = "EVA"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/eva, 32)
+
+/obj/machinery/password_id_panel/tech_storage
+	id_tag = "TECH_STORAGE_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_TECH_STORAGE)
+	password_jobs = list(
+		/datum/job/chief_engineer,
+		/datum/job/research_director,
+		/datum/job/roboticist,
+		/datum/job/station_engineer,
+	)
+	password_location = "Tech Storage"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/tech_storage, 32)
+
+/obj/machinery/password_id_panel/telecomms
+	id_tag = "TELECOMMS_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_TCOMMS)
+	password_jobs = list(
+		/datum/job/chief_engineer,
+		/datum/job/station_engineer,
+	)
+	password_location = "the Telecomms Room"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/telecomms, 32)
+
+/obj/machinery/password_id_panel/virology
+	id_tag = "VIROLOGY_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_VIROLOGY)
+	password_jobs = list(
+		/datum/job/chief_medical_officer,
+		/datum/job/doctor,
+		/datum/job/virologist,
+	)
+	password_location = "the Virology Lab"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/virology, 32)
+
+/obj/machinery/password_id_panel/crematorium
+	id_tag = "CREMATORIUM_PASSWORD_PANEL"
+	save_password = TRUE
+	req_access = list(ACCESS_CREMATORIUM)
+	password_jobs = list(
+		/datum/job/chaplain,
+	)
+	password_location = "the Crematorium"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel/crematorium, 32)

--- a/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
+++ b/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
@@ -79,6 +79,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel, 32)
 		return NONE
 
 	playsound(src, 'sound/machines/card_slide.ogg', 45, TRUE)
+	if(!is_operational || !linked_door || !linked_door.is_operational)
+		balloon_alert(user, "nothing happens!")
+		return ITEM_INTERACT_BLOCKING
 	if(!valid_id(user, id))
 		access_denied(user)
 		return ITEM_INTERACT_BLOCKING
@@ -123,7 +126,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel, 32)
 
 /obj/machinery/password_id_panel/update_icon_state()
 	. = ..()
-	icon_state = "[base_icon_state][is_locked()]"
+	icon_state = "[base_icon_state][!is_locked()]"
 
 /obj/machinery/password_id_panel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
+++ b/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
@@ -89,6 +89,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel, 32)
 	access_granted(user)
 	return ITEM_INTERACT_SUCCESS
 
+/obj/machinery/password_id_panel/interact(mob/user)
+	if(isAdminGhostAI(user) || issilicon(user))
+		access_granted(user)
+		return TRUE
+	return ..()
+
 /// Returns a random 5 digit password.
 /obj/machinery/password_id_panel/proc/randomize_password()
 	return "[rand(0, 9)][rand(0, 9)][rand(0, 9)][rand(0, 9)][rand(0, 9)]"

--- a/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
+++ b/maplestation_modules/code/game/objects/structures/pass_id_panel.dm
@@ -126,7 +126,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/password_id_panel, 32)
 
 /obj/machinery/password_id_panel/update_icon_state()
 	. = ..()
-	icon_state = "[base_icon_state][!is_locked()]"
+	icon_state = "[base_icon_state][is_operational || !is_locked()]"
 
 /obj/machinery/password_id_panel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/tgui/packages/tgui/interfaces/LockedSafe.tsx
+++ b/tgui/packages/tgui/interfaces/LockedSafe.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from 'tgui-core/components';
+import { Box, Flex, Stack } from 'tgui-core/components';
 import { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
@@ -16,22 +16,28 @@ export const LockedSafe = (props) => {
   const { act, data } = useBackend<Data>();
   const { input_code, locked, lock_code } = data;
   return (
-    <Window width={300} height={400} theme="ntos">
+    <Window width={300} height={440} theme="retro">
       <Window.Content>
-        <Box m="6px">
-          <Box mb="6px" className="NuclearBomb__displayBox">
-            {input_code}
-          </Box>
-          <Box className="NuclearBomb__displayBox">
-            {!lock_code && 'No password set.'}
-            {!!lock_code && (!locked ? 'Unlocked' : 'Locked')}
-          </Box>
-          <Flex ml="3px">
-            <Flex.Item>
-              <NukeKeypad />
-            </Flex.Item>
-          </Flex>
-        </Box>
+        <Stack vertical>
+          <Stack.Item>
+            <Box mb="6px" className="NuclearBomb__displayBox">
+              {input_code}
+            </Box>
+          </Stack.Item>
+          <Stack.Item>
+            <Box className="NuclearBomb__displayBox">
+              {!lock_code && 'No password set.'}
+              {!!lock_code && (!locked ? 'Unlocked' : 'Locked')}
+            </Box>
+          </Stack.Item>
+          <Stack.Item grow align="center">
+            <Flex width="100%">
+              <Flex.Item>
+                <NukeKeypad />
+              </Flex.Item>
+            </Flex>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION
(I think I subconsciously stole this idea from Kapu) 

Some secure areas with shutters have had their shutters removed and replaced with Access Panels

<img width="564" height="460" alt="image" src="https://github.com/user-attachments/assets/939c636e-6668-4e57-b81e-97fb17b0928c" />

These panels bolt shut the corresponding door until you either
1. Swipe a keycard with the correct access
2. Enter the correct password 

Upon which the door will be bolted open until you either
1. Swipe your keycard once again
2. Clear the password

Some jobs have intrinsic knowledge of the passwords for some doors
<img width="350" height="226" alt="image" src="https://github.com/user-attachments/assets/afa40577-8a4b-40f5-ad74-3c3b6208c72a" />

Some access panels may have additional requirements to be used, such as the armory panel requiring a certain alert level

AIs can override the door as normal, and the doors are hackable as normal

These serve multiple purposes:
- Ever wanted a door to be public access but had no way to accomplish that? Now you can just swipe and forget!
- Lost your ID? You can still access critical rooms for emergencies!
- Only guy who can access something on the other side of the station but you need in urgently? Ask for the password over comms!
- Mind reader? Steal the password from someone's memories!
- RP opportunities by accidentally leaving an important door open? Sure why not!

And in the future we could do stuff like
- Check a keypad for fingerprints to find the password
- Have keypad locked dorms rooms instead of a bolt
