### PR TITLE
Post round hyperfixation fixes: Mostly examine related stuff

### DIFF
--- a/code/__DEFINES/rotation.dm
+++ b/code/__DEFINES/rotation.dm
@@ -8,6 +8,8 @@
 #define ROTATION_NO_FLIPPING (1<<3)
 /// If an object needs to have an empty spot available in target direction (used for windoors and railings)
 #define ROTATION_NEEDS_ROOM (1<<4)
+/// The turf the object is on needs to be unblocked for the rotation to occur
+#define ROTATION_NEEDS_UNBLOCKED (1<<5)
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE -90

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -172,3 +172,6 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 /// Anywhere on Earth
 #define TIMEZONE_ANYWHERE_ON_EARTH -12
+
+/// in the grim darkness of the thirteenth space station there is no timezones, since they break IC game times. Use this for all IC/round time values
+#define NO_TIMEZONE 0

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -606,6 +606,8 @@
 	if(SStitle.stats_faded || !hud?.mymob?.client?.prefs?.read_preference(/datum/preference/toggle/show_init_stats))
 		alpha = 0 // we still need to init it incase they turn it back on
 
+INITIALIZE_IMMEDIATE(/atom/movable/screen/lobby_music)
+
 /atom/movable/screen/lobby_music
 	icon = 'maplestation_modules/icons/hud/lobby_spinner.dmi'
 	icon_state = "spinner"
@@ -635,9 +637,10 @@
 	start_time = world.time
 	end_time = start_time + SSticker.login_length
 	START_PROCESSING(SSlobby_music_player, src)
+	update_maptext()
 
 /atom/movable/screen/lobby_music/process(seconds_per_tick)
-	maptext = "[SStitle.music_maptext]<br>[MAPTEXT("\u25B6 [time2text(min(world.time - start_time, SSticker.login_length), "mm:ss", 0)] / [time2text(SSticker.login_length, "mm:ss", 0)]s")]"
+	update_maptext()
 	if(world.time >= end_time)
 		animate(src, alpha = 0, time = 5 SECONDS)
 		return PROCESS_KILL
@@ -645,6 +648,9 @@
 /atom/movable/screen/lobby_music/proc/cancel_tracking()
 	STOP_PROCESSING(SSlobby_music_player, src)
 	animate(src, alpha = 0, time = 1 SECONDS)
+
+/atom/movable/screen/lobby_music/proc/update_maptext()
+	maptext = "[SStitle.music_maptext]<br>[MAPTEXT("\u25B6 [time2text(max(10, min(world.time - start_time, SSticker.login_length)), "mm:ss", NO_TIMEZONE)] / [time2text(maX(100, SSticker.login_length), "mm:ss", 0)]s")]"
 
 /atom/movable/screen/lobby_music/Destroy()
 	STOP_PROCESSING(SSlobby_music_player, src)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -786,7 +786,7 @@ SUBSYSTEM_DEF(ticker)
 		return
 
 	login_music = new_music
-	login_length = rustg_sound_length(new_music)
+	login_length = rustg_sound_length(new_music) || 1500 // default to 2.5 minutes if we can't get the length
 	var/list/music_file_components = splittext(new_music, "/")
 	var/music_file_name = length(music_file_components) && music_file_components[length(music_file_components)] || new_music
 	var/list/music_name_components = splittext(music_file_name, "+")

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -75,6 +75,7 @@ Behavior that's still missing from this component that original food items had t
 
 /datum/component/edible/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE_TAGS, PROC_REF(examine_tags))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_ANIMAL, PROC_REF(UseByAnimal))
 	RegisterSignal(parent, COMSIG_ATOM_CHECKPARTS, PROC_REF(OnCraft))
 	RegisterSignal(parent, COMSIG_OOZE_EAT_ATOM, PROC_REF(on_ooze_eat))
@@ -110,6 +111,7 @@ Behavior that's still missing from this component that original food items had t
 		COMSIG_ITEM_USED_AS_INGREDIENT,
 		COMSIG_OOZE_EAT_ATOM,
 		COMSIG_ATOM_EXAMINE,
+		COMSIG_ATOM_EXAMINE_TAGS,
 	))
 
 	qdel(GetComponent(/datum/component/connect_loc_behalf))
@@ -214,9 +216,6 @@ Behavior that's still missing from this component that original food items had t
 	var/atom/owner = parent
 	if(food_flags & FOOD_NO_EXAMINE)
 		return
-	if(foodtypes)
-		var/list/types = bitfield_to_list(foodtypes, FOOD_FLAGS)
-		examine_list += span_notice("It is [LOWER_TEXT(english_list(types))].")
 
 	var/quality = get_perceived_food_quality(user)
 	if(quality > 0)
@@ -274,6 +273,14 @@ Behavior that's still missing from this component that original food items had t
 	if (isliving(user))
 		var/mob/living/living_user = user
 		living_user.taste(owner.reagents)
+
+/datum/component/edible/proc/examine_tags(datum/source, mob/user, list/examine_tags)
+	SIGNAL_HANDLER
+
+	if(food_flags & FOOD_NO_EXAMINE)
+		return
+	for(var/foodtype in bitfield_to_list(foodtypes, FOOD_FLAGS))
+		examine_tags[LOWER_TEXT(foodtype)] = "It's \a [LOWER_TEXT(foodtype)] food."
 
 /datum/component/edible/proc/UseFromHand(obj/item/source, mob/living/M, mob/living/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/jukebox.dm
+++ b/code/datums/components/jukebox.dm
@@ -110,10 +110,13 @@
 			new_track.song_beat = text2num(track_data[3])
 			config_songs[new_track.song_name] = new_track
 
-		var/datum/track/default/default_track = new()
-		if(config_songs[default_track.song_name])
-			config_songs["Duplicate-[default_track.song_name]"] = config_songs[default_track.song_name]
-		config_songs[default_track.song_name] = default_track
+		if(!length(config_songs))
+			var/datum/track/default/default_track = new()
+			config_songs["[default_track.song_name] (Default)"] = default_track
+
+		for(var/datum/track/track_subtype in subtypesof(/datum/track/preset))
+			var/datum/track/new_preset = new(track_subtype)
+			config_songs["[new_preset.song_name] (Lag Free)"] = new_preset
 
 	// returns a copy so it can mutate if desired.
 	return config_songs.Copy()
@@ -401,6 +404,30 @@
 
 // Default track supplied for testing and also because it's a banger
 /datum/track/default
+	song_path = 'sound/ambience/title3.ogg'
+	song_name = "Tintin on the Moon"
+	song_length = 3 MINUTES + 52 SECONDS
+	song_beat = 1 SECONDS
+
+/datum/track/preset/title_zero
+	song_path = 'sound/ambience/title0.ogg'
+	song_name = "Endless Space"
+	song_length = 3 MINUTES + 33 SECONDS
+	song_beat = 2 SECONDS
+
+/datum/track/preset/title_one
+	song_path = 'sound/ambience/title1.mod'
+	song_name = "Flip Flap"
+	song_length = 2 MINUTES + 31 SECONDS
+	song_beat = 1 SECONDS
+
+/datum/track/preset/title_two
+	song_path = 'sound/ambience/title2.ogg'
+	song_name = "Robocop"
+	song_length = 1 MINUTES + 58 SECONDS
+	song_beat = 4 SECONDS
+
+/datum/track/preset/title_three
 	song_path = 'sound/ambience/title3.ogg'
 	song_name = "Tintin on the Moon"
 	song_length = 3 MINUTES + 52 SECONDS

--- a/code/datums/components/jukebox.dm
+++ b/code/datums/components/jukebox.dm
@@ -110,9 +110,10 @@
 			new_track.song_beat = text2num(track_data[3])
 			config_songs[new_track.song_name] = new_track
 
-		if(!length(config_songs))
-			var/datum/track/default/default_track = new()
-			config_songs[default_track.song_name] = default_track
+		var/datum/track/default/default_track = new()
+		if(config_songs[default_track.song_name])
+			config_songs["Duplicate-[default_track.song_name]"] = config_songs[default_track.song_name]
+		config_songs[default_track.song_name] = default_track
 
 	// returns a copy so it can mutate if desired.
 	return config_songs.Copy()

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -115,6 +115,13 @@
 			if(!silent)
 				rotated_obj.balloon_alert(user, "can't rotate in that direction!")
 			return FALSE
+
+	if(rotation_flags & ROTATION_NEEDS_UNBLOCKED)
+		var/turf/rotate_turf = get_turf(rotated_obj)
+		if(rotate_turf.is_blocked_turf(source_atom = rotated_obj))
+			if(!silent)
+				rotated_obj.balloon_alert(user, "rotation is blocked!")
+			return FALSE
 	return TRUE
 
 /datum/component/simple_rotation/proc/default_post_rotation(mob/user, degrees)

--- a/code/datums/status_effects/debuffs/genetic_damage.dm
+++ b/code/datums/status_effects/debuffs/genetic_damage.dm
@@ -58,8 +58,9 @@
 		message = "Minor genetic damage detected."
 
 	if(message)
-		render_list += conditional_tooltip("<span class='alert ml-1'>[message]</span>", "Irreparable under normal circumstances - will decay over time.", tochat)
-		render_list += "<br>"
+		render_list += "<span class='alert ml-1'>"
+		render_list += conditional_tooltip("message]", "Irreparable under normal circumstances - will decay over time.", tochat)
+		render_list += "</span><br>"
 
 #undef GORILLA_MUTATION_CHANCE_PER_SECOND
 #undef GORILLA_MUTATION_MINIMUM_DAMAGE

--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -51,8 +51,9 @@
 
 	if(!advanced)
 		return
-	render_list += conditional_tooltip("<span class='info ml-1'>Subject is hallucinating.</span>", "Supply antipsychotic medication, such as [/datum/reagent/medicine/haloperidol::name] or [/datum/reagent/medicine/synaptizine::name].", tochat)
-	render_list += "<br>"
+	render_list += "<span class='info ml-1'>"
+	render_list += conditional_tooltip("Subject is hallucinating.", "Supply antipsychotic medication, such as [/datum/reagent/medicine/haloperidol::name] or [/datum/reagent/medicine/synaptizine::name].", tochat)
+	render_list += "</span><br>"
 
 /// Signal proc for [COMSIG_CARBON_CHECKING_BODYPART],
 /// checking bodyparts while hallucinating can cause them to appear more damaged than they are

--- a/code/game/atom/atom_examine.dm
+++ b/code/game/atom/atom_examine.dm
@@ -109,23 +109,31 @@
  * [COMSIG_ATOM_GET_EXAMINE_NAME] signal
  */
 /atom/proc/get_examine_name(mob/user)
-	var/list/override = list(article, null, "<em>[get_visible_name()]</em>")
+	var/list/override = list(article, null, get_visible_name())
 	SEND_SIGNAL(src, COMSIG_ATOM_GET_EXAMINE_NAME, user, override)
 
-	if(!isnull(override[EXAMINE_POSITION_ARTICLE]))
+	if(gender == PLURAL) // Defaults to "some" for plural because \a will not handle it correctly
+		override[EXAMINE_POSITION_ARTICLE] ||= "some"
+	if(override[EXAMINE_POSITION_ARTICLE])
 		override -= null // IF there is no "before", don't try to join it
 		return jointext(override, " ")
-	if(!isnull(override[EXAMINE_POSITION_BEFORE]))
+	if(override[EXAMINE_POSITION_BEFORE])
 		override -= null // There is no article, don't try to join it
 		return "\a [jointext(override, " ")]"
-	return "\a [src]"
+	return "\a [override[EXAMINE_POSITION_NAME]]"
+
+#define is_capitalized(char) ((text2ascii(char) <= 90) && (text2ascii(char) >= 65))
 
 /mob/living/get_examine_name(mob/user)
 	var/visible_name = get_visible_name()
 	var/list/name_override = list(visible_name)
 	if(SEND_SIGNAL(user, COMSIG_LIVING_PERCEIVE_EXAMINE_NAME, src, visible_name, name_override) & COMPONENT_EXAMINE_NAME_OVERRIDEN)
 		return name_override[1]
-	return visible_name
+	if(is_capitalized(visible_name[1]))
+		return visible_name
+	return "\a [visible_name]"
+
+#undef is_capitalized
 
 /// Icon displayed in examine
 /atom/proc/get_examine_icon(mob/user)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -261,7 +261,7 @@
 	return add_item_to_steal(src, /obj/item/gun/energy/e_gun/hos)
 
 /datum/objective_item/steal/compactshotty
-	name = "the head of security's personal compact shotgun"
+	name = "the warden's personal compact shotgun"
 	targetitem = /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	excludefromjob = list(JOB_HEAD_OF_SECURITY)
 	item_owner = list(JOB_HEAD_OF_SECURITY)
@@ -449,7 +449,7 @@
 	return FALSE
 
 /datum/objective_item/steal/blackbox
-	name = "the Blackbox"
+	name = "the blackbox"
 	targetitem = /obj/item/blackbox
 	excludefromjob = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 	exists_on_map = TRUE

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 /obj/machinery/announcement_system
 	density = TRUE
 	name = "\improper Automated Announcement System"
+	article = "the"
 	desc = "An automated announcement system that handles minor announcements over the radio."
 	icon = 'icons/obj/machines/telecomms.dmi'
 	icon_state = "AAS_On"

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -48,7 +48,7 @@
 #define PREV_GENE 2
 
 /obj/machinery/computer/scan_consolenew
-	name = "DNA Console"
+	name = "\improper DNA Console"
 	desc = "From here you can research mysteries of the DNA!"
 	icon_screen = "dna"
 	icon_keyboard = "med_key"

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 
 /obj/machinery/requests_console
 	name = "requests console"
+	article = "the"
 	desc = "A console intended to send requests to different departments on the station."
 	icon = 'icons/obj/machines/wallmounts.dmi'
 	icon_state = "req_comp_off"

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -63,6 +63,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	AddComponent(/datum/component/simple_rotation, ROTATION_IGNORE_ANCHORED|ROTATION_REQUIRE_WRENCH|ROTATION_NEEDS_UNBLOCKED)
 	register_context()
 
 /obj/machinery/scanner_gate/Destroy(force)
@@ -78,6 +79,10 @@
 	if(n_spect)
 		n_spect.forceMove(drop_location())
 		n_spect = null
+
+/obj/machinery/scanner_gate/setDir(newdir)
+	. = ..()
+	scanline?.setDir(newdir)
 
 /obj/machinery/scanner_gate/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -1,6 +1,6 @@
 // A decorational representation of SSblackbox, usually placed alongside the message server. Also contains a traitor theft item.
 /obj/machinery/blackbox_recorder
-	name = "Blackbox Recorder"
+	name = "blackbox recorder"
 	icon = 'icons/obj/machines/telecomms.dmi'
 	icon_state = "blackbox"
 	density = TRUE
@@ -58,7 +58,8 @@
 	return ..()
 
 /obj/item/blackbox
-	name = "\proper the blackbox"
+	name = "blackbox"
+	article = "the"
 	desc = "A strange relic, capable of recording data on extradimensional vertices. It lives inside the blackbox recorder for safe keeping."
 	icon = 'icons/obj/machines/telecomms.dmi'
 	icon_state = "blackcube"
@@ -76,7 +77,7 @@
  * require the message server.
  */
 /obj/machinery/telecomms/message_server
-	name = "Messaging Server"
+	name = "messaging server"
 	desc = "A machine that processes and routes PDA and request console messages."
 	icon_state = "message_server"
 	telecomms_type = /obj/machinery/telecomms/message_server

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -18,6 +18,7 @@
  */
 /obj/item/blueprints
 	name = "station blueprints"
+	article = "the"
 	desc = "Blueprints of the station. There is a \"Classified\" stamp and several coffee stains on it."
 	icon = 'icons/obj/scrolls.dmi'
 	icon_state = "blueprints"
@@ -255,4 +256,3 @@
 #undef AREA_STATION
 #undef AREA_OUTDOORS
 #undef AREA_SPECIAL
-

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1227,6 +1227,7 @@
 
 /obj/item/card/id/advanced/gold/captains_spare
 	name = "captain's spare ID"
+	article = "the"
 	desc = "The spare ID of the High Lord himself."
 	registered_name = "Captain"
 	trim = /datum/id_trim/job/captain

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -165,7 +165,8 @@
 	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
 
 /obj/item/encryptionkey/heads/captain
-	name = "\proper the captain's encryption key"
+	name = "captain's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/captain"
 	post_init_icon_state = "cypherkey_cube"
@@ -174,7 +175,8 @@
 	greyscale_colors = "#2b2793#dca01b"
 
 /obj/item/encryptionkey/heads/rd
-	name = "\proper the research director's encryption key"
+	name = "research director's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/rd"
 	post_init_icon_state = "cypherkey_research"
@@ -183,7 +185,8 @@
 	greyscale_colors = "#bc4a9b#793a80"
 
 /obj/item/encryptionkey/heads/hos
-	name = "\proper the head of security's encryption key"
+	name = "head of security's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/hos"
 	post_init_icon_state = "cypherkey_security"
@@ -192,7 +195,8 @@
 	greyscale_colors = "#280b1a#820a16"
 
 /obj/item/encryptionkey/heads/ce
-	name = "\proper the chief engineer's encryption key"
+	name = "chief engineer's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/ce"
 	post_init_icon_state = "cypherkey_engineering"
@@ -201,7 +205,8 @@
 	greyscale_colors = "#dca01b#f8d860"
 
 /obj/item/encryptionkey/heads/cmo
-	name = "\proper the chief medical officer's encryption key"
+	name = "chief medical officer's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/cmo"
 	post_init_icon_state = "cypherkey_medical"
@@ -210,7 +215,8 @@
 	greyscale_colors = "#ebebeb#2b2793"
 
 /obj/item/encryptionkey/heads/hop
-	name = "\proper the head of personnel's encryption key"
+	name = "head of personnel's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/hop"
 	post_init_icon_state = "cypherkey_cube"
@@ -219,7 +225,8 @@
 	greyscale_colors = "#2b2793#c2c1c9"
 
 /obj/item/encryptionkey/heads/qm
-	name = "\proper the quartermaster's encryption key"
+	name = "quartermaster's encryption key"
+	article = "the"
 	icon = 'icons/map_icons/items/encryptionkey.dmi'
 	icon_state = "/obj/item/encryptionkey/heads/qm"
 	post_init_icon_state = "cypherkey_cargo"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -242,14 +242,16 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	command = TRUE
 
 /obj/item/radio/headset/heads/captain
-	name = "\proper the captain's headset"
+	name = "captain's headset"
+	article = "the"
 	desc = "The headset of the king."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/captain
 
 /obj/item/radio/headset/heads/captain/alt
-	name = "\proper the captain's bowman headset"
+	name = "captain's bowman headset"
+	article = "the"
 	desc = "The headset of the boss. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
 	worn_icon_state = "com_headset_alt"
@@ -259,21 +261,24 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
 /obj/item/radio/headset/heads/rd
-	name = "\proper the research director's headset"
+	name = "research director's headset"
+	article = "the"
 	desc = "Headset of the fellow who keeps society marching towards technological singularity."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/rd
 
 /obj/item/radio/headset/heads/hos
-	name = "\proper the head of security's headset"
+	name = "head of security's headset"
+	article = "the"
 	desc = "The headset of the man in charge of keeping order and protecting the station."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/hos
 
 /obj/item/radio/headset/heads/hos/advisor
-	name = "\proper the veteran security advisor headset"
+	name = "veteran security advisor's headset"
+	article = "the"
 	desc = "The headset of the man who was in charge of keeping order and protecting the station..."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
@@ -281,7 +286,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	command = FALSE
 
 /obj/item/radio/headset/heads/hos/alt
-	name = "\proper the head of security's bowman headset"
+	name = "head of security's bowman headset"
+	article = "the"
 	desc = "The headset of the man in charge of keeping order and protecting the station. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
 	worn_icon_state = "com_headset_alt"
@@ -291,28 +297,32 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
 /obj/item/radio/headset/heads/ce
-	name = "\proper the chief engineer's headset"
+	name = "chief engineer's headset"
+	article = "the"
 	desc = "The headset of the guy in charge of keeping the station powered and undamaged."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/ce
 
 /obj/item/radio/headset/heads/cmo
-	name = "\proper the chief medical officer's headset"
+	name = "chief medical officer's headset"
+	article = "the"
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/cmo
 
 /obj/item/radio/headset/heads/hop
-	name = "\proper the head of personnel's headset"
+	name = "head of personnel's headset"
+	article = "the"
 	desc = "The headset of the guy who will one day be captain."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/hop
 
 /obj/item/radio/headset/heads/qm
-	name = "\proper the quartermaster's headset"
+	name = "quartermaster's headset"
+	article = "the"
 	desc = "The headset of the guy who runs the cargo department."
 	icon_state = "com_headset"
 	worn_icon_state = "com_headset"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -343,7 +343,9 @@
 		//Genetic stability
 		if(advanced && humantarget.has_dna() && humantarget.dna.stability != initial(humantarget.dna.stability))
 			if(humantarget.dna.stability <= 0)
-				render_list += conditional_tooltip("<span class='alert ml-1'>Genetic Stability: CRITICAL [humantarget.dna.stability] %</span><br>", "Supply [/datum/reagent/medicine/mutadone::name].", tochat)
+				render_list += "<span class='alert ml-1'>"
+				render_list += conditional_tooltip("Genetic Stability: CRITICAL [humantarget.dna.stability] %", "Supply [/datum/reagent/medicine/mutadone::name].", tochat)
+				render_list += "</span><br>"
 			else
 				render_list += "<span class='info ml-1'>Genetic Stability: [humantarget.dna.stability] %</span><br>"
 
@@ -412,7 +414,9 @@
 	var/blood_alcohol_content = target.get_blood_alcohol_content()
 	if(blood_alcohol_content > 0)
 		if(blood_alcohol_content >= 0.24)
-			render_list += conditional_tooltip("<span class='alert ml-1'>Blood alcohol content: <b>CRITICAL [blood_alcohol_content] %</b></span><br>", "Supply [/datum/reagent/medicine/antihol::name], stomach pump, or blood filter.", tochat)
+			render_list += "<span class='alert ml-1'>"
+			render_list += conditional_tooltip("Blood alcohol content: <b>CRITICAL [blood_alcohol_content] %</b>", "Supply [/datum/reagent/medicine/antihol::name], stomach pump, or blood filter.", tochat)
+			render_list += "</span><br>"
 		else
 			render_list += "<span class='info ml-1'>Blood alcohol content: [blood_alcohol_content] %</span><br>"
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -4,6 +4,7 @@
 
 /obj/item/melee/chainofcommand
 	name = "chain of command"
+	article = "the"
 	desc = "A tool used by great men to placate the frothing masses."
 	icon = 'icons/obj/weapons/whip.dmi'
 	icon_state = "chain"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -344,7 +344,7 @@
 	return
 
 /obj/item/stack/medical/bruise_pack
-	name = "bruise pack"
+	name = "bruise packs"
 	singular_name = "bruise pack"
 	desc = "A therapeutic gel pack and bandages designed to treat blunt-force trauma."
 	icon_state = "brutepack"
@@ -564,9 +564,8 @@
 	 */
 
 /obj/item/stack/medical/suture
-	name = "suture"
+	name = "sutures"
 	desc = "Basic sterile sutures used to seal up cuts and lacerations and stop bleeding."
-	gender = PLURAL
 	singular_name = "suture"
 	icon_state = "suture"
 	self_delay = 3 SECONDS
@@ -581,17 +580,19 @@
 	heal_sound = 'maplestation_modules/sound/items/snip.ogg'
 
 /obj/item/stack/medical/suture/emergency
-	name = "emergency suture"
+	name = "emergency sutures"
 	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."
+	singular_name = "emergency suture"
 	heal_brute = 5
 	amount = 5
 	max_amount = 5
 	merge_type = /obj/item/stack/medical/suture/emergency
 
 /obj/item/stack/medical/suture/medicated
-	name = "medicated suture"
-	icon_state = "suture_purp"
+	name = "medicated sutures"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
+	singular_name = "medicated suture"
+	icon_state = "suture_purp"
 	heal_brute = 15
 	stop_bleeding = 1
 	grind_results = list(/datum/reagent/medicine/polypyr = 1)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	))
 
 /obj/item/stack/rods
-	name = "iron rod"
+	name = "iron rods"
 	desc = "Some rods. Can be used for building or something."
 	singular_name = "iron rod"
 	icon_state = "rods"

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -751,3 +751,16 @@
 	add_hiddenprint_list(GET_ATOM_HIDDENPRINTS(from))
 	fingerprintslast = from.fingerprintslast
 	//TODO bloody overlay
+
+/obj/item/stack/update_name(updates)
+	. = ..()
+	if(!singular_name)
+		return
+	if(amount > 1)
+		// only reset if necessary
+		if(singular_name != initial(name))
+			name = initial(name)
+		gender = PLURAL
+	else
+		name = singular_name
+		gender = NEUTER

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -149,6 +149,7 @@
 
 /obj/item/storage/backpack/captain
 	name = "captain's backpack"
+	article = "the"
 	desc = "It's a special backpack made exclusively for Nanotrasen officers."
 	icon_state = "backpack-captain"
 	inhand_icon_state = "captainpack"
@@ -372,6 +373,7 @@
 
 /obj/item/storage/backpack/satchel/cap
 	name = "captain's satchel"
+	article = "the"
 	desc = "An exclusive satchel for Nanotrasen officers."
 	icon_state = "satchel-captain"
 	inhand_icon_state = "satchel-cap"
@@ -530,6 +532,7 @@
 
 /obj/item/storage/backpack/duffelbag/captain
 	name = "captain's duffel bag"
+	article = "the"
 	desc = "A large duffel bag for holding extra captainly goods."
 	icon_state = "duffel-captain"
 	inhand_icon_state = "duffel-captain"
@@ -887,6 +890,7 @@
 
 /obj/item/storage/backpack/messenger/cap
 	name = "captain's messenger bag"
+	article = "the"
 	desc = "An exclusive messenger bag for Nanotrasen officers, made of real whale leather."
 	icon_state = "messenger_captain"
 	inhand_icon_state = "messenger_captain"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -56,7 +56,8 @@
 	))
 
 /obj/item/storage/belt/utility/chief
-	name = "\improper Chief Engineer's toolbelt" //"the Chief Engineer's toolbelt", because "Chief Engineer's toolbelt" is not a proper noun
+	name = "chief engineer's toolbelt"
+	article = "the"
 	desc = "Holds tools, looks snazzy."
 	icon_state = "utility_ce"
 	inhand_icon_state = "utility_ce"

--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -8,34 +8,42 @@
 
 /obj/item/storage/bag/garment/captain
 	name = "captain's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the captain."
 
 /obj/item/storage/bag/garment/hos
 	name = "head of security's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the head of security."
 
 /obj/item/storage/bag/garment/warden
 	name = "warden's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the warden."
 
 /obj/item/storage/bag/garment/hop
 	name = "head of personnel's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the head of personnel."
 
 /obj/item/storage/bag/garment/research_director
 	name = "research director's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the research director."
 
 /obj/item/storage/bag/garment/chief_medical
 	name = "chief medical officer's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the chief medical officer."
 
 /obj/item/storage/bag/garment/engineering_chief
 	name = "chief engineer's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the chief engineer."
 
 /obj/item/storage/bag/garment/quartermaster
-	name = "quartermasters's garment bag"
+	name = "quartermaster's garment bag"
+	article = "the"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the quartermaster."
 
 /obj/item/storage/bag/garment/Initialize(mapload)

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -168,7 +168,8 @@
 		. += medalicon
 
 /obj/item/storage/lockbox/medal/hop
-	name = "Head of Personnel medal box"
+	name = "head of personnel's medal box"
+	article = "the"
 	desc = "A locked box used to store medals to be given to those exhibiting excellence in management."
 	req_access = list(ACCESS_HOP)
 

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -206,6 +206,7 @@
 
 /obj/item/tank/jetpack/oxygen/captain
 	name = "captain's jetpack"
+	article = "the"
 	desc = "A compact, lightweight jetpack containing a high amount of compressed oxygen."
 	icon_state = "jetpack-captain"
 	inhand_icon_state = "jetpack-captain"

--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -20,15 +20,17 @@ path/corner/color_name {\
 	buildstackamount = 1
 	item_chair = null
 	fishing_modifier = -4
+	var/has_armrest = TRUE
 	var/mutable_appearance/armrest
 
 /obj/structure/chair/sofa/Initialize(mapload)
 	. = ..()
-	gen_armrest()
+	if(has_armrest)
+		gen_armrest()
 	AddElement(/datum/element/soft_landing)
 
 /obj/structure/chair/sofa/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
-	if(same_z_layer)
+	if(same_z_layer || !has_armrest)
 		return ..()
 	cut_overlay(armrest)
 	QDEL_NULL(armrest)
@@ -48,7 +50,8 @@ path/corner/color_name {\
 
 /obj/structure/chair/sofa/post_buckle_mob(mob/living/M)
 	. = ..()
-	update_armrest()
+	if(has_armrest)
+		update_armrest()
 
 /obj/structure/chair/sofa/proc/update_armrest()
 	if(has_buckled_mobs())
@@ -58,7 +61,8 @@ path/corner/color_name {\
 
 /obj/structure/chair/sofa/post_unbuckle_mob()
 	. = ..()
-	update_armrest()
+	if(has_armrest)
+		update_armrest()
 
 /obj/structure/chair/sofa/corner/handle_layer() //only the armrest/back of this chair should cover the mob.
 	return
@@ -105,6 +109,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	post_init_icon_state = "bench_middle"
 	greyscale_config = /datum/greyscale_config/bench_middle
 	greyscale_colors = "#af7d28"
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bench/left
 	icon_state = "/obj/structure/chair/sofa/bench/left"
@@ -136,6 +141,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	max_integrity = 60
 	buildstacktype = /obj/item/stack/sheet/mineral/bamboo
 	buildstackamount = 3
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bamboo/left
 	icon_state = "bamboo_sofaend_left"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -246,6 +246,7 @@ LINEN BINS
 
 /obj/item/bedsheet/captain
 	name = "captain's bedsheet"
+	article = "the"
 	desc = "It has a Nanotrasen symbol on it, and was woven with a revolutionary new kind of thread guaranteed to have 0.01% permeability for most non-chemical substances, popular among most modern captains."
 	icon_state = "sheetcaptain"
 	inhand_icon_state = "sheetcaptain"
@@ -253,6 +254,7 @@ LINEN BINS
 
 /obj/item/bedsheet/rd
 	name = "research director's bedsheet"
+	article = "the"
 	desc = "It appears to have a beaker emblem, and is made out of fire-resistant material, although it probably won't protect you in the event of fires you're familiar with every day."
 	icon_state = "sheetrd"
 	inhand_icon_state = "sheetrd"
@@ -261,6 +263,7 @@ LINEN BINS
 // for Free Golems.
 /obj/item/bedsheet/rd/royal_cape
 	name = "Royal Cape of the Liberator"
+	article = "the"
 	desc = "Majestic."
 	dream_messages = list("mining", "stone", "a golem", "freedom", "doing whatever")
 
@@ -273,6 +276,7 @@ LINEN BINS
 
 /obj/item/bedsheet/cmo
 	name = "chief medical officer's bedsheet"
+	article = "the"
 	desc = "It's a sterilized blanket that has a cross emblem. There's some cat fur on it, likely from Runtime."
 	icon_state = "sheetcmo"
 	inhand_icon_state = "sheetcmo"
@@ -280,6 +284,7 @@ LINEN BINS
 
 /obj/item/bedsheet/hos
 	name = "head of security's bedsheet"
+	article = "the"
 	desc = "It is decorated with a shield emblem. While crime doesn't sleep, you do, but you are still THE LAW!"
 	icon_state = "sheethos"
 	inhand_icon_state = "sheethos"
@@ -287,6 +292,7 @@ LINEN BINS
 
 /obj/item/bedsheet/hop
 	name = "head of personnel's bedsheet"
+	article = "the"
 	desc = "It is decorated with a key emblem. For those rare moments when you can rest and cuddle with Ian without someone screaming for you over the radio."
 	icon_state = "sheethop"
 	inhand_icon_state = "sheethop"
@@ -294,6 +300,7 @@ LINEN BINS
 
 /obj/item/bedsheet/ce
 	name = "chief engineer's bedsheet"
+	article = "the"
 	desc = "It is decorated with a wrench emblem. It's highly reflective and stain resistant, so you don't need to worry about ruining it with oil."
 	icon_state = "sheetce"
 	inhand_icon_state = "sheetce"
@@ -301,6 +308,7 @@ LINEN BINS
 
 /obj/item/bedsheet/qm
 	name = "quartermaster's bedsheet"
+	article = "the"
 	desc = "It is decorated with a crate emblem in silver lining.  It's rather tough, and just the thing to lie on after a hard day of pushing paper."
 	icon_state = "sheetqm"
 	inhand_icon_state = "sheetqm"
@@ -308,6 +316,7 @@ LINEN BINS
 
 /obj/item/bedsheet/chaplain
 	name = "chaplain's blanket"
+	article = "the"
 	desc = "A blanket woven with the hearts of gods themselves... Wait, that's just linen."
 	icon_state = "sheetchap"
 	inhand_icon_state = "sheetchap"
@@ -346,6 +355,7 @@ LINEN BINS
 
 /obj/item/bedsheet/wiz
 	name = "wizard's bedsheet"
+	article = "the"
 	desc = "A special fabric enchanted with magic so you can have an enchanted night. It even glows!"
 	icon_state = "sheetwiz"
 	inhand_icon_state = "sheetwiz"

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -1,5 +1,6 @@
 /obj/structure/closet/secure_closet/quartermaster
 	name = "quartermaster's locker"
+	article = "the"
 	req_access = list(ACCESS_QM)
 	icon_state = "qm"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,5 +1,6 @@
 /obj/structure/closet/secure_closet/engineering_chief
 	name = "chief engineer's locker"
+	article = "the"
 	req_access = list(ACCESS_CE)
 	icon_state = "ce"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -71,6 +71,7 @@
 
 /obj/structure/closet/secure_closet/chief_medical
 	name = "chief medical officer's locker"
+	article = "the"
 	req_access = list(ACCESS_CMO)
 	icon_state = "cmo"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -1,5 +1,6 @@
 /obj/structure/closet/secure_closet/research_director
 	name = "research director's locker"
+	article = "the"
 	req_access = list(ACCESS_RD)
 	icon_state = "rd"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -1,5 +1,6 @@
 /obj/structure/closet/secure_closet/captains
 	name = "captain's locker"
+	article = "the"
 	icon_state = "cap"
 	req_access = list(ACCESS_CAPTAIN)
 
@@ -23,6 +24,7 @@
 
 /obj/structure/closet/secure_closet/hop
 	name = "head of personnel's locker"
+	article = "the"
 	icon_state = "hop"
 	req_access = list(ACCESS_HOP)
 
@@ -47,6 +49,7 @@
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"
+	article = "the"
 	icon_state = "hos"
 	req_access = list(ACCESS_HOS)
 
@@ -77,6 +80,7 @@
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"
+	article = "the"
 	icon_state = "warden"
 	req_access = list(ACCESS_ARMORY)
 
@@ -143,7 +147,8 @@
 	new /obj/item/encryptionkey/headset_med(src)
 
 /obj/structure/closet/secure_closet/detective
-	name = "\improper detective's cabinet"
+	name = "detective's cabinet"
+	article = "the"
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70

--- a/code/game/objects/structures/secure_safe.dm
+++ b/code/game/objects/structures/secure_safe.dm
@@ -27,6 +27,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
 
 /obj/structure/secure_safe/hos
 	name = "head of security's safe"
+	article = "the"
 
 /**
  * This safe is meant to be damn robust. To break in, you're supposed to get creative, or use acid or an explosion.
@@ -39,6 +40,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
  */
 /obj/structure/secure_safe/caps_spare
 	name = "captain's spare ID safe"
+	article = "the"
 	desc = "In case of emergency, do not break glass. All Captains and Acting Captains are provided with codes to access this safe. \
 		It is made out of the same material as the station's Black Box and is designed to resist all conventional weaponry. \
 		There appears to be a small amount of surface corrosion. It doesn't look like it could withstand much of an explosion.\

--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -9,7 +9,7 @@
 
 // Relays don't handle any actual communication. Global NTNet datum does that, relays only tell the datum if it should or shouldn't work.
 /obj/machinery/ntnet_relay
-	name = "NTNet Quantum Relay"
+	name = "\improper NTNet quantum relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = ACTIVE_POWER_USE
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 10 //10kW, apropriate for machine that keeps massive cross-Zlevel wireless network operational. Used to be 20 but that actually drained the smes one round

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -11,6 +11,7 @@
 // DAT FUKKEN DISK.
 /obj/item/disk/nuclear
 	name = "nuclear authentication disk"
+	article = "the"
 	desc = "Better keep this safe."
 	icon_state = "nucleardisk"
 	max_integrity = 250

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -93,9 +93,6 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		buildstage = AIR_ALARM_BUILD_NO_CIRCUIT
 		set_panel_open(TRUE)
 
-	if(name == initial(name))
-		name = "[get_area_name(src)] Air Alarm"
-
 	tlv_collection = list()
 	tlv_collection["pressure"] = new /datum/tlv/pressure
 	tlv_collection["temperature"] = new /datum/tlv/temperature
@@ -166,7 +163,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /obj/machinery/airalarm/update_name(updates)
 	. = ..()
-	name = "[get_area_name(my_area)] Air Alarm"
+	name = "\improper [get_area_name(my_area, TRUE)] air alarm"
+	article = "the"
 
 /obj/machinery/airalarm/on_exit_area(datum/source, area/area_to_unregister)
 	//we cannot unregister from an area we never registered to in the first place

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -118,7 +118,7 @@
 // Basic canister per gas below here
 
 /obj/machinery/portable_atmospherics/canister/air
-	name = "Air canister"
+	name = "\improper Air canister"
 	desc = "Pre-mixed air."
 	icon_state = "/obj/machinery/portable_atmospherics/canister/air"
 	post_init_icon_state = ""
@@ -126,7 +126,7 @@
 	greyscale_colors = "#c6c0b5"
 
 /obj/machinery/portable_atmospherics/canister/antinoblium
-	name = "Antinoblium canister"
+	name = "\improper Antinoblium canister"
 	gas_type = /datum/gas/antinoblium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/antinoblium"
@@ -143,7 +143,7 @@
 	greyscale_colors = "#9b5d7f#d0d2a0"
 
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide
-	name = "Carbon dioxide canister"
+	name = "\improper Carbon dioxide canister"
 	gas_type = /datum/gas/carbon_dioxide
 	icon_state = "/obj/machinery/portable_atmospherics/canister/carbon_dioxide"
 	post_init_icon_state = ""
@@ -151,7 +151,7 @@
 	greyscale_colors = "#4e4c48#eaeaea"
 
 /obj/machinery/portable_atmospherics/canister/freon
-	name = "Freon canister"
+	name = "\improper Freon canister"
 	gas_type = /datum/gas/freon
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/freon"
@@ -160,7 +160,7 @@
 	greyscale_colors = "#6696ee#fefb30"
 
 /obj/machinery/portable_atmospherics/canister/halon
-	name = "Halon canister"
+	name = "\improper Halon canister"
 	gas_type = /datum/gas/halon
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/halon"
@@ -169,7 +169,7 @@
 	greyscale_colors = "#9b5d7f#368bff"
 
 /obj/machinery/portable_atmospherics/canister/healium
-	name = "Healium canister"
+	name = "\improper Healium canister"
 	gas_type = /datum/gas/healium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/healium"
@@ -178,7 +178,7 @@
 	greyscale_colors = "#009823#ff0e00"
 
 /obj/machinery/portable_atmospherics/canister/helium
-	name = "Helium canister"
+	name = "\improper Helium canister"
 	gas_type = /datum/gas/helium
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/helium"
@@ -187,7 +187,7 @@
 	greyscale_colors = "#9b5d7f#368bff"
 
 /obj/machinery/portable_atmospherics/canister/hydrogen
-	name = "Hydrogen canister"
+	name = "\improper Hydrogen canister"
 	gas_type = /datum/gas/hydrogen
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/hydrogen"
@@ -196,7 +196,7 @@
 	greyscale_colors = "#eaeaea#be3455"
 
 /obj/machinery/portable_atmospherics/canister/miasma
-	name = "Miasma canister"
+	name = "\improper Miasma canister"
 	gas_type = /datum/gas/miasma
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/miasma"
@@ -205,7 +205,7 @@
 	greyscale_colors = "#009823#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
-	name = "Nitrogen canister"
+	name = "\improper Nitrogen canister"
 	gas_type = /datum/gas/nitrogen
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrogen"
 	post_init_icon_state = ""
@@ -213,7 +213,7 @@
 	greyscale_colors = "#e9ff5c#f4fce8"
 
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide
-	name = "Nitrous oxide canister"
+	name = "\improper Nitrous oxide canister"
 	gas_type = /datum/gas/nitrous_oxide
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrous_oxide"
 	post_init_icon_state = ""
@@ -221,7 +221,7 @@
 	greyscale_colors = "#c63e3b#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/nitrium
-	name = "Nitrium canister"
+	name = "\improper Nitrium canister"
 	gas_type = /datum/gas/nitrium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nitrium"
 	post_init_icon_state = ""
@@ -229,7 +229,7 @@
 	greyscale_colors = "#7b4732"
 
 /obj/machinery/portable_atmospherics/canister/nob
-	name = "Hyper-noblium canister"
+	name = "\improper Hyper-noblium canister"
 	gas_type = /datum/gas/hypernoblium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/nob"
 	post_init_icon_state = ""
@@ -237,7 +237,7 @@
 	greyscale_colors = "#6399fc#b2b2b2"
 
 /obj/machinery/portable_atmospherics/canister/oxygen
-	name = "Oxygen canister"
+	name = "\improper Oxygen canister"
 	gas_type = /datum/gas/oxygen
 	icon_state = "/obj/machinery/portable_atmospherics/canister/oxygen"
 	post_init_icon_state = ""
@@ -245,7 +245,7 @@
 	greyscale_colors = "#2786e5#e8fefe"
 
 /obj/machinery/portable_atmospherics/canister/pluoxium
-	name = "Pluoxium canister"
+	name = "\improper Pluoxium canister"
 	gas_type = /datum/gas/pluoxium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/pluoxium"
 	post_init_icon_state = ""
@@ -253,7 +253,7 @@
 	greyscale_colors = "#2786e5"
 
 /obj/machinery/portable_atmospherics/canister/proto_nitrate
-	name = "Proto Nitrate canister"
+	name = "\improper Proto Nitrate canister"
 	gas_type = /datum/gas/proto_nitrate
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/proto_nitrate"
@@ -262,7 +262,7 @@
 	greyscale_colors = "#008200#33cc33"
 
 /obj/machinery/portable_atmospherics/canister/plasma
-	name = "Plasma canister"
+	name = "\improper Plasma canister"
 	gas_type = /datum/gas/plasma
 	icon_state = "/obj/machinery/portable_atmospherics/canister/plasma"
 	post_init_icon_state = ""
@@ -270,7 +270,7 @@
 	greyscale_colors = "#f62800#000000"
 
 /obj/machinery/portable_atmospherics/canister/tritium
-	name = "Tritium canister"
+	name = "\improper Tritium canister"
 	gas_type = /datum/gas/tritium
 	icon_state = "/obj/machinery/portable_atmospherics/canister/tritium"
 	post_init_icon_state = ""
@@ -278,7 +278,7 @@
 	greyscale_colors = "#3fcd40#000000"
 
 /obj/machinery/portable_atmospherics/canister/water_vapor
-	name = "Water vapor canister"
+	name = "\improper Water vapor canister"
 	gas_type = /datum/gas/water_vapor
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/water_vapor"
@@ -287,7 +287,7 @@
 	greyscale_colors = "#4c4e4d#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/zauker
-	name = "Zauker canister"
+	name = "\improper Zauker canister"
 	gas_type = /datum/gas/zauker
 	filled = 1
 	icon_state = "/obj/machinery/portable_atmospherics/canister/zauker"
@@ -298,7 +298,7 @@
 // Special canisters below here
 
 /obj/machinery/portable_atmospherics/canister/fusion_test
-	name = "fusion test canister"
+	name = "\improper fusion test canister"
 	desc = "Don't be a badmin."
 	temp_limit = 1e12
 	pressure_limit = 1e14

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -154,6 +154,7 @@
 	desc = "You can totally see in the dark now!"
 	icon_state = "night"
 	inhand_icon_state = "glasses"
+	article = "a set of"
 	flags_cover = GLASSESCOVERSEYES
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	// Dark green
@@ -168,11 +169,13 @@
 /obj/item/clothing/glasses/eyepatch
 	name = "eyepatch"
 	desc = "Yarr."
+	gender = NEUTER
 	icon_state = "eyepatch"
 	base_icon_state = "eyepatch"
 	inhand_icon_state = null
 	actions_types = list(/datum/action/item_action/flip)
 	dog_fashion = /datum/dog_fashion/head/eyepatch
+	custom_materials = null
 
 /obj/item/clothing/glasses/eyepatch/attack_self(mob/user, modifiers)
 	. = ..()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/glasses/hud
 	name = "HUD"
 	desc = "A heads-up display that provides important info in (almost) real time."
+	gender = NEUTER
 	actions_types = list(/datum/action/item_action/toggle_wearable_hud)
 	/// Whether the HUD info is on or off
 	var/display_active = TRUE
@@ -94,6 +95,7 @@
 /obj/item/clothing/glasses/hud/health/sunglasses
 	name = "medical HUDSunglasses"
 	desc = "Sunglasses with a medical HUD."
+	gender = PLURAL
 	icon_state = "sunhudmed"
 	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = GLASSESCOVERSEYES
@@ -137,6 +139,7 @@
 	desc = "Sunglasses with a diagnostic HUD."
 	icon_state = "sunhuddiag"
 	inhand_icon_state = "glasses"
+	gender = PLURAL
 	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = GLASSESCOVERSEYES
 	tint = 1
@@ -179,6 +182,7 @@
 	name = "security HUDSunglasses"
 	desc = "Sunglasses with a security HUD."
 	icon_state = "sunhudsec"
+	gender = PLURAL
 	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = GLASSESCOVERSEYES
 	tint = 1
@@ -213,6 +217,7 @@
 	desc = "GAR glasses with a HUD."
 	icon_state = "gar_sec"
 	inhand_icon_state = "gar_black"
+	gender = PLURAL
 	alternate_worn_layer = ABOVE_BODY_FRONT_HEAD_LAYER
 	force = 10
 	throwforce = 10
@@ -298,6 +303,7 @@
 	name = "police aviators"
 	desc = "For thinking you look cool while brutalizing protestors and minorities."
 	icon_state = "bigsunglasses"
+	gender = PLURAL
 	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = GLASSESCOVERSEYES
 	tint = 1

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -83,6 +83,7 @@
 /obj/item/clothing/gloves/captain
 	desc = "Regal blue gloves, with a nice gold trim, a diamond anti-shock coating, and an integrated thermal barrier. Swanky."
 	name = "captain's gloves"
+	article = "the"
 	icon_state = "captain"
 	inhand_icon_state = null
 	greyscale_colors = null

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -99,6 +99,7 @@
 //Captain
 /obj/item/clothing/head/hats/caphat
 	name = "captain's hat"
+	article = "the"
 	desc = "It's good being the king."
 	icon_state = "captain"
 	inhand_icon_state = "that"
@@ -120,12 +121,14 @@
 
 /obj/item/clothing/head/hats/caphat/parade
 	name = "captain's parade cap"
+	article = "the"
 	desc = "Worn only by Captains with an abundance of class."
 	icon_state = "capcap"
 	dog_fashion = null
 
 /obj/item/clothing/head/caphat/beret
 	name = "captain's beret"
+	article = "the"
 	desc = "For the Captains known for their sense of fashion."
 	icon = 'icons/map_icons/clothing/head/_head.dmi'
 	icon_state = "/obj/item/clothing/head/caphat/beret"
@@ -138,6 +141,7 @@
 //Head of Personnel
 /obj/item/clothing/head/hats/hopcap
 	name = "head of personnel's cap"
+	article = "the"
 	icon_state = "hopcap"
 	desc = "The symbol of true bureaucratic micromanagement."
 	armor_type = /datum/armor/hats_hopcap
@@ -413,6 +417,7 @@
 
 /obj/item/clothing/head/hats/hos/beret
 	name = "head of security's beret"
+	article = "the"
 	desc = "A robust beret for the Head of Security, for looking stylish while not sacrificing protection."
 	icon = 'icons/map_icons/clothing/head/_head.dmi'
 	icon_state = "/obj/item/clothing/head/hats/hos/beret"
@@ -424,6 +429,7 @@
 
 /obj/item/clothing/head/hats/hos/beret/navyhos
 	name = "head of security's formal beret"
+	article = "the"
 	desc = "A special beret with the Head of Security's insignia emblazoned on it. A symbol of excellence, a badge of courage, a mark of distinction."
 	icon_state = "/obj/item/clothing/head/hats/hos/beret/navyhos"
 	greyscale_colors = "#638799#f0cc8f"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -190,6 +190,7 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 
 /obj/item/clothing/mask/gas/atmos/captain
 	name = "captain's gas mask"
+	article = "the"
 	desc = "Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone."
 	icon_state = "gas_cap"
 	inhand_icon_state = "gasmask_captain"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -174,6 +174,7 @@
 
 /obj/item/clothing/suit/armor/hos/trenchcoat/winter
 	name = "head of security's winter trenchcoat"
+	article = "the"
 	desc = "A trenchcoat enhanced with a special lightweight kevlar, padded with wool on the collar and inside. You feel strangely lonely wearing this coat."
 	icon_state = "hoswinter"
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
@@ -241,6 +242,7 @@
 
 /obj/item/clothing/suit/armor/vest/capcarapace
 	name = "captain's carapace"
+	article = "the"
 	desc = "A fireproof armored chestpiece reinforced with ceramic plates and plasteel pauldrons to provide additional protection whilst still offering maximum mobility and flexibility. Issued only to the station's finest, although it does chafe your nipples."
 	icon_state = "capcarapace"
 	inhand_icon_state = "armor"
@@ -266,6 +268,7 @@
 
 /obj/item/clothing/suit/armor/vest/capcarapace/captains_formal
 	name = "captain's parade coat"
+	article = "the"
 	desc = "For when an armoured vest isn't fashionable enough."
 	icon_state = "capformal"
 	inhand_icon_state = null

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -20,36 +20,43 @@
 
 /obj/item/clothing/neck/cloak/hos
 	name = "head of security's cloak"
+	article = "the"
 	desc = "Worn by Securistan, ruling the station with an iron fist."
 	icon_state = "hoscloak"
 
 /obj/item/clothing/neck/cloak/qm
 	name = "quartermaster's cloak"
+	article = "the"
 	desc = "Worn by Cargonia, supplying the station with the necessary tools for survival."
 
 /obj/item/clothing/neck/cloak/cmo
 	name = "chief medical officer's cloak"
+	article = "the"
 	desc = "Worn by Meditopia, the valiant men and women keeping pestilence at bay."
 	icon_state = "cmocloak"
 
 /obj/item/clothing/neck/cloak/ce
 	name = "chief engineer's cloak"
+	article = "the"
 	desc = "Worn by Engitopia, wielders of an unlimited power."
 	icon_state = "cecloak"
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/neck/cloak/rd
 	name = "research director's cloak"
+	article = "the"
 	desc = "Worn by Sciencia, thaumaturges and researchers of the universe."
 	icon_state = "rdcloak"
 
 /obj/item/clothing/neck/cloak/cap
 	name = "captain's cloak"
+	article = "the"
 	desc = "Worn by the commander of Space Station 13."
 	icon_state = "capcloak"
 
 /obj/item/clothing/neck/cloak/hop
 	name = "head of personnel's cloak"
+	article = "the"
 	desc = "Worn by the Head of Personnel. It smells faintly of bureaucracy."
 	icon_state = "hopcloak"
 
@@ -85,4 +92,3 @@
 	desc = "Worn by the wisest of veteran employees, this legendary cloak is only attainable by maintaining a living employment agreement with Nanotrasen for over <b>five thousand hours</b>. This status symbol represents a being is better than you in nearly every quantifiable way, simple as that."
 	icon_state = "playercloak"
 	element_type = /datum/element/skill_reward/veteran
-

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -62,6 +62,7 @@
 //Captain
 /obj/item/clothing/suit/jacket/capjacket
 	name = "captain's parade jacket"
+	article = "the"
 	desc = "Worn by a Captain to show their class."
 	icon_state = "capjacket"
 	inhand_icon_state = "bio_suit"
@@ -245,6 +246,7 @@
 
 /obj/item/clothing/suit/jacket/quartermaster
 	name = "quartermaster's overcoat"
+	article = "the"
 	desc = "A luxury, brown double-breasted overcoat made from kangaroo skin. It's gold cuffs are linked and styled on the credits symbol. It makes you feel more important than you probably are."
 	icon_state = "qm_coat"
 	blood_overlay_type = "coat"
@@ -318,6 +320,7 @@
 
 /obj/item/clothing/suit/jacket/hos/blue
 	name = "head of security's jacket"
+	article = "the"
 	desc = "This piece of clothing was specifically designed for asserting superior authority."
 	icon_state = "hosbluejacket"
 	inhand_icon_state = null
@@ -325,6 +328,7 @@
 
 /obj/item/clothing/suit/jacket/hos/tan
 	name = "head of security's jacket"
+	article = "the"
 	desc = "This piece of clothing was specifically designed for asserting superior authority."
 	icon_state = "hostanjacket"
 	inhand_icon_state = null

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -38,6 +38,7 @@
 
 /obj/item/clothing/suit/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"
+	article = "the"
 	desc = "Bluer than the standard model."
 	icon_state = "labcoat_cmo"
 	inhand_icon_state = null
@@ -68,7 +69,8 @@
 	AddComponent(/datum/component/adjust_fishing_difficulty, -2) //FISH DOCTOR?!
 
 /obj/item/clothing/suit/toggle/labcoat/mad
-	name = "\proper The Mad's labcoat"
+	name = "Mad's labcoat"
+	article = "the"
 	desc = "It makes you look capable of konking someone on the noggin and shooting them into space."
 	icon_state = "labgreen"
 	inhand_icon_state = null

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -161,6 +161,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/captain
 	name = "captain's winter coat"
+	article = "the"
 	desc = "A luxurious winter coat, stuffed with the down of the endangered Uka bird and trimmed with genuine sable. The fabric is an indulgently soft micro-fiber, \
 			and the deep ultramarine colour is only one that could be achieved with minute amounts of crystalline bluespace dust woven into the thread between the plectrums. \
 			Extremely lavish, and extremely durable."
@@ -198,6 +199,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/hop
 	name = "head of personnel's winter coat"
+	article = "the"
 	desc = "A cozy winter coat, covered in thick fur. The breast features a proud yellow chevron, reminding everyone that you're the second banana."
 	icon_state = "coathop"
 	inhand_icon_state = null
@@ -334,6 +336,7 @@
 // Chief Medical Officer
 /obj/item/clothing/suit/hooded/wintercoat/medical/cmo
 	name = "chief medical officer's winter coat"
+	article = "the"
 	desc = "A winter coat in a vibrant shade of blue with a small silver caduceus instead of a plastic zipper tab. The normal liner is replaced with an exceptionally thick, soft layer of fur."
 	icon_state = "coatcmo"
 	inhand_icon_state = null
@@ -462,6 +465,7 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/science/rd
 	name = "research director's winter coat"
+	article = "the"
 	desc = "A thick arctic winter coat with an outdated atomic model instead of a plastic zipper tab. Most in the know are heavily aware that Bohr's model of the atom was outdated by the time of the 1930s when the Heisenbergian and Schrodinger models were generally accepted for true. Nevertheless, we still see its use in anachronism, roleplaying, and, in this case, as a zipper tab. At least it should keep you warm on your ivory pillar."
 	icon_state = "coatrd"
 	inhand_icon_state = null
@@ -555,6 +559,7 @@
 // Chief Engineer
 /obj/item/clothing/suit/hooded/wintercoat/engineering/ce
 	name = "chief engineer's winter coat"
+	article = "the"
 	desc = "A white winter coat with reflective green and yellow stripes. Stuffed with asbestos, treated with fire retardant PBDE, lined with a micro thin sheet of lead foil and snugly fitted to your body's measurements. This baby's ready to save you from anything except the thyroid cancer and systemic fibrosis you'll get from wearing it. The zipper tab is a tiny golden wrench."
 	icon_state = "coatce"
 	inhand_icon_state = null
@@ -608,6 +613,7 @@
 // Quartermaster
 /obj/item/clothing/suit/hooded/wintercoat/cargo/qm
 	name = "quartermaster's winter coat"
+	article = "the"
 	desc = "A dark brown winter coat that has a golden crate pin for its zipper pully."
 	icon_state = "coatqm"
 	inhand_icon_state = null

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -105,6 +105,7 @@
 
 /obj/item/clothing/accessory/medal/gold/captain
 	name = "medal of captaincy"
+	article = "the"
 	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of a captain to Nanotrasen, and their undisputable authority over their crew."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -259,7 +259,6 @@
 	acid = 30
 
 /obj/item/clothing/under/costume/buttondown
-	gender = PLURAL
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	custom_price = PAYCHECK_CREW
 	icon = 'icons/obj/clothing/under/shorts_pants_shirts.dmi'

--- a/code/modules/clothing/under/jobs/cargo.dm
+++ b/code/modules/clothing/under/jobs/cargo.dm
@@ -4,12 +4,14 @@
 
 /obj/item/clothing/under/rank/cargo/qm
 	name = "quartermaster's uniform"
+	article = "the"
 	desc = "A brown dress shirt, coupled with a pair of black slacks. It's specially designed to prevent back injuries caused by pushing paper."
 	icon_state = "qm"
 	inhand_icon_state = "lb_suit"
 
 /obj/item/clothing/under/rank/cargo/qm/skirt
 	name = "quartermaster's skirt"
+	article = "the"
 	desc = "A brown dress shirt, coupled with a long pleated black skirt. It's specially designed to prevent back injuries caused by pushing paper."
 	icon_state = "qm_skirt"
 	inhand_icon_state = "lb_suit"

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -30,11 +30,13 @@
 /obj/item/clothing/under/rank/civilian/head_of_personnel
 	desc = "A slick uniform worn by those to earn the position of \"Head of Personnel\"."
 	name = "head of personnel's uniform"
+	article = "the"
 	icon_state = "hop"
 	inhand_icon_state = "b_suit"
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt
 	name = "head of personnel's skirt"
+	article = "the"
 	desc = "A slick uniform and skirt combo worn by those to earn the position of \"Head of Personnel\"."
 	icon_state = "hop_skirt"
 	inhand_icon_state = "b_suit"
@@ -45,6 +47,7 @@
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/suit
 	name = "head of personnel's suit"
+	article = "the"
 	desc = "A teal suit and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit"
 	inhand_icon_state = "g_suit"

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -14,6 +14,7 @@
 
 /obj/item/clothing/under/rank/captain/skirt
 	name = "captain's jumpskirt"
+	article = "the"
 	desc = "It's a blue jumpskirt with some gold markings denoting the rank of \"Captain\"."
 	icon_state = "captain_skirt"
 	inhand_icon_state = "b_suit"
@@ -24,6 +25,7 @@
 
 /obj/item/clothing/under/rank/captain/suit
 	name = "captain's suit"
+	article = "the"
 	desc = "A green suit and yellow necktie. Exemplifies authority."
 	icon_state = "green_suit"
 	inhand_icon_state = "dg_suit"
@@ -31,6 +33,7 @@
 
 /obj/item/clothing/under/rank/captain/suit/skirt
 	name = "green suitskirt"
+	article = "the"
 	desc = "A green suitskirt and yellow necktie. Exemplifies authority."
 	icon_state = "green_suit_skirt"
 	inhand_icon_state = "dg_suit"
@@ -41,6 +44,7 @@
 
 /obj/item/clothing/under/rank/captain/parade
 	name = "captain's parade uniform"
+	article = "the"
 	desc = "A captain's luxury-wear, for special occasions."
 	icon_state = "captain_parade"
 	inhand_icon_state = null

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -13,6 +13,7 @@
 /obj/item/clothing/under/rank/engineering/chief_engineer
 	desc = "It's a high visibility jumpsuit given to those engineers insane enough to achieve the rank of \"Chief Engineer\". Made from fire resistant materials."
 	name = "chief engineer's jumpsuit"
+	article = "the"
 	icon_state = "chiefengineer"
 	inhand_icon_state = "gy_suit"
 	armor_type = /datum/armor/clothing_under/engineering_chief_engineer
@@ -23,6 +24,7 @@
 
 /obj/item/clothing/under/rank/engineering/chief_engineer/skirt
 	name = "chief engineer's jumpskirt"
+	article = "the"
 	desc = "It's a high visibility jumpskirt given to those engineers insane enough to achieve the rank of \"Chief Engineer\". Made from fire resistant materials."
 	icon_state = "chief_skirt"
 	inhand_icon_state = "gy_suit"
@@ -33,6 +35,7 @@
 
 /obj/item/clothing/under/rank/engineering/chief_engineer/turtleneck
 	name = "chief engineer's turtleneck"
+	article = "the"
 	desc = "A yellow turtleneck and white khakis, for a chief engineer with a superior sense of style."
 	icon_state = "ceturtle"
 	inhand_icon_state = "y_suit"
@@ -42,6 +45,7 @@
 
 /obj/item/clothing/under/rank/engineering/chief_engineer/turtleneck/skirt
 	name = "chief engineer's turtleneck skirt"
+	article = "the"
 	desc = "A yellow turtleneck and white khaki skirt, for a chief engineer with a superior sense of style."
 	icon_state = "ceturtle_skirt"
 	inhand_icon_state = "y_suit"

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -25,11 +25,13 @@
 /obj/item/clothing/under/rank/medical/chief_medical_officer
 	desc = "It's a jumpsuit worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	name = "chief medical officer's jumpsuit"
+	article = "the"
 	icon_state = "cmo"
 	inhand_icon_state = "w_suit"
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt
 	name = "chief medical officer's jumpskirt"
+	article = "the"
 	desc = "It's a jumpskirt worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
 	icon_state = "cmo_skirt"
 	inhand_icon_state = "w_suit"
@@ -40,6 +42,7 @@
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/scrubs
 	name = "chief medical officer's scrubs"
+	article = "the"
 	desc = "A distinctive set of white and turquoise scrubs given to chief medical officers who desire a clinical look."
 	icon_state = "scrubscmo"
 	inhand_icon_state = "w_suit"
@@ -50,6 +53,7 @@
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck
 	name = "chief medical officer's turtleneck"
+	article = "the"
 	desc = "A light blue turtleneck and tan khakis, for a chief medical officer with a superior sense of style."
 	icon_state = "cmoturtle"
 	inhand_icon_state = "b_suit"
@@ -59,6 +63,7 @@
 
 /obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck/skirt
 	name = "chief medical officer's turtleneck skirt"
+	article = "the"
 	desc = "A light blue turtleneck and tan khaki skirt, for a chief medical officer with a superior sense of style."
 	icon_state = "cmoturtle_skirt"
 	inhand_icon_state = "b_suit"

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -9,6 +9,7 @@
 /obj/item/clothing/under/rank/rnd/research_director
 	desc = "It's a suit worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	name = "research director's vest suit"
+	article = "the"
 	icon_state = "director"
 	inhand_icon_state = "lb_suit"
 	armor_type = /datum/armor/clothing_under/rnd_research_director
@@ -26,6 +27,7 @@
 
 /obj/item/clothing/under/rank/rnd/research_director/skirt
 	name = "research director's vest suitskirt"
+	article = "the"
 	desc = "It's a suitskirt worn by those with the know-how to achieve the position of \"Research Director\". Its fabric provides minor protection from biological contaminants."
 	icon_state = "director_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS
@@ -35,6 +37,7 @@
 
 /obj/item/clothing/under/rank/rnd/research_director/alt
 	name = "research director's tan suit"
+	article = "the"
 	desc = "Maybe you'll engineer your own half-man, half-pig creature some day. Its fabric provides minor protection from biological contaminants."
 	icon = 'icons/map_icons/clothing/under/_under.dmi'
 	worn_icon = 'icons/mob/clothing/under/shorts_pants_shirts.dmi'
@@ -48,6 +51,7 @@
 
 /obj/item/clothing/under/rank/rnd/research_director/alt/skirt
 	name = "research director's tan suitskirt"
+	article = "the"
 	icon = 'icons/map_icons/clothing/under/_under.dmi'
 	icon_state = "/obj/item/clothing/under/rank/rnd/research_director/alt/skirt"
 	post_init_icon_state = "buttondown_skirt"
@@ -60,6 +64,7 @@
 /obj/item/clothing/under/rank/rnd/research_director/turtleneck
 	desc = "A Nanotrasen-purple turtleneck and black jeans, for a director with a superior sense of style."
 	name = "research director's turtleneck"
+	article = "the"
 	icon_state = "rdturtle"
 	inhand_icon_state = "p_suit"
 	can_adjust = TRUE
@@ -67,6 +72,7 @@
 
 /obj/item/clothing/under/rank/rnd/research_director/turtleneck/skirt
 	name = "research director's turtleneck skirt"
+	article = "the"
 	desc = "A Nanotrasen-purple turtleneck and a black skirt, for a director with a superior sense of style."
 	icon_state = "rdturtle_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -141,6 +141,7 @@
  */
 /obj/item/clothing/under/rank/security/head_of_security
 	name = "head of security's uniform"
+	article = "the"
 	desc = "A security jumpsuit decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "rhos"
 	inhand_icon_state = "r_suit"
@@ -155,6 +156,7 @@
 
 /obj/item/clothing/under/rank/security/head_of_security/skirt
 	name = "head of security's skirt"
+	article = "the"
 	desc = "A security jumpskirt decorated for those few with the dedication to achieve the position of Head of Security."
 	icon_state = "rhos_skirt"
 	inhand_icon_state = "r_suit"
@@ -165,12 +167,14 @@
 
 /obj/item/clothing/under/rank/security/head_of_security/grey
 	name = "head of security's grey jumpsuit"
+	article = "the"
 	desc = "There are old men, and there are bold men, but there are very few old, bold men."
 	icon_state = "hos"
 	inhand_icon_state = "gy_suit"
 
 /obj/item/clothing/under/rank/security/head_of_security/alt
 	name = "head of security's turtleneck"
+	article = "the"
 	desc = "A stylish alternative to the normal head of security jumpsuit, complete with tactical pants."
 	icon_state = "hosalt"
 	inhand_icon_state = "bl_suit"
@@ -178,6 +182,7 @@
 
 /obj/item/clothing/under/rank/security/head_of_security/alt/skirt
 	name = "head of security's turtleneck skirt"
+	article = "the"
 	desc = "A stylish alternative to the normal head of security jumpsuit, complete with a tactical skirt."
 	icon_state = "hosalt_skirt"
 	inhand_icon_state = "bl_suit"
@@ -189,6 +194,7 @@
 
 /obj/item/clothing/under/rank/security/head_of_security/parade
 	name = "head of security's parade uniform"
+	article = "the"
 	desc = "A male head of security's luxury-wear, for special occasions."
 	icon_state = "hos_parade_male"
 	inhand_icon_state = "r_suit"
@@ -196,6 +202,7 @@
 
 /obj/item/clothing/under/rank/security/head_of_security/parade/female
 	name = "head of security's parade uniform"
+	article = "the"
 	desc = "A female head of security's luxury-wear, for special occasions."
 	icon_state = "hos_parade_fem"
 	inhand_icon_state = "r_suit"
@@ -205,6 +212,7 @@
 /obj/item/clothing/under/rank/security/head_of_security/formal
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
 	name = "head of security's formal uniform"
+	article = "the"
 	icon_state = "hosblueclothes"
 	inhand_icon_state = null
 	alt_covers_chest = TRUE

--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -4,6 +4,7 @@
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	custom_price = PAYCHECK_CREW
+	article = "a pair of"
 	icon = 'icons/obj/clothing/under/shorts_pants_shirts.dmi'
 	worn_icon = 'icons/mob/clothing/under/shorts_pants_shirts.dmi'
 	species_exception = list(/datum/species/golem)

--- a/code/modules/clothing/under/shorts.dm
+++ b/code/modules/clothing/under/shorts.dm
@@ -8,6 +8,7 @@
 	greyscale_config_worn = /datum/greyscale_config/shorts/worn
 	greyscale_colors = "#575757#3E3E3E#75634F"
 	gender = PLURAL
+	article = "a pair of"
 	body_parts_covered = GROIN
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	supports_variations_flags = CLOTHING_NO_VARIATION

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -300,6 +300,7 @@
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE
 	decomp_type = /obj/item/food/deadmouse/moldy
+	food_flags = FOOD_FINGER_FOOD
 	var/body_color = "gray"
 	var/critter_type = /mob/living/basic/mouse
 

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -102,10 +102,12 @@
 
 /obj/item/folder/biscuit/confidential/spare_id_safe_code
 	name = "spare ID safe code biscuit card"
+	article = "the"
 	contained_slip = /obj/item/paper/paperslip/corporate/fluff/spare_id_safe_code
 
 /obj/item/folder/biscuit/confidential/emergency_spare_id_safe_code
 	name = "spare emergency ID safe code biscuit card"
+	article = "the"
 	contained_slip = /obj/item/paper/paperslip/corporate/fluff/emergency_spare_id_safe_code
 
 //Biscuits which start open. Used for crafting, printing, and such

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -180,6 +180,7 @@
 
 /obj/item/pen/fountain/captain
 	name = "captain's fountain pen"
+	article = "the"
 	desc = "It's an expensive Oak fountain pen. The nib is quite sharp."
 	icon_state = "pen-fountain-o"
 	force = 5

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -35,6 +35,7 @@
 	dye_color = DYE_LAW
 
 /obj/item/stamp/head
+	article = "the"
 
 /obj/item/stamp/head/Initialize(mapload)
 	. = ..()
@@ -82,7 +83,7 @@
 	dye_color = DYE_REDCOAT
 
 /obj/item/stamp/void
-	name = "VOID rubber stamp"
+	name = "\improper VOID rubber stamp"
 	icon_state = "stamp-void"
 
 /obj/item/stamp/clown
@@ -98,15 +99,16 @@
 /obj/item/stamp/chap
 	name = "chaplain's rubber stamp"
 	icon_state = "stamp-chap"
+	article = "the"
 	dye_color = DYE_CHAP
 
 /obj/item/stamp/centcom
-	name = "CentCom rubber stamp"
+	name = "\improper CentCom rubber stamp"
 	icon_state = "stamp-centcom"
 	dye_color = DYE_CENTCOM
 
 /obj/item/stamp/syndicate
-	name = "Syndicate rubber stamp"
+	name = "\improper Syndicate rubber stamp"
 	icon_state = "stamp-syndicate"
 	dye_color = DYE_SYNDICATE
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -200,6 +200,7 @@
 		req_access = list(ACCESS_ENGINE_EQUIP)
 	if(auto_name)
 		name = "\improper [get_area_name(area, TRUE)] APC"
+		article = "the"
 
 	//Initialize its electronics
 	set_wires(new /datum/wires/apc(src))
@@ -267,6 +268,7 @@
 	. = ..()
 	if(auto_name)
 		name = "\improper [get_area_name(area, TRUE)] APC"
+		article = "the"
 
 /obj/machinery/power/apc/proc/assign_to_area(area/target_area = get_area(src))
 	if(area == target_area)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -74,6 +74,7 @@
 
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
+	article = "the"
 	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	cell_type = /obj/item/stock_parts/power_store/cell/hos_gun
 	icon_state = "hoslaser"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -69,6 +69,7 @@
 
 /obj/item/gun/energy/laser/captain
 	name = "antique laser gun"
+	article = "the"
 	icon_state = "caplaser"
 	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = null

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1401,6 +1401,13 @@
 		burn_wound.victim.apply_damage(0.5, TOX, burn_wound.limb, wound_bonus = CANT_WOUND)
 		burn_wound.victim.apply_damage(0.5, BURN, burn_wound.limb, wound_bonus = CANT_WOUND)
 
+/datum/reagent/space_cleaner/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	if(!HAS_TRAIT(affected_mob, TRAIT_TOXINLOVER) && !prob(5))
+		return
+	for(var/obj/item/organ/internal/organ in affected_mob.organs)
+		organ.wash(clean_types|CLEAN_RAD)
+
 /datum/reagent/space_cleaner/ez_clean
 	name = "EZ Clean"
 	description = "A powerful, acidic cleaner sold by Waffle Co. Affects organic matter while leaving other objects unaffected."

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -25,6 +25,11 @@
 		var/list/types = bitfield_to_list(drink_type, FOOD_FLAGS)
 		. += span_notice("It is [LOWER_TEXT(english_list(types))].")
 
+/obj/item/reagent_containers/cup/examine_tags(mob/user)
+	. = ..()
+	for(var/foodtype in bitfield_to_list(drink_type, FOOD_FLAGS))
+		.[LOWER_TEXT(foodtype)] = "It's \a [LOWER_TEXT(foodtype)] drink."
+
 /**
  * Checks if the mob actually liked drinking this cup.
  *

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -72,7 +72,7 @@
 	if(message_in_a_bottle)
 		. += span_info("there's \a [message_in_a_bottle] inside it. Break it to take it out, or find a beach or ocean and toss it with [EXAMINE_HINT("right-click")].")
 	else if(isGlass)
-		. += span_tinynoticeital("you could place a paper, photo or space cash inside it...")
+		. += span_tinynoticeital("You could place a piece of paper, photo or space cash inside it...")
 
 /obj/item/reagent_containers/cup/glass/bottle/update_overlays()
 	. = ..()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -25,7 +25,7 @@
 		return FALSE
 
 /obj/machinery/computer/camera_advanced/xenobio
-	name = "Slime management console"
+	name = "slime management console"
 	desc = "A computer used for remotely handling slimes."
 	networks = list(CAMERANET_NETWORK_SS13)
 	circuit = /obj/item/circuitboard/computer/xenobiology

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -8,6 +8,7 @@
 
 /obj/machinery/computer/shuttle
 	name = "shuttle console"
+	article = "the"
 	desc = "A shuttle control computer."
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -93,7 +93,7 @@
 	machine_name = "MediDrobe"
 
 /obj/machinery/vending/wardrobe/engi_wardrobe
-	name = "EngiDrobe"
+	name = "\improper EngiDrobe"
 	desc = "A vending machine renowned for vending industrial grade clothing."
 	icon_state = "engidrobe"
 	product_ads = "Guaranteed to protect your feet from industrial accidents!;Afraid of radiation? Then wear yellow!"
@@ -123,7 +123,7 @@
 	machine_name = "EngiDrobe"
 
 /obj/machinery/vending/wardrobe/atmos_wardrobe
-	name = "AtmosDrobe"
+	name = "\improper AtmosDrobe"
 	desc = "This relatively unknown vending machine delivers clothing for Atmospherics Technicians, an equally unknown job."
 	icon_state = "atmosdrobe"
 	product_ads = "Get your inflammable clothing right here!!!"
@@ -148,7 +148,7 @@
 	machine_name = "AtmosDrobe"
 
 /obj/machinery/vending/wardrobe/cargo_wardrobe
-	name = "CargoDrobe"
+	name = "\improper CargoDrobe"
 	desc = "A highly advanced vending machine for buying cargo related clothing for free."
 	icon_state = "cargodrobe"
 	product_ads = "Upgraded Assistant Style! Pick yours today!;These shorts are comfy and easy to wear, get yours now!"
@@ -189,7 +189,7 @@
 	machine_name = "CargoDrobe"
 
 /obj/machinery/vending/wardrobe/robo_wardrobe
-	name = "RoboDrobe"
+	name = "\improper RoboDrobe"
 	desc = "A vending machine designed to dispense clothing known only to roboticists."
 	icon_state = "robodrobe"
 	product_ads = "You turn me TRUE, use defines!;0110001101101100011011110111010001101000011001010111001101101000011001010111001001100101"
@@ -223,7 +223,7 @@
 	machine_name = "RoboDrobe"
 
 /obj/machinery/vending/wardrobe/science_wardrobe
-	name = "SciDrobe"
+	name = "\improper SciDrobe"
 	desc = "A simple vending machine suitable to dispense well tailored science clothing. Endorsed by Space Cubans."
 	icon_state = "scidrobe"
 	product_ads = "Longing for the smell of plasma burnt flesh? Buy your science clothing now!;Made with 10% Auxetics, so you don't have to worry about losing your arm!"
@@ -251,7 +251,7 @@
 	machine_name = "SciDrobe"
 
 /obj/machinery/vending/wardrobe/hydro_wardrobe
-	name = "Hydrobe"
+	name = "\improper Hydrobe"
 	desc = "A machine with a catchy name. It dispenses botany related clothing and gear."
 	icon_state = "hydrobe"
 	product_ads = "Do you love soil? Then buy our clothes!;Get outfits to match your green thumb here!"
@@ -279,7 +279,7 @@
 	machine_name = "HyDrobe"
 
 /obj/machinery/vending/wardrobe/curator_wardrobe
-	name = "CuraDrobe"
+	name = "\improper CuraDrobe"
 	desc = "A lowstock vendor only capable of vending clothing for curators and librarians."
 	icon_state = "curadrobe"
 	product_ads = "Glasses for your eyes and literature for your soul, Curadrobe has it all!; Impress & enthrall your library guests with Curadrobe's extended line of pens!"
@@ -312,7 +312,7 @@
 	machine_name = "CuraDrobe"
 
 /obj/machinery/vending/wardrobe/coroner_wardrobe
-	name = "MortiDrobe"
+	name = "\improper MortiDrobe"
 	desc = "A favorite among nihilists."
 	icon_state = "coroner_drobe"
 	product_ads = "Any day above ground is a good one!;My day starts when yours ends!;And they call this a dying business!;See you when you're dead!"
@@ -358,7 +358,7 @@
 	machine_name = "MortiDrobe"
 
 /obj/machinery/vending/wardrobe/bar_wardrobe
-	name = "BarDrobe"
+	name = "\improper BarDrobe"
 	desc = "A stylish vendor to dispense the most stylish bar clothing!"
 	icon_state = "bardrobe"
 	product_ads = "Guaranteed to prevent stains from spilled drinks!"
@@ -394,7 +394,7 @@
 	machine_name = "BarDrobe"
 
 /obj/machinery/vending/wardrobe/chef_wardrobe
-	name = "ChefDrobe"
+	name = "\improper ChefDrobe"
 	desc = "This vending machine might not dispense meat, but it certainly dispenses chef related clothing."
 	icon_state = "chefdrobe"
 	product_ads = "Our clothes are guaranteed to protect you from food splatters!"
@@ -424,7 +424,7 @@
 	machine_name = "ChefDrobe"
 
 /obj/machinery/vending/wardrobe/jani_wardrobe
-	name = "JaniDrobe"
+	name = "\improper JaniDrobe"
 	desc = "A self cleaning vending machine capable of dispensing clothing for janitors."
 	icon_state = "janidrobe"
 	product_ads = "Come and get your janitorial clothing, now endorsed by lizard janitors everywhere!"
@@ -463,7 +463,7 @@
 	machine_name = "JaniDrobe"
 
 /obj/machinery/vending/wardrobe/law_wardrobe
-	name = "LawDrobe"
+	name = "\improper LawDrobe"
 	desc = "Objection! This wardrobe dispenses the rule of law... and lawyer clothing."
 	icon_state = "lawdrobe"
 	product_ads = "OBJECTION! Get the rule of law for yourself!"
@@ -551,7 +551,7 @@
 	machine_name = "DeusVend"
 
 /obj/machinery/vending/wardrobe/chem_wardrobe
-	name = "ChemDrobe"
+	name = "\improper ChemDrobe"
 	desc = "A vending machine for dispensing chemistry related clothing."
 	icon_state = "chemdrobe"
 	product_ads = "Our clothes are 0.5% more resistant to acid spills! Get yours now!"
@@ -582,7 +582,7 @@
 	machine_name = "ChemDrobe"
 
 /obj/machinery/vending/wardrobe/gene_wardrobe
-	name = "GeneDrobe"
+	name = "\improper GeneDrobe"
 	desc = "A machine for dispensing clothing related to genetics."
 	icon_state = "genedrobe"
 	product_ads = "Perfect for the mad scientist in you!"
@@ -607,7 +607,7 @@
 	machine_name = "GeneDrobe"
 
 /obj/machinery/vending/wardrobe/viro_wardrobe
-	name = "ViroDrobe"
+	name = "\improper ViroDrobe"
 	desc = "An unsterilized machine for dispending virology related clothing."
 	icon_state = "virodrobe"
 	product_ads = " Viruses getting you down? Then upgrade to sterilized clothing today!"

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6386,7 +6386,6 @@
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\bridge_officer.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\medical.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\noble_ambassador.dm"
-#include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\quartermaster.dm"
 #include "maplestation_modules\code\game\objects\structures\crate_lockers\closets\secure\security.dm"
 #include "maplestation_modules\code\modules\admin\admin_vv.dm"
 #include "maplestation_modules\code\modules\admin\smites\pain_smite.dm"

--- a/maplestation_modules/code/datums/elements/unique_examine.dm
+++ b/maplestation_modules/code/datums/elements/unique_examine.dm
@@ -34,7 +34,6 @@
 /datum/element/unique_examine/Attach(atom/thing, desc, requirement = EXAMINE_CHECK_NONE, requirement_list, affiliation, hint = TRUE, real_name = "")
 	. = ..()
 
-	/// Init our vars
 	desc_requirement = requirement
 	special_desc = desc
 	special_desc_req = requirement_list
@@ -66,6 +65,11 @@
 	UnregisterSignal(thing, list(COMSIG_ATOM_EXAMINE, COMSIG_ATOM_EXAMINE_MORE))
 
 /datum/element/unique_examine/proc/hint_at(datum/source, mob/examiner, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!toy_name && !get_all_fulfilled_requirements(examiner)[desc_requirement])
+		return
+
 	// What IS this thing anyways?
 	var/thing = "thing"
 	if(ismob(source))
@@ -85,10 +89,14 @@
 	if(isstructure(source))
 		thing = "structure"
 
-	examine_list += span_smallnoticeital("This [thing] might have additional information if you [EXAMINE_CLOSER_BOLD].")
+	examine_list += span_smallnoticeital("This [thing] may have additional information if you [EXAMINE_CLOSER_BOLD].")
 
 /datum/element/unique_examine/proc/examine(datum/source, mob/examiner, list/examine_list)
 	SIGNAL_HANDLER
+
+	var/list/fulfilled_requirements = get_all_fulfilled_requirements(examiner)
+	if(!toy_name && !fulfilled_requirements[desc_requirement])
+		return
 
 	var/datum/mind/examiner_mind = examiner.mind
 	if(!examiner_mind)
@@ -99,75 +107,53 @@
 		//Will always show if set
 		if(EXAMINE_CHECK_NONE)
 			composed_message = "You note the following: <br>"
-
 		//Mindshield checks
 		if(EXAMINE_CHECK_MINDSHIELD)
-			if(HAS_TRAIT(examiner, TRAIT_MINDSHIELD))
-				composed_message = "You note the following because of your [span_blue(span_bold("mindshield"))]: <br>"
-
+			composed_message = "You note the following because of your [span_blue(span_bold("mindshield"))]: <br>"
 		//Syndicate checks
 		if(EXAMINE_CHECK_SYNDICATE)
-			if(check_if_syndicate(examiner_mind))
-				composed_message = "You note the following because of your [span_red(span_bold("Syndicate Affiliation"))]: <br>"
-
+			composed_message = "You note the following because of your [span_red(span_bold("Syndicate Affiliation"))]: <br>"
 		//Aantag checks
 		if(EXAMINE_CHECK_ANTAG)
-			for(var/datum/antagonist/antag_datum as anything in special_desc_req)
-				if(examiner_mind.has_antag_datum(antag_datum))
-					composed_message = "You note the following because of your [span_red(span_bold(special_desc_affiliation ? special_desc_affiliation : "[antag_datum.name] Role"))]: <br>"
-					break
+			var/datum/antagonist/antag_datum = fulfilled_requirements[EXAMINE_CHECK_ANTAG]
+			composed_message = "You note the following because of your [span_red(span_bold(special_desc_affiliation ? special_desc_affiliation : "[antag_datum.name] Role"))]: <br>"
 
 		//Job (title) checks
 		if(EXAMINE_CHECK_JOB)
-			for(var/checked_job in special_desc_req)
-				if(examiner_mind.assigned_role.title == checked_job)
-					composed_message = "You note the following because of your job as a [span_bold(checked_job)]: <br>"
-					break
+			var/checked_job = fulfilled_requirements[EXAMINE_CHECK_JOB]
+			composed_message = "You note the following because of your job as a [span_bold(checked_job)]: <br>"
 
 		//Department checks
 		if(EXAMINE_CHECK_DEPARTMENT)
-			if(examiner_mind.assigned_role.departments_bitflags & special_desc_req)
-				composed_message = "You note the following because of your place [get_department(special_desc_req)]: <br>"
+			composed_message = "You note the following because of your place [get_department(special_desc_req)]: <br>"
 
 		//Standard faction checks
 		if(EXAMINE_CHECK_FACTION)
-			for(var/checked_faction in special_desc_req)
-				if(checked_faction in examiner.faction)
-					composed_message = "You note the following because of your loyalty to [get_formatted_faction(checked_faction)]: <br>"
-					break
+			var/checked_faction = fulfilled_requirements[EXAMINE_CHECK_FACTION]
+			composed_message = "You note the following because of your loyalty to [get_formatted_faction(checked_faction)]: <br>"
 
 		// Skillchip checks
 		if(EXAMINE_CHECK_SKILLCHIP)
-			var/obj/item/organ/internal/brain/examiner_brain = examiner.get_organ_slot(ORGAN_SLOT_BRAIN)
-			for(var/obj/item/skillchip/checked_skillchip in examiner_brain?.skillchips)
-				if(checked_skillchip.active && (checked_skillchip.type in special_desc_req))
-					composed_message += "You note the following because of your implanted [span_readable_yellow(span_bold(checked_skillchip.name))]: <br>"
-					break
+			var/obj/item/skillchip/checked_skillchip = fulfilled_requirements[EXAMINE_CHECK_SKILLCHIP]
+			composed_message = "You note the following because of your implanted [span_readable_yellow(span_bold(checked_skillchip.name))]: <br>"
 
 		// Trait checks
 		if(EXAMINE_CHECK_TRAIT)
-			for(var/checked_trait in special_desc_req)
-				if(HAS_TRAIT(examiner, checked_trait))
-					composed_message += "You note the following because of a [span_readable_yellow(span_bold("trait"))] you have: <br>"
-					break
+			composed_message = "You note the following because of a [span_readable_yellow(span_bold("trait"))] you have: <br>"
 
 		// Species checks
 		if(EXAMINE_CHECK_SPECIES)
-			for(var/datum/species/checked_species as anything in special_desc_req)
-				if(is_species(examiner, checked_species))
-					composed_message += "You note the following because of [span_green(span_bold("your [checked_species.name] species"))]: <br>"
-					break
+			var/mob/living/carbon/human/human_examiner = examiner
+			composed_message = "You note the following because you are a [span_green(span_bold(human_examiner.dna.species.name))]: <br>"
 
-	if(length(composed_message) > 0)
+	if(composed_message)
 		composed_message += special_desc
 	else if(toy_name) //If we don't have a message and we're a toy, add on the toy message.
-		composed_message += "The popular toy resembling \a [toy_name] from your local arcade, suitable for children and adults alike."
+		composed_message = "The popular toy resembling \a [toy_name] from your local arcade, suitable for children and adults alike."
 	examine_list += span_info(composed_message)
 
 /// Check if we're any spice or variety of syndicate (antagonists, ghost roles, or special)
 /datum/element/unique_examine/proc/check_if_syndicate(datum/mind/our_mind)
-	. = FALSE
-
 	if(our_mind.has_antag_datum(/datum/antagonist/traitor))
 		return TRUE
 	if(our_mind.has_antag_datum(/datum/antagonist/nukeop))
@@ -176,6 +162,8 @@
 		return TRUE
 	if(ROLE_SYNDICATE in our_mind.current.faction)
 		return TRUE
+
+	return FALSE
 
 // Formats some of the more common faction names into a more accurate string.
 /datum/element/unique_examine/proc/get_formatted_faction(faction)
@@ -215,20 +203,79 @@
 	. = "on the station"
 
 	if(department_bitflag & DEPARTMENT_BITFLAG_COMMAND)
-		. =  "as a member of command staff"
+		. = "as a member of command staff"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_SECURITY)
-		. =  "as a member of security force"
+		. = "as a member of security force"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_SERVICE)
-		. =  "in the service department"
+		. = "in the service department"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_CARGO)
-		. =  "in the cargo bay"
+		. = "in the cargo bay"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_ENGINEERING)
-		. =  "as one of the engineers"
+		. = "as one of the engineers"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_SCIENCE)
-		. =  "in the science team"
+		. = "in the science team"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_MEDICAL)
-		. =  "in the medical field"
+		. = "in the medical field"
 	else if(department_bitflag & DEPARTMENT_BITFLAG_SILICON)
-		. =  "as a silicon unit"
+		. = "as a silicon unit"
 
 	return span_bold(.)
+
+/datum/element/unique_examine/proc/get_all_fulfilled_requirements(mob/examiner) as /list
+	var/list/fulfilled_requirements = list(EXAMINE_CHECK_NONE = TRUE)
+
+	var/datum/mind/examiner_mind = examiner.mind
+	if(!examiner_mind)
+		return fulfilled_requirements
+
+	//Mindshield checks
+	if(HAS_TRAIT(examiner, TRAIT_MINDSHIELD))
+		fulfilled_requirements[EXAMINE_CHECK_MINDSHIELD] = TRUE
+
+	//Syndicate checks
+	if(check_if_syndicate(examiner_mind))
+		fulfilled_requirements[EXAMINE_CHECK_SYNDICATE] = TRUE
+
+	//Aantag checks
+	for(var/antag_type in special_desc_req)
+		var/datum/antagonist/antag_datum = examiner_mind.has_antag_datum(antag_type)
+		if(antag_datum)
+			fulfilled_requirements[EXAMINE_CHECK_ANTAG] = antag_datum
+			break
+
+	//Job (title) checks
+	for(var/checked_job in special_desc_req)
+		if(examiner_mind.assigned_role.title == checked_job)
+			fulfilled_requirements[EXAMINE_CHECK_JOB] = checked_job
+			break
+
+	//Department checks
+	if(examiner_mind.assigned_role.departments_bitflags & special_desc_req)
+		fulfilled_requirements[EXAMINE_CHECK_DEPARTMENT] = TRUE
+
+	//Standard faction checks
+	for(var/checked_faction in special_desc_req)
+		if(checked_faction in examiner.faction)
+			fulfilled_requirements[EXAMINE_CHECK_FACTION] = checked_faction
+			break
+
+	// Skillchip checks
+	var/obj/item/organ/internal/brain/examiner_brain = examiner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	for(var/obj/item/skillchip/checked_skillchip as anything in examiner_brain?.skillchips)
+		if(checked_skillchip.active && is_type_in_list(checked_skillchip, special_desc_req))
+			fulfilled_requirements[EXAMINE_CHECK_SKILLCHIP] = checked_skillchip
+			break
+
+	// Trait checks
+	for(var/checked_trait in special_desc_req)
+		if(HAS_TRAIT(examiner, checked_trait))
+			fulfilled_requirements[EXAMINE_CHECK_TRAIT] = checked_trait
+			break
+
+	// Species checks
+	for(var/checked_species in special_desc_req)
+		if(is_species(examiner, checked_species))
+			fulfilled_requirements[EXAMINE_CHECK_SPECIES] = checked_species
+			break
+
+	return fulfilled_requirements

--- a/maplestation_modules/code/datums/pain/pain_status_effects/anesthetic.dm
+++ b/maplestation_modules/code/datums/pain/pain_status_effects/anesthetic.dm
@@ -91,4 +91,6 @@
 /datum/status_effect/anesthesia_grog/proc/report_grog(datum/source, list/render_list, advanced, mob/user, mode, tochat)
 	SIGNAL_HANDLER
 
-	render_list += conditional_tooltip("<span class='alert ml-1'>[strength > 50 ? "Moderate" : "Trace"] amount of anesthetic detected in bloodstream.</span>", "Will subside over time.", tochat)
+	render_list += "<span class='alert ml-1'>"
+	render_list += conditional_tooltip("[strength > 50 ? "Moderate" : "Trace"] amount of anesthetic detected in bloodstream.</span>", "Will subside over time.", tochat)
+	render_list += "</span><br>"

--- a/maplestation_modules/code/game/machinery/fax_machine.dm
+++ b/maplestation_modules/code/game/machinery/fax_machine.dm
@@ -86,6 +86,8 @@ GLOBAL_LIST_EMPTY(fax_machines)
 	GLOB.fax_machines += src
 	set_room_tag(TRUE, !mapload)
 	wires = new /datum/wires/fax(src)
+	if(name != initial(name))
+		article = "the"
 
 /obj/machinery/fax/Destroy()
 	QDEL_NULL(stored_paper)
@@ -371,10 +373,12 @@ GLOBAL_LIST_EMPTY(fax_machines)
 	if(to_curr_room)
 		room_tag = get_area_name(src, TRUE) // no proper or improper tags on this
 		if(name == initial(name))
-			name = "[fax_name || get_area_name(src, FALSE)] [name]"
+			name = "[fax_name || get_area_name(src, TRUE)] [name]"
+			article = "the"
 	else
 		room_tag = null
 		name = initial(name)
+		article = initial(article)
 
 	if(update_all_faxes)
 		for(var/obj/machinery/fax/other_fax as anything in GLOB.fax_machines)
@@ -721,7 +725,7 @@ GLOBAL_LIST_EMPTY(fax_machines)
 	var/was_faxed_from
 
 /obj/item/paper/processed
-	name = "\proper classified paperwork"
+	name = "classified paperwork"
 	desc = "Some classified paperwork sent by the big men themselves."
 	/// Assoc list of data related to our paper.
 	var/list/paper_data

--- a/maplestation_modules/code/game/machinery/guess_pass.dm
+++ b/maplestation_modules/code/game/machinery/guess_pass.dm
@@ -132,6 +132,7 @@
 /obj/machinery/guest_pass/Initialize(mapload)
 	. = ..()
 	name = "[dept_name] [name]"
+	article = "the"
 	update_appearance()
 
 /obj/machinery/guest_pass/update_icon_state()

--- a/maplestation_modules/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/maplestation_modules/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -1,19 +1,22 @@
 /// -- Modular encryption keys --
 // Bridge Officer's Key
 /obj/item/encryptionkey/heads/bridge_officer
-	name = "\proper the bridge officer's encryption key"
+	name = "bridge officer's encryption key"
+	article = "the"
 	icon_state = "hop_cypherkey"
 	channels = list(RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_COMMAND = 1)
 
 // Asset Protection's Key
 /obj/item/encryptionkey/heads/asset_protection
-	name = "\proper the asset protection's encryption key"
+	name = "asset protection's encryption key"
+	article = "the"
 	icon_state = "hos_cypherkey"
 	channels = list(RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_COMMAND = 1)
 
 // Noble Ambassador's Key
 /obj/item/encryptionkey/heads/noble_ambassador
-	name = "\proper the noble ambassador's encryption key"
+	name = "noble ambassador's encryption key"
+	article = "the"
 	icon_state = "cypherkey_cube"
 	channels = list(RADIO_CHANNEL_COMMAND = 1)
 	greyscale_config = /datum/greyscale_config/encryptionkey_cube

--- a/maplestation_modules/code/game/objects/items/devices/radio/headset.dm
+++ b/maplestation_modules/code/game/objects/items/devices/radio/headset.dm
@@ -1,21 +1,24 @@
 /// -- Modular headsets --
 // Bridge Officer's headset
 /obj/item/radio/headset/heads/bridge_officer
-	name = "\proper the bridge officer's headset"
+	name = "bridge officer's headset"
+	article = "the"
 	desc = "The headset of the person in charge of filing paperwork for the heads of staff."
 	icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/bridge_officer
 
 // Asset Protection's headset
 /obj/item/radio/headset/heads/asset_protection
-	name = "\proper the asset protection officer's headset"
+	name = "asset protection officer's headset"
+	article = "the"
 	desc = "The headset of the person in charge of assisting and protecting the heads of staff."
 	icon_state = "com_headset"
 	keyslot = /obj/item/encryptionkey/heads/asset_protection
 
 // Asset Protection's bowman
 /obj/item/radio/headset/heads/asset_protection/alt
-	name = "\proper the asset protection officer's bowman headset"
+	name = "asset protection officer's bowman headset"
+	article = "the"
 	desc = "The headset of the person in charge of assisting and protecting the heads of staff. Protects ears from flashbangs."
 	icon_state = "com_headset_alt"
 
@@ -24,7 +27,8 @@
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
 /obj/item/radio/headset/heads/noble_ambassador
-	name = "\proper the noble ambassador's headset"
+	name = "noble ambassador's headset"
+	article = "the"
 	desc = "The headset of the ambassador from Mu, responsible for upholding their laws and ensuring the crew's wellbeing."
 	worn_icon = 'maplestation_modules/icons/mob/clothing/ears.dmi'
 	worn_icon_state = "noble_headset"

--- a/maplestation_modules/code/game/objects/items/storage/garment.dm
+++ b/maplestation_modules/code/game/objects/items/storage/garment.dm
@@ -81,9 +81,3 @@
 			continue
 
 		atom_storage.attempt_insert(locker_clothing, override = TRUE, force = TRUE)
-
-/obj/item/storage/bag/garment/magic/quartermaster
-	name = "quartermaster's garment bag"
-	desc = "A bag for storing extra clothes and shoes. This one belongs to the quartermaster."
-	// I don't feel the need to cache this because only 1 should ever exist
-	blacklisted_types = list(/obj/item/clothing/suit/utility/fire, /obj/item/clothing/mask/gas)

--- a/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/asset_protection.dm
+++ b/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/asset_protection.dm
@@ -2,7 +2,8 @@
 
 // The actual Asset Protection's locker of equipment
 /obj/structure/closet/secure_closet/asset_protection
-	name = "\proper asset protection's locker"
+	name = "asset protection's locker"
+	article = "the"
 	req_access = list(ACCESS_COMMAND)
 	icon = 'maplestation_modules/icons/obj/locker.dmi'
 	icon_state = "ap"

--- a/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/bridge_officer.dm
+++ b/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/bridge_officer.dm
@@ -2,7 +2,8 @@
 
 // The actual Bridge Officer's locker of equipment
 /obj/structure/closet/secure_closet/bridge_officer
-	name = "\proper bridge officer's locker"
+	name = "bridge officer's locker"
+	article = "the"
 	req_access = list(ACCESS_COMMAND)
 	icon = 'maplestation_modules/icons/obj/locker.dmi'
 	icon_state = "bo"

--- a/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/noble_ambassador.dm
+++ b/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/noble_ambassador.dm
@@ -1,5 +1,6 @@
 /obj/structure/closet/secure_closet/noble_ambassador
-	name = "\proper noble ambassador's locker"
+	name = "noble ambassador's locker"
+	article = "the"
 	desc = "It's a card-locked storage unit. You sure wish it had less spartan decorations."
 	req_access = list(ACCESS_COMMAND)
 	icon = 'maplestation_modules/icons/obj/locker.dmi'

--- a/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/quartermaster.dm
+++ b/maplestation_modules/code/game/objects/structures/crate_lockers/closets/secure/quartermaster.dm
@@ -1,4 +1,0 @@
-// -- Quartermaster locker stuff. --
-/obj/structure/closet/secure_closet/quartermaster/PopulateContents()
-	. = ..()
-	new /obj/item/storage/bag/garment/magic/quartermaster(src) // done at the veeeery end for a reason.

--- a/maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/code/captainclothing.dm
+++ b/maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/code/captainclothing.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/under/rank/captain/formal
 	name = "captain's turtleneck"
+	article = "the"
 	desc = "Clothing designed for the commander of the station, the turtleneck is soft to the touch."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -20,6 +21,7 @@
 
 /obj/item/clothing/under/rank/captain/formal/skirt
 	name = "captain's skirtleneck"
+	article = "the"
 	desc = "A uniform designed for the commander of the station, the skirt is just long enough to clear the length standard."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -40,6 +42,7 @@
 
 /obj/item/clothing/shoes/jackboots/captain
 	name = "captain's boots"
+	article = "the"
 	desc = "Hard leather boots meant for the commander of the station, these boots look combat ready."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -58,6 +61,7 @@
 
 /obj/item/clothing/gloves/captain/formal
 	name = "captain's black gloves"
+	article = "the"
 	desc = "Black gloves commanding officer gloves with a sleek appearance to them."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -77,6 +81,7 @@
 
 /obj/item/clothing/suit/armor/vest/capformalcarapace
 	name = "captain's quality carapace"
+	article = "the"
 	desc = "A high quality carapace fitted with sturdy painted metal plating. This one is meant for the stations commander."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -94,6 +99,7 @@
 
 /obj/item/clothing/suit/armor/vest/capvestformal
 	name = "captain's vest"
+	article = "the"
 	desc = "An elegant heavy duty vest. It appears that this vest was modified from a bullet proof vest."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -111,6 +117,7 @@
 
 /obj/item/clothing/neck/cloak/capformal
 	name = "captain's half cape"
+	article = "the"
 	desc = "Worn by the commander of the station, this cape only covers half of the body."
 	icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_icon.dmi'
 	worn_icon = 'maplestation_modules/code/modules/clothing/equipment_sets/captain_equipment/captain_worn.dmi'
@@ -124,6 +131,7 @@
 
 /obj/item/storage/bag/garment/cap_cust
 	name = "captain's extended garment bag"
+	article = "the"
 	desc = "Due to the captain's over-extravagance, a second garment bag had to be requisitioned to hold all of their various outfits."
 
 	// Clothes to the bag

--- a/maplestation_modules/code/modules/clothing/suits/labcoat.dm
+++ b/maplestation_modules/code/modules/clothing/suits/labcoat.dm
@@ -8,6 +8,7 @@
 
 /obj/item/clothing/suit/toggle/labcoat/ce
 	name = "chief engineer's labcoat"
+	article = "the"
 	desc = "Has black and gold panels unlike the standard labcoat model."
 	icon_state = "labcoat_ce"
 	icon = 'maplestation_modules/icons/mob/clothing/suit.dmi' //I could make a sprite for this but i'm lazy, so have same as ingame sprite.

--- a/maplestation_modules/code/modules/mob/living/carbon/human/rad_rework/radiation.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/rad_rework/radiation.dm
@@ -154,7 +154,8 @@
 /datum/status_effect/irradiated/proc/on_healthscan(datum/source, list/render_list, advanced, mob/user, mode, tochat)
 	SIGNAL_HANDLER
 
-	render_list += conditional_tooltip("<span class='alert ml-1'>Subject is irradiated.</span>", "Supply antiradiation or antitoxin, such as [/datum/reagent/medicine/potass_iodide::name] or [/datum/reagent/medicine/pen_acid::name].", tochat)
+	render_list += "<span class='alert ml-1'>"
+	render_list += conditional_tooltip("Subject is irradiated.", "Supply antiradiation or antitoxin, such as [/datum/reagent/medicine/potass_iodide::name] or [/datum/reagent/medicine/pen_acid::name].", tochat)
 	render_list += "<br>"
 
 /datum/status_effect/irradiated/proc/radimmune_gained(...)


### PR DESCRIPTION
1. I hyperfixated on making examine titles more pleasant to read.

Many proper nouns will now read proper as `the [x]`: `the captain's jumpsuit`, `the nuclear authentication disk`, `the Arrivals air alarm`

Stack items will now read as `an iron rod` vs `some iron rods` when singular vs many

Many atoms improperly treated as proper are now improper.

Simple mobs are now treated as `a` unless they have a proper name: `That's a mouse` vs `That's Jerm`

2. Fixes stackable component visuals. 

Additionally stackable component now formats examine items appropriately: `They are wearing an eyepatch and a security hud.`, 

Also the examine message was tweaked to be an examine tag.

5. Food and drink on-examine food types is now printed as examine tags `It is small, meat, and raw.`

6. Fixes the lobby spinner... a little bit. It still has some interesting behavior due to time2text but it can't be avoided... I think

7. Adds all the title themes to the jukebox so they can be played lag free

8. Refactored the examine lore element to not hint more information is present if you don't know any information about it

9. Deletes the defunct quartermaster's garment bag, since they have a real one

10. Fixes benches erroring people

11. Fixes some health analyzer formatting

12. Space cleaner now has a rare chance to clear irradiated organs, or guaranteed if the consumer is a toxin lover