### PR TITLE
Makes umbrellas not disappear.

### DIFF
--- a/code/datums/components/transforming.dm
+++ b/code/datums/components/transforming.dm
@@ -238,7 +238,10 @@
 
 	source.hitsound = initial(source.hitsound)
 	source.update_weight_class(initial(source.w_class))
-	source.icon_state = initial(source.icon_state)
+	if(source.post_init_icon_state) // NON-MODULE CHANGE START : literally just a bug fix
+		source.icon_state = initial(source.post_init_icon_state)
+	else
+		source.icon_state = initial(source.icon_state) // NON-MODULE CHANGE END
 	source.inhand_icon_state = initial(source.inhand_icon_state)
 	if(ismob(source.loc))
 		var/mob/loc_mob = source.loc


### PR DESCRIPTION
This PR makes umbrellas not disappear after being extended and then retracted again.

On a side note, it overall just fixes anything with a post_init_icon_state being used with the transforming component. Might be useful to somebody somewhere.
