### PR TITLE
Makes situations that change sprint length max also cap their sprint.

### DIFF
--- a/maplestation_modules/code/datums/elements/bodypart_sprint_buff.dm
+++ b/maplestation_modules/code/datums/elements/bodypart_sprint_buff.dm
@@ -35,3 +35,4 @@
 		return
 
 	new_owner.sprint_length_max -= buff_amount
+	new_owner.sprint_length = min(new_owner.sprint_length_max, new_owner.sprint_length)

--- a/maplestation_modules/code/datums/quirks/neutral.dm
+++ b/maplestation_modules/code/datums/quirks/neutral.dm
@@ -121,6 +121,7 @@
 	sprint_length_multiplier = new_sprint_length
 	sprint_regen_multiplier = new_sprint_regen
 	quirk_human.sprint_length_max *= new_sprint_length
+	quirk_human.sprint_length = min(quirk_human.sprint_length_max, quirk_human.sprint_length)
 	quirk_human.sprint_regen_per_second *= new_sprint_regen
 
 #define RANDOM_INNATE_MUTATION "Random"

--- a/maplestation_modules/code/modules/library/skill_learning/job_skillchips/mining.dm
+++ b/maplestation_modules/code/modules/library/skill_learning/job_skillchips/mining.dm
@@ -57,6 +57,7 @@
 	if(station_check)
 		if(human_source.unset_pain_mod(PAIN_MOD_OFF_STATION))
 			human_source.sprint_length_max /= 1.5
+			human_source.sprint_length = min(human_source.sprint_length_max, human_source.sprint_length)
 			human_source.sprint_regen_per_second /= 1.5
 			action.Remove(human_source)
 			to_chat(human_source, span_green("Returning to the station, you feel much more vulnerable to incoming pain."))


### PR DESCRIPTION
Three line fix. Should prevent caffeine addicts from hearing their heart in their ears whenever they end up at the station.

Might be better by using some kind of setter proc at the expense of incurring post object-oriented stress disorder to various coders.