### PR TITLE
Fixes to OmegaStation

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -26101,13 +26101,13 @@
 /turf/closed/wall,
 /area/station/maintenance/department/science)
 "fHF" = (
-/obj/structure/closet/crate/bin,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Library - Port"
 	},
+/obj/machinery/skill_station,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "fIX" = (
@@ -31687,6 +31687,7 @@
 /area/station/maintenance/department/medical)
 "pvN" = (
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2592,8 +2592,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -3199,8 +3199,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -5572,9 +5572,6 @@
 /area/station/security/brig)
 "aoA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secexterior";
 	name = "Brig"
@@ -5585,6 +5582,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -5823,7 +5823,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "apm" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
 	},
@@ -6002,9 +6001,6 @@
 /area/station/security/brig)
 "apC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secinterior";
 	name = "Brig"
@@ -6015,6 +6011,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -10955,6 +10954,7 @@
 	network = list("ss13","engine");
 	dir = 9
 	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "aEq" = (
@@ -16085,7 +16085,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aRS" = (
@@ -28401,6 +28403,21 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/green/telecomms,
 /area/station/tcommsat/server)
+"jHt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "jHM" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
@@ -28660,7 +28677,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "kfm" = (
@@ -28987,7 +29006,6 @@
 	},
 /area/station/engineering/lobby)
 "kKd" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
 	},
@@ -30359,8 +30377,8 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -30492,9 +30510,6 @@
 /area/station/service/cafeteria)
 "nkG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secexterior";
 	name = "Brig"
@@ -30509,6 +30524,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -31047,7 +31065,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-left"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "osC" = (
@@ -31265,6 +31285,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"oKO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "bridge-right"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/command/bridge)
 "oLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -37450,9 +37484,6 @@
 /area/station/science/breakroom)
 "xeR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "secinterior";
 	name = "Brig"
@@ -37466,6 +37497,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -73075,7 +73109,7 @@ swv
 aaK
 sLF
 abe
-kdc
+jHt
 ade
 jqT
 ade
@@ -73085,7 +73119,7 @@ aft
 ade
 abz
 adS
-aiC
+oKO
 psK
 afl
 anQ

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -57,6 +57,10 @@ map pubbystation
 	votable
 endmap
 
+map omegastation
+	votable
+endmap
+
 ## DEBUG MAPS
 
 map runtimestation


### PR DESCRIPTION
First Fix: The map is in maps.txt now, so it's actually playable without massive admin intervention.

Second Fix: Firelocks in the mining shuttle airlock are gone. They automatically trigger from being exposed to a vacuum making them rather annoying and useless.

Third Fix: This one is more of a modernisation that im just putting in because we'll forget about it, but the bridge and security airlocks have been converted to modern multi-directional cycle link helpers.

Fourth Fix: Skillsoft station in the library. There wasn't any in the map. Whoops.