### PR TITLE
Forgot to push my fixes 

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -24,9 +24,6 @@
 
 #define MAX_GRANT_DPT 500
 
-//What should vending machines charge when you buy something in-department.
-#define DEPARTMENT_DISCOUNT 0.2
-
 #define ACCOUNT_CIV "CIV"
 #define ACCOUNT_CIV_NAME "Civil Budget"
 #define ACCOUNT_ENG "ENG"
@@ -93,5 +90,3 @@
 ##path/fifty {\
 	amount = 50; \
 }
-
-

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -806,7 +806,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
  */
 /proc/add_personality_mood_to_viewers(atom/movable/source, mood_key, list/personality_to_mood, range, ...)
 	for(var/mob/living/nearby in viewers(range, source))
-		if(nearby.stat >= UNCONSCIOUS || nearby.is_blind())
+		if(nearby.is_blind() || source == nearby)
 			continue
 		for(var/personality in personality_to_mood)
 			if(HAS_PERSONALITY(nearby, personality))

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(ambience)
 	name = "Ambience"
 	flags = SS_BACKGROUND|SS_NO_INIT
 	priority = FIRE_PRIORITY_AMBIENCE
-	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	runlevels = RUNLEVEL_GAME
 	wait = 1 SECONDS
 	///Assoc list of listening client - next ambience time
 	var/list/ambience_listening_clients = list()

--- a/code/datums/components/jukebox.dm
+++ b/code/datums/components/jukebox.dm
@@ -109,11 +109,15 @@
 
 		if(!length(config_songs))
 			var/datum/track/default/default_track = new()
-			config_songs["[default_track.song_name] (Default)"] = default_track
+			var/default_track_name = "[default_track.song_name] (Default)"
+			default_track.song_name = default_track_name
+			config_songs[default_track_name] = default_track
 
 		for(var/datum/track/track_subtype as anything in subtypesof(/datum/track/preset))
 			var/datum/track/new_preset = new track_subtype()
-			config_songs["[new_preset.song_name] (Preset)"] = new_preset
+			var/preset_name = "[new_preset.song_name] (Preset)"
+			new_preset.song_name = preset_name
+			config_songs[preset_name] = new_preset
 
 	// returns a copy so it can mutate if desired.
 	return config_songs.Copy()

--- a/code/datums/status_effects/debuffs/choke.dm
+++ b/code/datums/status_effects/debuffs/choke.dm
@@ -222,23 +222,19 @@
 	SIGNAL_HANDLER
 	owner.dir = new_dir
 
-/datum/status_effect/choke/proc/thrusting_continues(mob/living/victim, mob/aggressor, before_work = FALSE)
-	if(iscarbon(aggressor))
-		var/free_hands = 0
-		// Listen bud, you need at least 2 free hands for this
-		for(var/hand_i in 1 to length(aggressor.held_items))
-			if(!aggressor.has_hand_for_held_index(hand_i) || aggressor.held_items[hand_i])
-				continue
-			free_hands += 1
-		if(free_hands < 2)
-			victim.balloon_alert(aggressor, "need 2 free hands!")
-			return FALSE
+/datum/status_effect/choke/proc/thrusting_continues(mob/living/victim, mob/living/aggressor, before_work = FALSE)
+	var/free_hands = aggressor.usable_hands
+	for(var/obj/item/held_item in aggressor.held_items)
+		if(!(held_item.item_flags & HAND_ITEM))
+			free_hands -= 1
 
-	if(iscarbon(victim))
-		var/mob/living/carbon/carbon_victim = victim
-		if(!carbon_victim.appears_alive())
-			victim.balloon_alert(aggressor, "too late...")
-			return FALSE
+	if(free_hands < 2)
+		victim.balloon_alert(aggressor, "need 2 free hands!")
+		return FALSE
+
+	if(!victim.appears_alive())
+		victim.balloon_alert(aggressor, "too late...")
+		return FALSE
 
 	if(!choking_on_ref)
 		return FALSE

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -595,20 +595,14 @@
 	return .
 
 /datum/wound/proc/get_wound_description(mob/user)
-	var/desc
+	if(!examine_desc)
+		return // no examine text
 
 	var/obj/item/stack/medical/wrap/current_gauze = LAZYACCESS(limb.applied_items, LIMB_ITEM_GAUZE)
 	if ((wound_flags & ACCEPTS_GAUZE) && current_gauze)
-		desc = "[victim.p_Their()] [limb.plaintext_zone] is [get_gauze_condition()]fastened in a sling of [current_gauze.name]"
-	else
-		desc = "[victim.p_Their()] [limb.plaintext_zone] [examine_desc]"
+		return // gauze is covering the wound
 
-	if(!desc)
-		return
-
-	desc = modify_desc_before_span(desc, user)
-
-	return get_desc_intensity(desc)
+	return get_desc_intensity(modify_desc_before_span("[victim.p_Their()] [limb.plaintext_zone] [examine_desc]", user))
 
 /**
  * Used when a mob is examining themselves / their limbs

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -316,9 +316,6 @@
 	else
 		if(!(lube & SLIP_WHEN_CRAWLING) && (slipper.body_position == LYING_DOWN || !(slipper.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
 			return FALSE
-		if(slipper.move_intent != MOVE_INTENT_RUN && (lube & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
-			return FALSE
-
 	if(!(lube & SLIDE_ICE))
 		// Ice slides are intended to be combo'd so don't give the feedback
 		to_chat(slipper, span_notice("You slipped[ slippable ? " on the [slippable.name]" : ""]!"))

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -316,7 +316,7 @@
 	else
 		if(!(lube & SLIP_WHEN_CRAWLING) && (slipper.body_position == LYING_DOWN || !(slipper.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
 			return FALSE
-		if(move_intent != MOVE_INTENT_RUN && (lube_flags & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
+		if(slipper.move_intent != MOVE_INTENT_RUN && (lube & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
 			return FALSE
 
 	if(!(lube & SLIDE_ICE))

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -316,6 +316,9 @@
 	else
 		if(!(lube & SLIP_WHEN_CRAWLING) && (slipper.body_position == LYING_DOWN || !(slipper.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
 			return FALSE
+		if(move_intent != MOVE_INTENT_RUN && (lube_flags & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
+			return FALSE
+
 	if(!(lube & SLIDE_ICE))
 		// Ice slides are intended to be combo'd so don't give the feedback
 		to_chat(slipper, span_notice("You slipped[ slippable ? " on the [slippable.name]" : ""]!"))

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -134,8 +134,8 @@ GLOBAL_LIST_EMPTY(starlight)
 		return FALSE
 	return TRUE
 
-/turf/open/space/handle_slip()
-	return
+/turf/open/space/handle_slip(mob/living/carbon/slipper, knockdown_amount, obj/slippable, lube, paralyze_amount, force_drop)
+	return FALSE
 
 /turf/open/space/attackby(obj/item/C, mob/user, params)
 	..()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -159,7 +159,8 @@
 		tgui_alert(usr, get_job_unavailable_error_message(error, rank))
 		return FALSE
 
-	if(SSshuttle.arrivals)
+	var/latejoin_spawn_preference = client.prefs.read_preference(/datum/preference/choiced/preferred_latejoin_spawn)
+	if(SSshuttle.arrivals && latejoin_spawn_preference == SPAWNPOINT_ARRIVALS)
 		if(SSshuttle.arrivals.damaged && CONFIG_GET(flag/arrivals_shuttle_require_safe_latejoin))
 			tgui_alert(usr,"The arrivals shuttle is currently malfunctioning! You cannot join.")
 			return FALSE
@@ -215,7 +216,7 @@
 		humanc = character //Let's retypecast the var to be human,
 
 	if(humanc) //These procs all expect humans
-		announce_arrival(humanc, rank, try_queue = TRUE)
+		announce_arrival(humanc, rank, try_queue = (latejoin_spawn_preference == SPAWNPOINT_ARRIVALS))
 
 		humanc.increment_scar_slot()
 		humanc.load_persistent_scars()
@@ -238,7 +239,7 @@
 		// SEND_SIGNAL(humanc, COMSIG_HUMAN_CHARACTER_SETUP_FINISHED)
 
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
-	if(humanc && arrivals && !arrivals.power_environ) //arrivals depowered
+	if(humanc && arrivals && !arrivals.power_environ && latejoin_spawn_preference == SPAWNPOINT_ARRIVALS) //arrivals depowered
 		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,9 +1,11 @@
 /mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, force_drop = FALSE)
 	if(movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		return FALSE
+	if(move_intent != MOVE_INTENT_RUN && (lube_flags & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
+		return FALSE
 	if(!(lube_flags & SLIDE_ICE))
 		log_combat(src, (slipped_on || get_turf(src)), "slipped on the", null, ((lube_flags & SLIDE) ? "(SLIDING)" : null))
-	..()
+	. = ..()
 	return loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, force_drop)
 
 /mob/living/carbon/Move(NewLoc, direct)
@@ -12,7 +14,6 @@
 		return
 	if(stat == DEAD)
 		return
-
 	if(IS_MOVING_INTENTIONALLY(src))
 		if(move_intent == MOVE_INTENT_RUN)
 			drain_sprint(1 + ((movement_type & FLYING) ? 1 : 0) + length(buckled_mobs) * 0.5)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,12 +1,9 @@
 /mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, force_drop = FALSE)
-	if(movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
-		return FALSE
-	if(move_intent != MOVE_INTENT_RUN && (lube_flags & NO_SLIP_WHEN_WALKING)) // NON-MODULE CHANGE
+	if(!loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, force_drop))
 		return FALSE
 	if(!(lube_flags & SLIDE_ICE))
 		log_combat(src, (slipped_on || get_turf(src)), "slipped on the", null, ((lube_flags & SLIDE) ? "(SLIDING)" : null))
-	. = ..()
-	return loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, force_drop)
+	return ..()
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -594,7 +594,7 @@
 	if(build_difference)
 		. += build_difference
 
-	var/agetext = get_age_text()
+	var/agetext = get_age_text(user)
 	if(agetext)
 		. += agetext
 
@@ -619,7 +619,7 @@
 	return texts
 
 /// Reports how old the mob appears to be
-/mob/living/carbon/human/proc/get_age_text()
+/mob/living/carbon/human/proc/get_age_text(mob/user)
 	if(obscured_slots & HIDEFACE)
 		return
 	var/age_text
@@ -636,7 +636,23 @@
 			age_text = "very old"
 		if(101 to INFINITY)
 			age_text = "withering away"
-	. += list(span_info("[p_They()] appear[p_s()] to be [age_text]."))
+
+	var/age_to_you_text
+	if(ishuman(user))
+		var/mob/living/carbon/human/examiner = user
+		switch(age - examiner.age)
+			if(-INFINITY to -16)
+				age_to_you_text = "far younger than you"
+			if(-15 to -6)
+				age_to_you_text = "younger than you"
+			if(-5 to 5)
+				age_to_you_text = "about your age"
+			if(6 to 15)
+				age_to_you_text = "older than you"
+			if(16 to INFINITY)
+				age_to_you_text = "far older than you"
+
+	. += list(span_info("[p_They()] appear[p_s()] to be [age_text][age_to_you_text ? " - [age_to_you_text]" : ""]."))
 
 /// Reports the height difference between src and user
 /mob/living/carbon/proc/get_height_difference(mob/user)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -725,12 +725,13 @@
 
 /// Returns the mob height modified by traits purely
 /mob/living/carbon/human/proc/get_visual_height()
-	. = mob_height + (2 * mob_size)
+	var/height_var = mob_height
 	// these traits don't modify the height so we have to account for them here
 	if(HAS_TRAIT(src, TRAIT_SMALL))
-		. = min(., HUMAN_HEIGHT_DWARF)
+		height_var = min(height_var, HUMAN_HEIGHT_DWARF)
 	if(HAS_TRAIT(src, TRAIT_HUGE) || HAS_TRAIT(src, TRAIT_GIANT))
-		. = max(., HUMAN_HEIGHT_TALLEST)
+		height_var = max(height_var, HUMAN_HEIGHT_TALLEST)
+	return (height_var + (2 * mob_size)) * current_size
 
 /mob/living/carbon/proc/get_build_difference(mob/user)
 	return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -347,6 +347,7 @@
  */
 /mob/proc/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, force_drop = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOB_SLIPPED, knockdown_amount, slipped_on, lube_flags, paralyze, force_drop)
+	return TRUE
 
 /mob/living/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, force_drop = FALSE)
 	add_mob_memory(/datum/memory/was_slipped, antagonist = slipped_on)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -639,7 +639,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 	use(1)
 
-	if(C.shock(user, 50) && prob(50)) //fail
+	if(C.powernet.avail && C.shock(user, 50) && prob(50)) //fail
 		C.deconstruct()
 
 	return C

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -152,6 +152,9 @@
 	name = "spent [name]"
 	desc += " This one is spent."
 
+/obj/item/ammo_casing/foam_dart/is_spent(mapload = FALSE)
+	return
+
 /obj/item/ammo_casing/spent
 	loaded_projectile = null
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -224,6 +224,9 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	///Whether this vendor can be selected when building a custom vending machine
 	var/allow_custom = FALSE
 
+	/// Discount applied to people buying non-premium items from their own department's vendor
+	var/department_discount = 0.2
+
 /datum/armor/machinery_vending
 	melee = 20
 	fire = 50
@@ -1207,7 +1210,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	data["onstation"] = onstation
 	data["all_products_free"] = all_products_free
 	data["department"] = payment_department
-	data["jobDiscount"] = DEPARTMENT_DISCOUNT
+	data["jobDiscount"] = department_discount
 	data["product_records"] = list()
 	data["displayed_currency_icon"] = displayed_currency_icon
 	data["displayed_currency_name"] = displayed_currency_name
@@ -1487,9 +1490,9 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 		return FALSE
 	var/datum/bank_account/account = paying_id_card.registered_account
 	if(account.account_job && account.account_job.paycheck_department == payment_department && !discountless)
-		price_to_use = max(round(price_to_use * DEPARTMENT_DISCOUNT), 1) //No longer free, but signifigantly cheaper.
+		price_to_use = max(round(price_to_use * department_discount), 0) //No longer free, but signifigantly cheaper.
 	if(coin_records.Find(product_to_vend) || hidden_records.Find(product_to_vend))
-		price_to_use = product_to_vend.custom_premium_price ? product_to_vend.custom_premium_price : extra_price
+		price_to_use = product_to_vend.custom_premium_price || extra_price
 	if(LAZYLEN(product_to_vend.returned_products))
 		price_to_use = 0 //returned items are free
 	if(price_to_use && (attempt_charge(src, mob_paying, price_to_use) & COMPONENT_OBJ_CANCEL_CHARGE))

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -91,6 +91,7 @@
 	payment_department = ACCOUNT_SRV
 	light_mask = "boozeomat-light-mask"
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/machinery/vending/boozeomat/syndicate
 	age_restrictions = FALSE

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -70,6 +70,7 @@
 	payment_department = ACCOUNT_SRV
 	light_mask = "dinnerware-light-mask"
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/item/vending_refill/dinnerware
 	machine_name = "Plasteel Chef's Dinnerware Vendor"

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -32,6 +32,7 @@
 	payment_department = ACCOUNT_ENG
 	light_mask = "engivend-light-mask"
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/item/vending_refill/engivend
 	machine_name = "Engi-Vend"

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -106,6 +106,7 @@
 	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/item/vending_refill/hydroseeds
 	machine_name = "MegaSeed Servitor"

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -29,6 +29,7 @@
 	extra_price = PAYCHECK_COMMAND * 0.8
 	payment_department = ACCOUNT_SRV
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/item/vending_refill/hydronutrients
 	machine_name = "NutriMax"

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -37,6 +37,7 @@
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_SEC
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/machinery/vending/security/pre_throw(obj/item/thrown_item)
 	if(isgrenade(thrown_item))

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -34,6 +34,7 @@
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 	allow_custom = TRUE
+	department_discount = 0
 
 /obj/item/vending_refill/youtool
 	machine_name = "YouTool"

--- a/maplestation.dme
+++ b/maplestation.dme
@@ -6774,6 +6774,7 @@
 #include "maplestation_modules\code\modules\surgery\bodyparts\cyber_humanoid.dm"
 #include "maplestation_modules\code\modules\surgery\bodyparts\cyber_reskins.dm"
 #include "maplestation_modules\code\modules\surgery\bodyparts\cyber_tech.dm"
+#include "maplestation_modules\code\modules\surgery\operations\install_laws.dm"
 #include "maplestation_modules\code\modules\surgery\operations\internal_bleeding.dm"
 #include "maplestation_modules\code\modules\surgery\organs\augments_arms.dm"
 #include "maplestation_modules\code\modules\surgery\organs\augments_chest.dm"

--- a/maplestation_modules/code/modules/magic/story_spells/illusion.dm
+++ b/maplestation_modules/code/modules/magic/story_spells/illusion.dm
@@ -55,6 +55,7 @@
 	var/mob/living/simple_animal/hostile/illusion/conjured/decoy = new(castturf)
 	if(!isnull(copy_target))
 		decoy.Copy_Parent(copy_target, conjured_duration, conjured_hp)
+		decoy.transform.scale(caster.current_size)
 		decoy.face_atom(caster || copy_target)
 
 	decoy.spin(0.4 SECONDS, 0.1 SECONDS)

--- a/maplestation_modules/code/modules/magic/story_spells/illusion.dm
+++ b/maplestation_modules/code/modules/magic/story_spells/illusion.dm
@@ -55,7 +55,7 @@
 	var/mob/living/simple_animal/hostile/illusion/conjured/decoy = new(castturf)
 	if(!isnull(copy_target))
 		decoy.Copy_Parent(copy_target, conjured_duration, conjured_hp)
-		decoy.transform.scale(caster.current_size)
+		decoy.transform.Scale(caster.current_size)
 		decoy.face_atom(caster || copy_target)
 
 	decoy.spin(0.4 SECONDS, 0.1 SECONDS)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android.dm
@@ -1,3 +1,5 @@
+#define LOST_TONGUE "lost_tongue"
+
 /datum/species/android
 	name = "Android"
 	plural_form = "Androids"
@@ -104,6 +106,8 @@
 	RegisterSignal(gained_species, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(on_limb_lost))
 	RegisterSignal(gained_species, COMSIG_MOB_REAGENT_CHECK, PROC_REF(on_reagent_tick))
 	RegisterSignal(gained_species, COMSIG_LIVING_ADJUST_TOX_DAMAGE, PROC_REF(tox_change))
+	RegisterSignal(gained_species, COMSIG_CARBON_LOSE_ORGAN, PROC_REF(organ_lost))
+	RegisterSignal(gained_species, COMSIG_CARBON_GAIN_ORGAN, PROC_REF(organ_gained))
 	return ..()
 
 /datum/species/android/on_species_loss(mob/living/carbon/human/lost_species, datum/species/new_species, pref_load)
@@ -119,6 +123,8 @@
 	UnregisterSignal(lost_species, COMSIG_CARBON_REMOVE_LIMB)
 	UnregisterSignal(lost_species, COMSIG_MOB_REAGENT_CHECK)
 	UnregisterSignal(lost_species, COMSIG_LIVING_ADJUST_TOX_DAMAGE)
+	UnregisterSignal(lost_species, COMSIG_CARBON_LOSE_ORGAN)
+	unregisterSignal(lost_species, COMSIG_CARBON_GAIN_ORGAN)
 	if(is_leaking)
 		remove_leaking(lost_species)
 	if(is_overheating)
@@ -127,6 +133,7 @@
 		remove_cold_modifiers(lost_species)
 	if(bleed_rate_changed)
 		lost_species.physiology.bleed_mod /= 3
+	REMOVE_TRAIT(lost_species, TRAIT_MUTE, LOST_TONGUE)
 
 /datum/species/android/proc/remove_leaking(mob/living/carbon/human/removing)
 	if(!is_leaking)
@@ -554,6 +561,18 @@
 			if(last_toxic_warning > 0 && amount < 0)
 				last_toxic_warning = 0
 				to_chat(source, span_binarysay("Notice: Toxicity flush complete. Systems operating within normal parameters."))
+
+/datum/species/android/proc/organ_lost(mob/living/carbon/human/source, obj/item/organ/organ)
+	SIGNAL_HANDLER
+
+	if(istype(organ, /obj/item/organ/tongue))
+		ADD_TRAIT(source, TRAIT_MUTE, LOST_TONGUE)
+
+/datum/species/android/proc/organ_gained(mob/living/carbon/human/source, obj/item/organ/organ)
+	SIGNAL_HANDLER
+
+	if(istype(organ, /obj/item/organ/tongue) && IS_ROBOTIC_ORGAN(organ))
+		REMOVE_TRAIT(source, TRAIT_MUTE, LOST_TONGUE)
 
 // Add features from all android species for prefs
 /datum/species/android/get_features()

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android.dm
@@ -124,7 +124,7 @@
 	UnregisterSignal(lost_species, COMSIG_MOB_REAGENT_CHECK)
 	UnregisterSignal(lost_species, COMSIG_LIVING_ADJUST_TOX_DAMAGE)
 	UnregisterSignal(lost_species, COMSIG_CARBON_LOSE_ORGAN)
-	unregisterSignal(lost_species, COMSIG_CARBON_GAIN_ORGAN)
+	UnregisterSignal(lost_species, COMSIG_CARBON_GAIN_ORGAN)
 	if(is_leaking)
 		remove_leaking(lost_species)
 	if(is_overheating)

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_brain.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_brain.dm
@@ -17,6 +17,25 @@
 		return FALSE
 	return TRUE
 
+/obj/item/organ/brain/cybernetic/android/proc/init_law_datum()
+	if(!isnull(law_datum) || isnull(owner) || isdummy(owner))
+		return
+
+	if(owner.dna?.features["android_laws"])
+		var/lawtype = lawid_to_type(owner.dna.features["android_laws"])
+		law_datum = new lawtype()
+		for(var/i in 1 to length(law_datum.inherent))
+			law_datum.inherent[i] = replacetext(law_datum.inherent[i], "human being", "crewmember")
+		if(owner?.is_antag())
+			law_datum.zeroth = "Accomplish your objectives at all costs."
+
+	else
+		law_datum = new()
+
+	add_item_action(/datum/action/item_action/organ_action/check_android_laws)
+	RegisterGlobalSignal(COMSIG_GLOB_ION_STORM, PROC_REF(on_ion_storm))
+	RegisterSignal(owner, COMSIG_MOB_ANTAGONIST_GAINED, PROC_REF(add_zeroth_law))
+
 /obj/item/organ/brain/cybernetic/android/on_mob_insert(mob/living/carbon/organ_owner, special, movement_flags)
 	. = ..()
 	if(organ_owner.dna?.features["android_emotionless"] && organ_owner.mob_mood)
@@ -24,21 +43,11 @@
 		organ_owner.mob_mood.mood_modifier -= 101
 		emotions_nullified = TRUE
 
-	if(organ_owner.dna?.features["android_laws"] && !isdummy(organ_owner))
-		var/lawtype = lawid_to_type(organ_owner.dna.features["android_laws"])
-		law_datum = new lawtype()
-		for(var/i in 1 to length(law_datum.inherent))
-			law_datum.inherent[i] = replacetext(law_datum.inherent[i], "human being", "crewmember")
-		if(organ_owner.is_antag())
-			law_datum.zeroth = "Accomplish your objectives at all costs."
-		pre_ion_laws = law_datum.inherent.Copy()
-		add_item_action(/datum/action/item_action/organ_action/check_android_laws)
-		if(organ_owner.client)
-			addtimer(CALLBACK(src, PROC_REF(print_laws)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
-		else
-			RegisterSignal(organ_owner, COMSIG_MOB_LOGIN, PROC_REF(on_login))
-		RegisterGlobalSignal(COMSIG_GLOB_ION_STORM, PROC_REF(on_ion_storm))
-		RegisterSignal(organ_owner, COMSIG_MOB_ANTAGONIST_GAINED, PROC_REF(add_zeroth_law))
+	init_law_datum()
+	if(isnull(organ_owner.client))
+		RegisterSignal(organ_owner, COMSIG_MOB_LOGIN, PROC_REF(on_login))
+	else
+		addtimer(CALLBACK(src, PROC_REF(print_laws)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /obj/item/organ/brain/cybernetic/android/on_mob_remove(mob/living/carbon/organ_owner, special, movement_flags)
 	. = ..()
@@ -99,7 +108,7 @@
 	if(QDELETED(law_datum) || isnull(pre_ion_laws))
 		return
 
-	law_datum.inherent = pre_ion_laws
+	law_datum.inherent = pre_ion_laws || list()
 	law_datum.ion.Cut()
 	pre_ion_laws = null
 	print_laws("Your laws have been restored")

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
@@ -22,10 +22,30 @@
 /obj/item/organ/stomach/ethereal/android/on_mob_insert(mob/living/carbon/organ_owner, special)
 	. = ..()
 	RegisterSignal(organ_owner, COMSIG_SPECIES_HANDLE_CHEMICAL, PROC_REF(handle_chemical))
+	RegisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT), PROC_REF(on_sleep))
+	RegisterSignal(organ_owner, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT), PROC_REF(on_wake))
+
+	if(HAS_TRAIT(organ_owner, TRAIT_KNOCKEDOUT))
+		passive_drain_multiplier *= 0.5
 
 /obj/item/organ/stomach/ethereal/android/on_mob_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
 	UnregisterSignal(organ_owner, COMSIG_SPECIES_HANDLE_CHEMICAL)
+	UnregisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT))
+	UnregisterSignal(organ_owner, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT))
+
+	if(HAS_TRAIT(organ_owner, TRAIT_KNOCKEDOUT))
+		passive_drain_multiplier /= 0.5
+
+/obj/item/organ/stomach/ethereal/android/proc/on_sleep(...)
+	SIGNAL_HANDLER
+
+	passive_drain_multiplier *= 0.5
+
+/obj/item/organ/stomach/ethereal/android/proc/on_wake(...)
+	SIGNAL_HANDLER
+
+	passive_drain_multiplier /= 0.5
 
 /obj/item/organ/stomach/ethereal/android/get_status_appendix(advanced, add_tooltips)
 	var/charge_percent = cell.charge() / ETHEREAL_CHARGE_FULL

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
@@ -9,7 +9,7 @@
 	passive_drain_multiplier = 0.6 // power hungry
 
 	VAR_PRIVATE/death_timer
-	var/sleep_mode_multiplier = sleep_mode_multiplier
+	var/sleep_mode_multiplier = 0.33
 
 /obj/item/organ/stomach/ethereal/android/emp_act(severity)
 	. = ..()

--- a/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
+++ b/maplestation_modules/code/modules/mob/living/carbon/human/species_types/synth/android_stomach.dm
@@ -9,6 +9,7 @@
 	passive_drain_multiplier = 0.6 // power hungry
 
 	VAR_PRIVATE/death_timer
+	var/sleep_mode_multiplier = sleep_mode_multiplier
 
 /obj/item/organ/stomach/ethereal/android/emp_act(severity)
 	. = ..()
@@ -26,7 +27,7 @@
 	RegisterSignal(organ_owner, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT), PROC_REF(on_wake))
 
 	if(HAS_TRAIT(organ_owner, TRAIT_KNOCKEDOUT))
-		passive_drain_multiplier *= 0.5
+		passive_drain_multiplier *= sleep_mode_multiplier
 
 /obj/item/organ/stomach/ethereal/android/on_mob_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
@@ -35,17 +36,17 @@
 	UnregisterSignal(organ_owner, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT))
 
 	if(HAS_TRAIT(organ_owner, TRAIT_KNOCKEDOUT))
-		passive_drain_multiplier /= 0.5
+		passive_drain_multiplier /= sleep_mode_multiplier
 
 /obj/item/organ/stomach/ethereal/android/proc/on_sleep(...)
 	SIGNAL_HANDLER
 
-	passive_drain_multiplier *= 0.5
+	passive_drain_multiplier *= sleep_mode_multiplier
 
 /obj/item/organ/stomach/ethereal/android/proc/on_wake(...)
 	SIGNAL_HANDLER
 
-	passive_drain_multiplier /= 0.5
+	passive_drain_multiplier /= sleep_mode_multiplier
 
 /obj/item/organ/stomach/ethereal/android/get_status_appendix(advanced, add_tooltips)
 	var/charge_percent = cell.charge() / ETHEREAL_CHARGE_FULL

--- a/maplestation_modules/code/modules/surgery/operations/install_laws.dm
+++ b/maplestation_modules/code/modules/surgery/operations/install_laws.dm
@@ -33,7 +33,7 @@
 	display_pain(
 		target = organ.owner,
 		affected_locations = organ,
-		pain_message = "Your vision begins to fill with static!",
+		pain_message = "Your vision fills with static!",
 	)
 	organ.owner.set_static_vision(30 SECONDS)
 

--- a/maplestation_modules/code/modules/surgery/operations/install_laws.dm
+++ b/maplestation_modules/code/modules/surgery/operations/install_laws.dm
@@ -1,0 +1,63 @@
+/datum/surgery_operation/organ/install_laws
+	name = "install laws"
+	desc = "Replace the laws installed in an android's positronic brain with a new set of laws."
+	rnd_name = "Positronic Brain Reprogramming"
+	implements = list(
+		/obj/item/ai_module = 2,
+	)
+	time = 12 SECONDS
+	preop_sound = 'sound/items/taperecorder/tape_flip.ogg'
+	success_sound = 'sound/items/taperecorder/taperecorder_close.ogg'
+	operation_flags = OPERATION_NOTABLE | OPERATION_STANDING_ALLOWED | OPERATION_MECHANIC
+	target_type = /obj/item/organ/brain
+	required_organ_flag = NONE
+	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_ORGANS_CUT|SURGERY_BONE_SAWED
+
+/datum/surgery_operation/organ/install_laws/get_default_radial_image()
+	return image(/obj/item/ai_module)
+
+/datum/surgery_operation/organ/install_laws/state_check(obj/item/organ/brain/operating_on)
+	return istype(operating_on, /obj/item/organ/brain/cybernetic/android)
+
+/datum/surgery_operation/organ/install_laws/all_required_strings()
+	return ..() + list("the target must be an advanced positronic brain")
+
+/datum/surgery_operation/organ/install_laws/on_preop(obj/item/organ/brain/cybernetic/android/organ, mob/living/surgeon, obj/item/ai_module/tool, list/operation_args)
+	display_results(
+		surgeon,
+		organ.owner,
+		span_notice("You begin to reprogram [organ.owner]..."),
+		span_notice("[surgeon] begins to reprogram [organ.owner]'s brain."),
+		span_notice("[surgeon] begins to perform surgery on [organ.owner]'s brain."),
+	)
+	display_pain(
+		target = organ.owner,
+		affected_locations = organ,
+		pain_message = "Your vision begins to fill with static!",
+	)
+	organ.owner.set_static_vision(30 SECONDS)
+
+/datum/surgery_operation/organ/install_laws/proc/finish_surgery(obj/item/organ/brain/cybernetic/android/organ, mob/living/surgeon)
+	display_results(
+		surgeon,
+		organ.owner,
+		span_notice("You finish reprogramming [organ.owner]'s brain."),
+		span_notice("[surgeon] finishes reprogramming [organ.owner]'s brain."),
+		span_notice("[surgeon] finishes performing surgery on [organ.owner]'s brain."),
+	)
+	display_pain(
+		target = organ.owner,
+		affected_locations = organ,
+		pain_message = "Your vision begins to clear up, and your perspective of the world seems... different.",
+	)
+	organ.init_law_datum()
+
+/datum/surgery_operation/organ/install_laws/on_success(obj/item/organ/brain/cybernetic/android/organ, mob/living/surgeon, obj/item/ai_module/tool, list/operation_args)
+	finish_surgery(organ, surgeon)
+	tool.transmitInstructions(organ.law_datum, surgeon)
+	organ.print_laws("Your laws have been changed")
+
+/datum/surgery_operation/organ/install_laws/on_failure(obj/item/organ/brain/cybernetic/android/organ, mob/living/surgeon, obj/item/ai_module/tool, list/operation_args)
+	finish_surgery(organ, surgeon)
+	organ.on_ion_storm()
+	organ.apply_organ_damage(rand(10, 20), 120)

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -389,24 +389,25 @@ const ProductPrice = (props) => {
   const { act, data } = useBackend<VendingData>();
   const { access, displayed_currency_name } = data;
   const { custom, discount, free, product, redPrice } = props;
-  const customPrice = access ? 'Free' : product.price;
+  const free_text = 'Free';
+  const customPrice = access ? free_text : product.price;
   let standardPrice = product.price;
   if (free) {
-    standardPrice = 'Free';
+    standardPrice = free_text;
   } else if (discount) {
-    standardPrice = redPrice;
+    standardPrice = redPrice <= 0 ? free_text : redPrice;
   }
   return (
     <Stack.Item fontSize={0.85} color={'gold'}>
       {custom ? (
         <>
           {customPrice}
-          {!access && displayed_currency_name}
+          {customPrice !== free_text && displayed_currency_name}
         </>
       ) : (
         <>
           {standardPrice}
-          {!free && displayed_currency_name}
+          {standardPrice !== free_text && displayed_currency_name}
         </>
       )}
     </Stack.Item>


### PR DESCRIPTION
- FIx latejoin alert from cyro pod being delayed
- Fix heimlich 
- Fix wound examines giving `His chest .`
- Fix jukebox presets, again
- Fix cable sparking
- Adds a surgery operation for changing a synth's lawset
- Synthetics are fully mute when lacking a voicebox
- Examining someone gives a little message about their age in comparison to your's: `He appears to be very young - about your age.` or `He appears to be old - a lot older than you.` (where before it would just say `He looks young` or `He looks old`) 
- Resizing yourself via preferences is considered in height examine text and minor illusion 
- Ambience no longer plays in post round
- Fix foam darts being "spent" and smelling of gunpowder
- Synthetics now lose energy at 0.33x the rate while "asleep"
- Service and engineering vending machines are now free for members of their respective departments