### PR TITLE
(Experimental) Humanoids no longer deathgasp on death / have no "is dead" examine message

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -103,16 +103,19 @@
 	icon_state = "brutedamageoverlay"
 	layer = UI_DAMAGE_LAYER
 	plane = FULLSCREEN_PLANE
+	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/oxy
 	icon_state = "oxydamageoverlay"
 	layer = UI_DAMAGE_LAYER
 	plane = FULLSCREEN_PLANE
+	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/crit
 	icon_state = "passage"
 	layer = CRIT_LAYER
 	plane = FULLSCREEN_PLANE
+	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/crit/vision
 	icon_state = "oxydamageoverlay"
@@ -125,9 +128,9 @@
 	icon_state = "blackimageoverlay"
 	layer = BLIND_LAYER
 	plane = FULLSCREEN_PLANE
+	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/blind/cyborg
-	show_when_dead = TRUE
 
 /atom/movable/screen/fullscreen/blind/noflicker
 	icon_state = "blackimageoverlaystatic"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -436,8 +436,13 @@
 	// Time of death
 	if(target.station_timestamp_timeofdeath && !target.appears_alive())
 		render_list += span_info(separator_hr("Mortality Information"))
-		render_list += "<span class='info ml-1'>Time of Death: [target.station_timestamp_timeofdeath]</span><br>"
-		render_list += "<span class='alert ml-1'><b>Subject died [DisplayTimeText(round(world.time - target.timeofdeath))] ago.</b></span><br>"
+		render_list += "<span class='info ml-1'>Time of Death: [target.station_timestamp_timeofdeath] (<i>[DisplayTimeText(round(world.time - target.timeofdeath))] ago</i>)</span><br>"
+		var/mob/dead/observer/ghost = target.get_ghost(TRUE, TRUE)
+		if(HAS_TRAIT(target, TRAIT_SUICIDED))
+			render_list += "<span class='deadsay ml-2'>&rdsh; Subject committed suicide - <b>do not resuscitate</b>.</span><br>"
+
+		else if(isnull(target.client) && !HAS_TRAIT(target, TRAIT_MIND_TEMPORARILY_GONE) && (isnull(ghost) || !ghost.can_reenter_corpse || !ghost.client))
+			render_list += "<span class='deadsay ml-2'>&rdsh; Subject catatonic - <b>resuscitation futile</b>.</span><br>"
 
 	. = jointext(render_list, "")
 	if(tochat)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -13,7 +13,6 @@
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
 	mouse_drop_zone = TRUE
-	living_flags = ALWAYS_DEATHGASP
 	///List of [/obj/item/organ]s in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/obj/item/organ/organs = list()
 	///Same as [above][/mob/living/carbon/var/organs], but stores "slot ID" - "organ" pairs for easy access.

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -28,26 +28,6 @@
 	// give us some space between clothing examine and the rest
 	ADD_NEWLINE_IF_NECESSARY(.)
 
-	var/appears_dead = FALSE
-	var/just_sleeping = FALSE
-
-	if(!appears_alive())
-		appears_dead = TRUE
-
-		var/obj/item/clothing/glasses/shades = get_item_by_slot(ITEM_SLOT_EYES)
-		var/are_we_in_weekend_at_bernies = shades?.tint && buckled && istype(buckled, /obj/vehicle/ridden/wheelchair)
-
-		if(isliving(user) && (HAS_MIND_TRAIT(user, TRAIT_NAIVE) || are_we_in_weekend_at_bernies))
-			just_sleeping = TRUE
-
-		if(!just_sleeping)
-			// since this is relatively important and giving it space makes it easier to read
-			ADD_NEWLINE_IF_NECESSARY(.)
-			if(HAS_TRAIT(src, TRAIT_SUICIDED))
-				. += span_warning("[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.")
-
-			. += generate_death_examine_text()
-
 	//Status effects
 	var/list/status_examines = get_status_effect_examinations(user)
 	if (length(status_examines))
@@ -194,21 +174,15 @@
 
 		if(length(bleeding_limbs))
 			var/bleed_text = "<b>"
-			if(appears_dead)
-				bleed_text += "<span class='deadsay'>"
-				bleed_text += "Blood is visible in [t_his] open "
-			else
-				bleed_text += "<span class='warning'>"
-				bleed_text += "[t_He] [t_is] [mob_biotypes & MOB_ORGANIC ? "bleeding" : "leaking [LOWER_TEXT(blood_type.reagent_type::name)]"] from [t_his] "
+			bleed_text += "<span class='warning'>"
+			bleed_text += "[t_He] [t_is] [mob_biotypes & MOB_ORGANIC ? "bleeding" : "leaking [LOWER_TEXT(blood_type.reagent_type::name)]"] from [t_his] "
 
 			bleed_text += english_list(bleeding_limbs, and_text = " and ")
 
-			if(appears_dead)
-				bleed_text += ", but it has pooled and is not flowing."
+			if(HAS_TRAIT(src, TRAIT_BLOODY_MESS))
+				bleed_text += " incredibly quickly!"
 			else
-				if(HAS_TRAIT(src, TRAIT_BLOODY_MESS))
-					bleed_text += " incredibly quickly"
-				bleed_text += "!"
+				bleed_text += "."
 
 			bleed_text += "</span></b>"
 
@@ -222,11 +196,13 @@
 	if(on_fire)
 		. += span_bolddanger("[t_He] [t_is] on fire!")
 
-	if(just_sleeping)
-		. += span_notice("[t_He] [t_is]n't responding to anything around [t_him] and seem[p_s()] to be asleep.")
+	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
+		. += span_notice("[t_He] [t_is]n't responding to anything around [t_him].")
 
-	else if(!appears_dead)
-		var/mob/living/living_user = user
+	else if(HAS_TRAIT(src, TRAIT_SOFT_CRIT))
+		. += span_notice("[t_He] [t_is] barely conscious.")
+
+	else
 		if(src != user)
 			if(HAS_TRAIT(user, TRAIT_EMPATH))
 				if (combat_mode)
@@ -237,7 +213,7 @@
 					. += "[t_He] seem[p_s()] sickly."
 				if(mob_mood.sanity <= SANITY_DISTURBED)
 					. += "[t_He] seem[p_s()] distressed."
-					living_user.add_mood_event("empath", /datum/mood_event/sad_empath, src)
+					astype(user, /mob/living)?.add_mood_event("empath", /datum/mood_event/sad_empath, src)
 				if(is_blind())
 					. += "[t_He] appear[p_s()] to be staring off into space."
 				if (HAS_TRAIT(src, TRAIT_DEAF))
@@ -249,16 +225,10 @@
 
 			if(HAS_TRAIT(user, TRAIT_SPIRITUAL) && mind?.holy_role && user != src)
 				. += "[t_He] [t_has] a holy aura about [t_him]."
-				living_user.add_mood_event("religious_comfort", /datum/mood_event/religiously_comforted)
+				astype(user, /mob/living)?.add_mood_event("religious_comfort", /datum/mood_event/religiously_comforted)
 
-		switch(stat)
-			if(UNCONSCIOUS, HARD_CRIT)
-				. += span_notice("[t_He] [t_is]n't responding to anything around [t_him] and seem[p_s()] to be asleep.")
-			if(SOFT_CRIT)
-				. += span_notice("[t_He] [t_is] barely conscious.")
-			if(CONSCIOUS)
-				if(HAS_TRAIT(src, TRAIT_DUMB))
-					. += "[t_He] [t_has] a stupid expression on [t_his] face."
+		if(HAS_TRAIT(src, TRAIT_DUMB))
+			. += "[t_He] [t_has] a stupid expression on [t_his] face."
 		if(get_organ_by_type(/obj/item/organ/brain) && isnull(ai_controller))
 			var/npc_message = ""
 			if(!key)
@@ -335,18 +305,6 @@
 		return
 
 	return examine_list.Join("<br>")
-
-/// Returns death message for mob examine text
-/mob/living/carbon/proc/generate_death_examine_text()
-	var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
-	var/t_He = p_They()
-	var/t_his = p_their()
-	var/t_is = p_are()
-	//This checks to see if the body is revivable
-	if(get_organ_by_type(/obj/item/organ/brain) && (client || HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE) || (ghost?.can_reenter_corpse && ghost?.client)))
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")
-	else
-		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...")
 
 /// Returns a list of "damtype" => damage description based off of which bodypart description is most common
 /mob/living/carbon/proc/get_majority_bodypart_damage_desc()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -201,7 +201,7 @@
 	if(!gibbed)
 		if(death_sound || death_message || (living_flags & ALWAYS_DEATHGASP))
 			INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, emote), "deathgasp")
-		send_death_moodlets()
+		// send_death_moodlets()
 
 	set_stat(DEAD)
 	SShealth_updates.queue_update(src, UPDATE_MEDHUD) // This is just for weird case where death is called out of nowhere

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -600,12 +600,12 @@
 /// Induces fake death on a living mob.
 /mob/living/proc/fakedeath(source, silent = FALSE)
 	if(stat != DEAD)
-		if(!silent)
-			emote("deathgasp")
+		// if(!silent)
+		// 	emote("deathgasp")
 		station_timestamp_timeofdeath = station_time_timestamp()
 
-	if(!HAS_TRAIT(src, TRAIT_FAKEDEATH) && !silent)
-		send_death_moodlets()
+	// if(!HAS_TRAIT(src, TRAIT_FAKEDEATH) && !silent)
+	// 	send_death_moodlets()
 	add_traits(list(TRAIT_FAKEDEATH, TRAIT_DEATHCOMA), source)
 
 ///Unignores all slowdowns that lack the IGNORE_NOSLOW flag.


### PR DESCRIPTION
- Humanoids no longer `seize up, their eyes dead and lifeless` when perishing
- Deceased humanoids, on examine, simply appear to be non-responsive. There isn't even an examine message for soulless mobs. 
- Health analyzer reports in "Mortality Information" about whether the target committed suicide or is otherwise catatonic. 
- (Temporarily?) disables death moodlets for standard deaths (you still get them for witnessing someone dust or gib)

Working off the idea I had a while back to kinda "phase out" the static death state.

Let's say you come across an unresponsive body in maintenance.

Right now it's one quick examine. Either:
- "oh it's a catatonic dead monkeyperson", and you move on...
- "oh, it's a dead member of the crew, better get them to medical"...
- or "oh it's just someone sleeping, I should check if they're in crit but otherwise it's whatever they're fine"

With the changes, you have to do your due diligence: 
- First, you need to shake them to see if they wake up.
- No wakey? Now you need to check their pulse
   - Normal pulse? just asleep, probably sedated by something. Notable but weird
   - If their pulse is high/low you know they're alive (but barely). Gotta call medical. 
   - If they lack a pulse, they're either dead or just about to be dead. Better start CPR!
- Regardless, now you must get the body to medical or get medical to the body to either help or identify it as soulless. 

